### PR TITLE
add onchainkit migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | [Deploying Contracts on Base](./skills/deploying-contracts-on-base/SKILL.md) | Deploys and verifies contracts on Base with Foundry, plus common troubleshooting guidance. |
 | [Running a Base Node](./skills/running-a-base-node/SKILL.md) | Covers production node setup, hardware requirements, networking ports, and syncing guidance. |
 | [Converting MiniKit to Farcaster](./skills/converting-minikit-to-farcaster/SKILL.md) | Migrates Mini Apps from MiniKit (OnchainKit) to native Farcaster SDK with mappings, examples, and pitfalls. |
+| [Migrating an OnchainKit App](./skills/migrating-an-onchainkit-app/SKILL.md) | Migrates apps from @coinbase/onchainkit to standalone wagmi/viem components, replacing the provider, wallet, and transaction components. |
 
 ## Installation
 

--- a/skills/migrating-an-onchainkit-app/SKILL.md
+++ b/skills/migrating-an-onchainkit-app/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: migrating-an-onchainkit-app
+description: >
+  Migrates apps from @coinbase/onchainkit to standalone wagmi/viem components.
+  Handles provider replacement (OnchainKitProvider to WagmiProvider),
+  wallet component replacement (Wallet/ConnectWallet to custom WalletConnect),
+  and transaction component replacement. Use when the user says "migrate my
+  onchainkit", "replace onchainkit provider", "migrate my wallet component",
+  "replace my onchainkit wallet", "migrate my transaction component",
+  "remove onchainkit dependency", or "move off onchainkit".
+---
+
+# OnchainKit Migration Skill
+
+Migrate apps from `@coinbase/onchainkit` to standalone `wagmi`/`viem` components with zero OnchainKit dependency.
+
+## Before Starting
+
+Create a `mistakes.md` file in the project root:
+
+```markdown
+# Migration Mistakes & Learnings
+
+Track errors, fixes, and lessons learned during OnchainKit migration.
+
+## Errors
+
+## Lessons Learned
+```
+
+Append every error, fix, and lesson to this file throughout the migration. This file improves the skill over time.
+
+## Migration Workflow
+
+Migrations MUST happen in this order. Do not skip steps.
+
+### Step 1: Detection
+
+Scan the project to understand current OnchainKit usage:
+
+1. Search all files for `@coinbase/onchainkit` imports
+2. Identify which components are used:
+   - **Provider**: `OnchainKitProvider` (always present if using OnchainKit)
+   - **Wallet**: `Wallet`, `ConnectWallet`, `WalletDropdown`, `WalletModal`, `Connected`
+   - **Transaction**: `Transaction`, `TransactionButton`, `TransactionStatus`
+   - **Other**: `Identity`, `Avatar`, `Name`, `Address`, `Swap`, `Checkout`, etc.
+3. Check `package.json` for existing `wagmi`, `viem`, `@tanstack/react-query` dependencies
+4. Identify the project's styling approach (Tailwind, CSS Modules, styled-components, etc.)
+5. Report findings to the user before proceeding
+
+### Step 2: Provider Migration (always first)
+
+Read [references/provider-migration.md](references/provider-migration.md) for detailed instructions and code.
+
+Summary:
+1. Ensure `wagmi`, `viem`, and `@tanstack/react-query` are installed
+2. Create `wagmi-config.ts` with chain and connector configuration
+3. Replace `OnchainKitProvider` with `WagmiProvider` + `QueryClientProvider`
+4. Remove `@coinbase/onchainkit/styles.css` import
+5. Remove any `SafeArea` or MiniKit imports from layout files
+
+**Validation gate**: Run `npm run build` (or the project's build command). Must pass before continuing. If it fails, fix errors and document them in `mistakes.md`.
+
+### Step 3: Wallet Migration (after provider)
+
+Read [references/wallet-migration.md](references/wallet-migration.md) for detailed instructions and code.
+
+Summary:
+1. Create a `WalletConnect` component using wagmi hooks (`useAccount`, `useConnect`, `useDisconnect`)
+2. Component includes a modal with wallet options: Base Account, Coinbase Wallet, MetaMask
+3. Shows truncated address + disconnect button when connected
+4. Replace all OnchainKit wallet imports and component usage
+
+**Validation gate**: Run `npm run build`. Must pass before continuing. Document any errors in `mistakes.md`.
+
+### Step 4: Transaction Migration (after wallet)
+
+Read [references/transaction-migration.md](references/transaction-migration.md) for detailed instructions and code.
+
+Summary:
+1. Check the `chainId` prop on existing `<Transaction />` components -- add any missing chains to `wagmi-config.ts`
+2. Create a `TransactionForm` component using wagmi hooks (`useWriteContract`, `useWaitForTransactionReceipt`, `useSwitchChain`)
+3. Component handles the full lifecycle: idle, pending wallet confirmation, confirming on-chain, success, error
+4. Replace all OnchainKit transaction imports (`Transaction`, `TransactionButton`, `TransactionStatus`, `TransactionSponsor`, etc.)
+5. Update the `calls` array format -- use `address`, `abi`, `functionName`, `args` with proper `as const` typing
+6. Map `onStatus` callback to the new lifecycle status names (init, pending, confirmed, success, error)
+
+**Validation gate**: Run `npm run build`. Must pass before continuing. Document any errors in `mistakes.md`.
+
+### Step 5: Cleanup
+
+1. Search for any remaining `@coinbase/onchainkit` imports -- there should be none
+2. Optionally remove `@coinbase/onchainkit` from `package.json` dependencies
+3. Run final `npm run build` to verify everything works
+4. Update `mistakes.md` with final lessons learned
+
+## Troubleshooting
+
+### Build fails after provider migration
+- **Missing dependencies**: Ensure `wagmi`, `viem`, `@tanstack/react-query` are installed
+- **Type errors with wagmi config**: Check that `chains` array has at least one chain and `transports` has a matching entry
+- **"use client" missing**: Both the provider and wallet components must have `"use client"` directive
+
+### MetaMask SDK react-native warning
+- The warning `Can't resolve '@react-native-async-storage/async-storage'` is harmless in web builds. It comes from MetaMask SDK and does not affect functionality.
+
+### Wallet won't connect
+- Verify the wagmi config has the correct connectors configured
+- Check that `WagmiProvider` wraps the component tree before any wallet hooks are used
+- Ensure `QueryClientProvider` is inside `WagmiProvider`
+
+### Transaction receipt stuck in pending
+- **Symptom**: Transaction hash appears, tx confirms on-chain, but UI stays stuck on "Transaction in progress..." forever
+- **Cause**: `useWaitForTransactionReceipt` has no RPC to poll because the transaction's chain is missing from the wagmi config's `chains` + `transports`
+- **Fix**: (1) Add the target chain to `wagmi-config.ts` chains array AND transports object. (2) Always pass `chainId` to `useWaitForTransactionReceipt({ hash, chainId })` so it polls the correct chain
+
+### Transaction targets wrong chain
+- The `TransactionForm` auto-switches chains, but the target chain must exist in the wagmi config's `chains` array and `transports` object
+- Common: add `baseSepolia` for testnet transactions (chainId 84532)
+
+### Next.js page export restrictions
+- Next.js only allows specific named exports from page files. Exporting contract call arrays or ABI constants from a page file will cause a build error
+- Fix: make them non-exported `const` declarations or move them to a separate module
+
+### ABI type errors after transaction migration
+- When defining ABIs inline, use `as const` on the array for proper type inference
+- Mark individual fields like `type: 'function' as const` and `stateMutability: 'nonpayable' as const`
+
+### Existing wagmi setup detected
+- If the project already wraps with `WagmiProvider`, do NOT add another one
+- Instead, just update the existing wagmi config to include the needed connectors
+- OnchainKit's provider detects and defers to existing wagmi providers -- the standalone setup should too
+
+## Important Notes
+
+- Always use `wagmi` and `viem` directly. Never import from `@coinbase/onchainkit`.
+- The `baseAccount` connector comes from `wagmi/connectors`, not from a separate package.
+- `wagmi-config.ts` must include every chain the app transacts on. If the original OnchainKit `<Transaction chainId={X} />` used a specific chain, that chain must be in both `chains` and `transports`. Without it, `useWaitForTransactionReceipt` will hang forever.
+- If the project uses Tailwind, use Tailwind classes for the components. If not, adapt to inline styles or the project's existing styling approach (e.g., CSS Modules).
+- Do not export contract call arrays, ABI constants, or other non-page values from Next.js page files. Use non-exported constants or a separate module.
+- Inspect the OnchainKit source code in `node_modules/@coinbase/onchainkit/src/` if you need to understand how a specific component works internally.

--- a/skills/migrating-an-onchainkit-app/references/provider-migration.md
+++ b/skills/migrating-an-onchainkit-app/references/provider-migration.md
@@ -1,0 +1,193 @@
+# Provider Migration: OnchainKitProvider to WagmiProvider
+
+Replace `OnchainKitProvider` from `@coinbase/onchainkit` with direct `WagmiProvider` + `QueryClientProvider` setup.
+
+## What OnchainKitProvider Does Internally
+
+OnchainKitProvider is a wrapper that:
+1. Creates a wagmi config with `base` + `baseSepolia` chains
+2. Uses `cookieStorage` for persistence and `ssr: true`
+3. Default connector: `baseAccount()` from `wagmi/connectors`
+4. Sets up CDP RPC URLs if `apiKey` is provided
+5. Creates a default `QueryClient` from `@tanstack/react-query`
+6. Applies theme/appearance settings via CSS custom properties
+
+The provider detects if `WagmiProvider` or `QueryClientProvider` already exist in the React tree and skips creating them if so.
+
+## Prerequisites
+
+Ensure these packages are installed. They are likely already present since OnchainKit depends on them:
+
+```bash
+npm install wagmi viem @tanstack/react-query
+```
+
+If the project uses Tailwind CSS and it's not yet installed:
+
+```bash
+npm install tailwindcss @tailwindcss/postcss postcss
+```
+
+## Step-by-Step Migration
+
+### 1. Create wagmi-config.ts
+
+Create a new file for the wagmi configuration. Place it alongside the existing provider file (typically `app/wagmi-config.ts`).
+
+```typescript
+import { http, cookieStorage, createConfig, createStorage } from "wagmi";
+import { base } from "wagmi/chains";
+import { coinbaseWallet, metaMask } from "wagmi/connectors";
+
+export const wagmiConfig = createConfig({
+  chains: [base],
+  connectors: [
+    coinbaseWallet({ appName: "My App", preference: "all" }),
+    metaMask(),
+  ],
+  storage: createStorage({ storage: cookieStorage }),
+  ssr: true,
+  transports: {
+    [base.id]: http(),
+  },
+});
+```
+
+**Adapt based on the existing OnchainKitProvider config:**
+- If `chain` prop was set to something other than `base`, use that chain instead
+- If `apiKey` was set, you can use CDP RPC URLs: `http(\`https://api.developer.coinbase.com/rpc/v1/base/${apiKey}\`)`
+- If `config.wallet.preference` was `"smartWalletOnly"`, adjust the coinbaseWallet connector accordingly
+- Add additional chains to the `chains` array and `transports` object as needed
+
+### 2. Rewrite the Provider Component
+
+Replace the existing provider file (typically `rootProvider.tsx` or `providers.tsx`).
+
+**Before (OnchainKit):**
+```typescript
+"use client";
+import { ReactNode } from "react";
+import { base } from "wagmi/chains";
+import { OnchainKitProvider } from "@coinbase/onchainkit";
+import "@coinbase/onchainkit/styles.css";
+
+export function RootProvider({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base}
+      config={{
+        appearance: { mode: "auto" },
+        wallet: { display: "modal", preference: "all" },
+      }}
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}
+```
+
+**After (wagmi/viem):**
+```typescript
+"use client";
+import { type ReactNode, useState } from "react";
+import { WagmiProvider } from "wagmi";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { wagmiConfig } from "./wagmi-config";
+
+export function RootProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}
+```
+
+Key changes:
+- Remove `@coinbase/onchainkit` import
+- Remove `@coinbase/onchainkit/styles.css` import
+- `QueryClient` is created with `useState` to avoid re-creation on re-renders
+- `WagmiProvider` must wrap `QueryClientProvider`
+
+### 3. Update Layout File
+
+Remove any OnchainKit-specific imports from the layout:
+
+- Remove `SafeArea` from `@coinbase/onchainkit/minikit`
+- Remove `minikitConfig` imports
+- Remove MiniKit-related metadata generation
+- Move `<RootProvider>` inside `<body>` (wagmi provider must be a client component, so it should wrap the content, not the `<html>` tag)
+
+**Before:**
+```typescript
+import { SafeArea } from "@coinbase/onchainkit/minikit";
+
+export default function RootLayout({ children }) {
+  return (
+    <RootProvider>
+      <html lang="en">
+        <body>
+          <SafeArea>{children}</SafeArea>
+        </body>
+      </html>
+    </RootProvider>
+  );
+}
+```
+
+**After:**
+```typescript
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <RootProvider>{children}</RootProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### 4. Verify
+
+Run the build command:
+```bash
+npm run build
+```
+
+Expected: Build succeeds. The MetaMask SDK warning about `@react-native-async-storage/async-storage` is harmless and can be ignored.
+
+## Edge Cases
+
+### Project already has a WagmiProvider
+If the project wraps with its own `WagmiProvider` outside of OnchainKit, simply remove the `OnchainKitProvider` wrapper. Update the existing wagmi config to include any connectors that were configured via OnchainKit.
+
+### Project uses CDP API key for RPC
+If the existing setup relied on `apiKey` for RPC access, add the CDP RPC URL to the transport:
+
+```typescript
+transports: {
+  [base.id]: http(`https://api.developer.coinbase.com/rpc/v1/base/${process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}`),
+},
+```
+
+### Project uses multiple chains
+Add all needed chains to both the `chains` array and `transports` object:
+
+```typescript
+import { base, baseSepolia } from "wagmi/chains";
+
+export const wagmiConfig = createConfig({
+  chains: [base, baseSepolia],
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(),
+  },
+  // ...rest
+});
+```

--- a/skills/migrating-an-onchainkit-app/references/transaction-migration.md
+++ b/skills/migrating-an-onchainkit-app/references/transaction-migration.md
@@ -1,0 +1,528 @@
+# Transaction Migration: OnchainKit Transaction to wagmi
+
+Replace OnchainKit's `Transaction`, `TransactionButton`, `TransactionStatus`, `TransactionSponsor`, and related components with a standalone `TransactionForm` component built on wagmi hooks.
+
+## What OnchainKit's Transaction Components Do
+
+OnchainKit provides a composable transaction system:
+- `<Transaction />` -- container that manages the full transaction lifecycle, accepts `calls`, `chainId`, `onStatus`
+- `<TransactionButton />` -- submits the transaction, shows status-dependent text (Transact/Confirm/Try again/View transaction)
+- `<TransactionStatus />` -- displays current transaction state with label and action
+- `<TransactionStatusLabel />` -- text label ("Confirm in wallet", "Transaction in progress", "Successful", error message)
+- `<TransactionStatusAction />` -- link to block explorer or call status viewer
+- `<TransactionSponsor />` -- shows "Zero transaction fee" when paymaster is configured
+- `LifecycleStatus` type -- status object with `statusName` and `statusData`
+
+Internally, OnchainKit uses two submission paths:
+- **Smart Wallet (batched):** `useSendCalls` (EIP-5792) for wallets with `atomicBatch` capability
+- **EOA (single):** `useSendTransaction` with `encodeFunctionData` for standard wallets
+
+The replacement component uses `useWriteContract` which handles both EOA and smart wallet scenarios for single contract calls.
+
+## Prerequisites
+
+- Provider migration must be completed first (WagmiProvider + QueryClientProvider in the tree)
+- Tailwind CSS installed (if not, install it or adapt styles)
+- If the transaction targets a chain other than what's in the wagmi config, add that chain to `wagmi-config.ts`
+
+## Important: Chain Configuration
+
+OnchainKit's Transaction accepts a `chainId` prop and handles chain switching. The replacement does too, BUT the target chain must exist in the wagmi config's `chains` array and `transports` object.
+
+For example, if transactions target Base Sepolia (84532):
+
+```typescript
+import { base, baseSepolia } from "wagmi/chains";
+
+export const wagmiConfig = createConfig({
+  chains: [base, baseSepolia],
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(),
+  },
+  // ...rest
+});
+```
+
+## The TransactionForm Component
+
+Create `app/components/TransactionForm.tsx` (or wherever components live in the project):
+
+```typescript
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import {
+  useAccount,
+  useWriteContract,
+  useWaitForTransactionReceipt,
+  useSwitchChain,
+} from "wagmi";
+import type { Abi, Address } from "viem";
+
+type ContractCall = {
+  address: Address;
+  abi: Abi;
+  functionName: string;
+  args?: readonly unknown[];
+  value?: bigint;
+};
+
+type LifecycleStatus =
+  | { statusName: "init"; statusData: null }
+  | { statusName: "pending"; statusData: null }
+  | { statusName: "confirmed"; statusData: { transactionHash: string } }
+  | {
+      statusName: "success";
+      statusData: { transactionHash: string; blockNumber: bigint };
+    }
+  | { statusName: "error"; statusData: { message: string } };
+
+type TransactionFormProps = {
+  calls: ContractCall[];
+  chainId?: number;
+  buttonText?: string;
+  onStatus?: (status: LifecycleStatus) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function TransactionForm({
+  calls,
+  chainId,
+  buttonText = "Transact",
+  onStatus,
+  disabled = false,
+  className,
+}: TransactionFormProps) {
+  const { isConnected, chainId: currentChainId } = useAccount();
+  const { switchChainAsync } = useSwitchChain();
+
+  const [status, setStatus] = useState<LifecycleStatus>({
+    statusName: "init",
+    statusData: null,
+  });
+
+  const updateStatus = useCallback(
+    (newStatus: LifecycleStatus) => {
+      setStatus(newStatus);
+      onStatus?.(newStatus);
+    },
+    [onStatus]
+  );
+
+  const {
+    writeContract,
+    data: txHash,
+    isPending: isWritePending,
+    reset: resetWrite,
+  } = useWriteContract();
+
+  // CRITICAL: Always pass chainId so wagmi polls the correct chain's RPC.
+  // Without this, if the user's wallet is on a different chain than the
+  // transaction target, wagmi has no transport to poll and the receipt
+  // is never found -- the UI hangs in "pending" forever.
+  const { data: receipt, isLoading: isWaiting } =
+    useWaitForTransactionReceipt({
+      hash: txHash,
+      chainId,
+    });
+
+  useEffect(() => {
+    if (isWritePending) {
+      updateStatus({ statusName: "pending", statusData: null });
+    }
+  }, [isWritePending, updateStatus]);
+
+  useEffect(() => {
+    if (txHash && !receipt) {
+      updateStatus({
+        statusName: "confirmed",
+        statusData: { transactionHash: txHash },
+      });
+    }
+  }, [txHash, receipt, updateStatus]);
+
+  useEffect(() => {
+    if (receipt) {
+      updateStatus({
+        statusName: "success",
+        statusData: {
+          transactionHash: receipt.transactionHash,
+          blockNumber: receipt.blockNumber,
+        },
+      });
+    }
+  }, [receipt, updateStatus]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!isConnected || calls.length === 0) return;
+
+    try {
+      if (chainId && currentChainId !== chainId) {
+        await switchChainAsync({ chainId });
+      }
+
+      const call = calls[0];
+      writeContract(
+        {
+          address: call.address,
+          abi: call.abi,
+          functionName: call.functionName,
+          args: call.args ?? [],
+          value: call.value,
+          chainId,
+        },
+        {
+          onError: (error) => {
+            const isUserRejection =
+              error.message?.includes("User rejected") ||
+              error.message?.includes("User denied") ||
+              error.message?.includes("Request denied");
+            const message = isUserRejection
+              ? "Request denied."
+              : error.message || "Transaction failed";
+            updateStatus({ statusName: "error", statusData: { message } });
+          },
+        }
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Transaction failed";
+      updateStatus({ statusName: "error", statusData: { message } });
+    }
+  }, [
+    isConnected,
+    calls,
+    chainId,
+    currentChainId,
+    switchChainAsync,
+    writeContract,
+    updateStatus,
+  ]);
+
+  const handleReset = useCallback(() => {
+    resetWrite();
+    updateStatus({ statusName: "init", statusData: null });
+  }, [resetWrite, updateStatus]);
+
+  const isLoading = isWritePending || isWaiting;
+
+  return (
+    <div className={`flex flex-col gap-3 ${className ?? ""}`}>
+      {status.statusName === "success" ? (
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              const hash = status.statusData.transactionHash;
+              const explorerBase = chainId === 84532
+                ? "https://sepolia.basescan.org"
+                : "https://basescan.org";
+              window.open(`${explorerBase}/tx/${hash}`, "_blank");
+            }}
+            className="rounded-lg bg-green-600 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-green-700"
+          >
+            View transaction
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="rounded-lg border border-zinc-200 px-4 py-3 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            Send another
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={status.statusName === "error" ? handleReset : handleSubmit}
+          disabled={disabled || !isConnected || isLoading}
+          className={`rounded-lg px-4 py-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+            status.statusName === "error"
+              ? "bg-red-600 text-white hover:bg-red-700"
+              : "bg-blue-600 text-white hover:bg-blue-700"
+          }`}
+        >
+          {isWritePending && (
+            <span className="inline-flex items-center gap-2">
+              <svg
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Confirm in wallet...
+            </span>
+          )}
+          {isWaiting && (
+            <span className="inline-flex items-center gap-2">
+              <svg
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Transaction in progress...
+            </span>
+          )}
+          {status.statusName === "error" && "Try again"}
+          {status.statusName === "init" && buttonText}
+          {status.statusName === "confirmed" && !isWaiting && buttonText}
+        </button>
+      )}
+
+      <TransactionStatusDisplay status={status} chainId={chainId} />
+    </div>
+  );
+}
+
+function TransactionStatusDisplay({
+  status,
+  chainId,
+}: {
+  status: LifecycleStatus;
+  chainId?: number;
+}) {
+  if (status.statusName === "init") return null;
+
+  const explorerBase =
+    chainId === 84532
+      ? "https://sepolia.basescan.org"
+      : "https://basescan.org";
+
+  return (
+    <div className="text-sm">
+      {status.statusName === "pending" && (
+        <p className="text-yellow-600 dark:text-yellow-400">
+          Confirm in wallet.
+        </p>
+      )}
+      {status.statusName === "confirmed" && (
+        <p className="text-blue-600 dark:text-blue-400">
+          Transaction in progress...
+        </p>
+      )}
+      {status.statusName === "success" && (
+        <div className="flex items-center gap-2">
+          <p className="text-green-600 dark:text-green-400">Successful!</p>
+          <a
+            href={`${explorerBase}/tx/${status.statusData.transactionHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
+          >
+            View on explorer
+          </a>
+        </div>
+      )}
+      {status.statusName === "error" && (
+        <p className="text-red-600 dark:text-red-400">
+          {status.statusData.message}
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+## Step-by-Step Replacement
+
+### 1. Check Chain Configuration
+
+Look at the `chainId` prop on the existing `<Transaction />` component. If it references a chain not in the wagmi config, add it:
+
+```typescript
+// Common: Base Sepolia for testnet
+import { base, baseSepolia } from "wagmi/chains";
+// Add to wagmi config chains array and transports
+```
+
+### 2. Create the Component File
+
+Copy the `TransactionForm` component code above into the project's components directory.
+
+### 3. Replace OnchainKit Transaction Imports and Usage
+
+**Before (OnchainKit):**
+```typescript
+import {
+  Transaction,
+  TransactionButton,
+  TransactionSponsor,
+  TransactionStatus,
+  TransactionStatusAction,
+  TransactionStatusLabel,
+} from '@coinbase/onchainkit/transaction';
+import type { LifecycleStatus } from '@coinbase/onchainkit/transaction';
+
+const calls = [
+  {
+    address: '0x67c97D1FB8184F038592b2109F854dfb09C77C75',
+    abi: clickContractAbi,
+    functionName: 'click',
+    args: [],
+  }
+];
+
+<Transaction
+  chainId={84532}
+  calls={calls}
+  onStatus={handleOnStatus}
+>
+  <TransactionButton />
+  <TransactionSponsor />
+  <TransactionStatus>
+    <TransactionStatusLabel />
+    <TransactionStatusAction />
+  </TransactionStatus>
+</Transaction>
+```
+
+**After (wagmi):**
+```typescript
+import { TransactionForm } from "./components/TransactionForm";
+import type { Address } from "viem";
+
+const clickContractAddress: Address = '0x67c97D1FB8184F038592b2109F854dfb09C77C75';
+const clickContractAbi = [
+  {
+    type: 'function' as const,
+    name: 'click',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable' as const,
+  },
+] as const;
+
+const calls = [
+  {
+    address: clickContractAddress,
+    abi: clickContractAbi,
+    functionName: 'click',
+    args: [],
+  },
+];
+
+<TransactionForm
+  calls={calls}
+  chainId={84532}
+  buttonText="Click"
+  onStatus={handleOnStatus}
+/>
+```
+
+### 4. Handle the onStatus Callback
+
+The OnchainKit `LifecycleStatus` type has these states: `init`, `transactionIdle`, `buildingTransaction`, `transactionPending`, `transactionLegacyExecuted`, `success`, `error`, `reset`.
+
+The replacement uses a simplified set: `init`, `pending`, `confirmed`, `success`, `error`.
+
+**Mapping:**
+
+| OnchainKit Status | Replacement Status |
+|---|---|
+| `init` / `transactionIdle` | `init` |
+| `buildingTransaction` / `transactionPending` | `pending` |
+| `transactionLegacyExecuted` | `confirmed` |
+| `success` | `success` |
+| `error` | `error` |
+
+If the existing `onStatus` callback checks specific OnchainKit status names, update the checks to use the new names.
+
+### 5. Verify
+
+Run `npm run build` and confirm no errors.
+
+## What's Not Covered
+
+### Gas Sponsorship (TransactionSponsor)
+OnchainKit's `TransactionSponsor` uses a paymaster URL to sponsor gas fees. This requires a paymaster service (e.g., Coinbase Developer Platform Paymaster). The replacement component does not include paymaster support. To add it, you would need to use wagmi's `useSendCalls` with the paymaster capability.
+
+### Batched Calls (EIP-5792)
+OnchainKit's Transaction supports batching multiple calls into a single transaction for smart wallets. The replacement uses `useWriteContract` which handles one call at a time. For batched calls, use wagmi's `useSendCalls` hook directly.
+
+### Transaction Toast
+OnchainKit's `TransactionToast` provides toast-style notifications. The replacement shows inline status instead. Add a toast library if toast notifications are needed.
+
+## Common Issues
+
+### Transaction receipt stuck in pending (UI hangs after wallet confirms)
+**This is the most common bug.** The transaction hash appears, the tx confirms on-chain, but the UI stays stuck on "Transaction in progress..." forever.
+
+**Cause:** `useWaitForTransactionReceipt` needs an RPC to poll for the receipt. If the transaction's chain is not in the wagmi config's `chains` + `transports`, wagmi has no RPC endpoint to poll, so `isSuccess` never becomes `true`.
+
+**Fix (two parts):**
+1. Add the transaction's target chain to `wagmi-config.ts`:
+```typescript
+import { base, baseSepolia } from "wagmi/chains";
+
+export const wagmiConfig = createConfig({
+  chains: [base, baseSepolia],  // Must include every chain the app transacts on
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(),   // Must have a transport for each chain
+  },
+  // ...rest
+});
+```
+2. Always pass `chainId` to `useWaitForTransactionReceipt`:
+```typescript
+const { data: receipt } = useWaitForTransactionReceipt({
+  hash: txHash,
+  chainId,  // Ensures polling uses the correct chain's transport
+});
+```
+
+### Next.js page export restrictions
+Next.js only allows specific named exports from page files (`default`, `metadata`, `generateMetadata`, `generateStaticParams`, etc.). If you export contract call arrays, ABI constants, or other non-page values from a page file, the build will fail with an error like: `"calls" is not a valid Page export field`.
+
+**Fix:** Move contract call arrays, ABIs, and addresses to a separate module (e.g., `contracts.ts`) or make them non-exported `const` declarations within the page file.
+
+### Type error: comparison with "UserRejectedRequestError"
+The wagmi error types don't include `UserRejectedRequestError` as a direct name match. Instead, check `error.message` for "User rejected" or "User denied" strings.
+
+### Transaction targets wrong chain
+The component auto-switches chains via `useSwitchChain`. But the target chain must exist in the wagmi config. If you get a chain error, add the chain to `wagmi-config.ts`.
+
+### "useWriteContract must be used within WagmiProvider"
+Same as wallet: ensure the component is inside the WagmiProvider tree.
+
+### ABI type errors
+When defining the ABI inline, use `as const` on the array to get proper type inference:
+```typescript
+const abi = [
+  {
+    type: 'function' as const,
+    name: 'click',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable' as const,
+  },
+] as const;
+```

--- a/skills/migrating-an-onchainkit-app/references/troubleshooting.md
+++ b/skills/migrating-an-onchainkit-app/references/troubleshooting.md
@@ -1,0 +1,79 @@
+# Troubleshooting OnchainKit Migration
+
+## Build Errors
+
+### `Module not found: Can't resolve '@react-native-async-storage/async-storage'`
+**Cause**: MetaMask SDK includes a react-native dependency that doesn't resolve in web environments.
+**Impact**: Warning only. Does not affect functionality.
+**Solution**: Ignore. This is a known issue with MetaMask SDK's web bundle.
+
+### `Type error: Cannot find module 'wagmi/connectors'`
+**Cause**: Outdated wagmi version.
+**Solution**: Update wagmi to >= 2.16:
+```bash
+npm install wagmi@latest
+```
+
+### `Error: useAccount must be used within WagmiConfig`
+**Cause**: A component using wagmi hooks is rendering outside the WagmiProvider tree.
+**Solution**: Ensure `WagmiProvider` wraps the entire app. In Next.js, this goes in the root provider component. Both the provider and any component using wagmi hooks must have `"use client"` directive.
+
+### `Error: No QueryClient set, use QueryClientProvider`
+**Cause**: `QueryClientProvider` is missing from the provider tree.
+**Solution**: Add `QueryClientProvider` inside `WagmiProvider`:
+```typescript
+<WagmiProvider config={wagmiConfig}>
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+</WagmiProvider>
+```
+
+### `Error: Invalid chain configuration`
+**Cause**: The `transports` object doesn't have an entry for every chain in the `chains` array.
+**Solution**: Every chain in `chains` needs a matching transport:
+```typescript
+createConfig({
+  chains: [base, baseSepolia],
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(), // Must match
+  },
+});
+```
+
+## Runtime Errors
+
+### Wallet modal opens but nothing happens on click
+**Cause**: The connector might not be available or the wallet extension isn't installed.
+**Solution**: For extension-based wallets (MetaMask), the user needs the extension installed. For Coinbase Wallet and Base Account, they work via popup/redirect without an extension.
+
+### Connection succeeds but address doesn't display
+**Cause**: Component not re-rendering after connection state change.
+**Solution**: Ensure the component using `useAccount()` is a client component with `"use client"`. wagmi hooks trigger re-renders automatically when state changes.
+
+### Dark mode styles not working
+**Cause**: Tailwind dark mode not configured.
+**Solution**: Tailwind v4 uses `prefers-color-scheme` by default. If the project uses class-based dark mode, ensure the `<html>` element has the `dark` class. For Tailwind v3, check `tailwind.config.js` has `darkMode: 'class'`.
+
+## Migration-Specific Issues
+
+### OnchainKit styles break after removing the import
+**Cause**: Some layouts depended on OnchainKit's global CSS.
+**Solution**: The OnchainKit CSS mainly provides:
+- Custom `ock-*` CSS variables for theming
+- Rounded corner and color utilities
+- Font styling
+
+These are replaced by Tailwind utilities. If specific layouts break, inspect the element and add equivalent Tailwind classes.
+
+### Multiple wallet connection prompts
+**Cause**: The wagmi config has connectors that auto-connect on page load.
+**Solution**: Use `cookieStorage` for persistence (prevents reconnection prompts):
+```typescript
+storage: createStorage({ storage: cookieStorage }),
+```
+
+### SSR hydration mismatch
+**Cause**: Wallet state differs between server and client render.
+**Solution**: Ensure the wagmi config has `ssr: true` and the provider component has `"use client"` directive. Use `cookieStorage` for state persistence across SSR.

--- a/skills/migrating-an-onchainkit-app/references/wallet-migration.md
+++ b/skills/migrating-an-onchainkit-app/references/wallet-migration.md
@@ -1,0 +1,346 @@
+# Wallet Migration: OnchainKit Wallet to WalletConnect
+
+Replace OnchainKit's `Wallet`, `ConnectWallet`, `WalletDropdown`, `WalletModal`, and `Connected` components with a standalone `WalletConnect` component built on wagmi hooks.
+
+## What OnchainKit's Wallet Components Do
+
+OnchainKit provides several wallet components:
+- `<Wallet />` -- container that manages open/closed state
+- `<ConnectWallet />` -- button that triggers connection (renders as "Connect Wallet" when disconnected)
+- `<WalletDropdown />` -- dropdown with identity info and actions
+- `<WalletModal />` -- modal with multiple wallet options (Base Account, Coinbase, MetaMask, Phantom, etc.)
+- `<Connected />` -- conditional renderer based on wallet connection state
+
+The replacement `WalletConnect` component combines all of this into one component.
+
+## Prerequisites
+
+- Provider migration must be completed first (WagmiProvider + QueryClientProvider in the tree)
+- Tailwind CSS installed (if not, install it or adapt styles)
+
+## The WalletConnect Component
+
+Create `app/components/WalletConnect.tsx` (or wherever components live in the project):
+
+```typescript
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAccount, useConnect, useDisconnect } from "wagmi";
+import {
+  baseAccount,
+  coinbaseWallet,
+  metaMask,
+} from "wagmi/connectors";
+
+function truncateAddress(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+type WalletOption = {
+  id: string;
+  name: string;
+  connect: () => void;
+};
+
+function WalletModal({
+  onClose,
+  appName = "My App",
+}: {
+  onClose: () => void;
+  appName?: string;
+}) {
+  const { connect } = useConnect();
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === backdropRef.current) onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [onClose]);
+
+  const walletOptions: WalletOption[] = [
+    {
+      id: "base-account",
+      name: "Sign in with Base",
+      connect: () => {
+        connect({ connector: baseAccount({ appName }) });
+        onClose();
+      },
+    },
+    {
+      id: "coinbase-wallet",
+      name: "Coinbase Wallet",
+      connect: () => {
+        connect({
+          connector: coinbaseWallet({ appName, preference: "all" }),
+        });
+        onClose();
+      },
+    },
+    {
+      id: "metamask",
+      name: "MetaMask",
+      connect: () => {
+        connect({
+          connector: metaMask({
+            dappMetadata: {
+              name: appName,
+              url: typeof window !== "undefined" ? window.location.origin : "",
+            },
+          }),
+        });
+        onClose();
+      },
+    },
+  ];
+
+  const [primaryOption, ...otherOptions] = walletOptions;
+
+  return (
+    <div
+      ref={backdropRef}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Connect Wallet"
+    >
+      <div className="relative w-[22rem] rounded-xl bg-white p-6 pb-4 shadow-xl dark:bg-zinc-900">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-4 right-4 flex h-6 w-6 items-center justify-center rounded-md text-zinc-400 transition-colors hover:text-zinc-600 dark:hover:text-zinc-200"
+          aria-label="Close modal"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1 1L13 13M1 13L13 1"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+
+        <h2 className="mb-6 text-center text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          Connect Wallet
+        </h2>
+
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={primaryOption.connect}
+            className="w-full rounded-lg bg-blue-600 px-4 py-3 text-left font-medium text-white transition-colors hover:bg-blue-700"
+          >
+            {primaryOption.name}
+          </button>
+
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-zinc-200 dark:border-zinc-700" />
+            </div>
+            <div className="relative flex justify-center">
+              <span className="bg-white px-2 text-xs text-zinc-400 dark:bg-zinc-900 dark:text-zinc-500">
+                or use another wallet
+              </span>
+            </div>
+          </div>
+
+          {otherOptions.map((wallet) => (
+            <button
+              key={wallet.id}
+              type="button"
+              onClick={wallet.connect}
+              className="w-full rounded-lg border border-zinc-200 bg-white px-4 py-3 text-left font-medium text-zinc-900 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-750"
+            >
+              {wallet.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WalletConnect({ appName = "My App" }: { appName?: string }) {
+  const { address, isConnected } = useAccount();
+  const { disconnect } = useDisconnect();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  if (isConnected && address) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="rounded-lg bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+          {truncateAddress(address)}
+        </span>
+        <button
+          type="button"
+          onClick={() => disconnect()}
+          className="rounded-lg border border-zinc-200 px-3 py-2 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+      >
+        Connect Wallet
+      </button>
+      {isModalOpen && (
+        <WalletModal
+          onClose={() => setIsModalOpen(false)}
+          appName={appName}
+        />
+      )}
+    </>
+  );
+}
+```
+
+## Step-by-Step Replacement
+
+### 1. Create the Component File
+
+Copy the component code above into the project's components directory.
+
+### 2. Replace OnchainKit Wallet Imports
+
+Find all files importing from `@coinbase/onchainkit/wallet` or using `Connected` from `@coinbase/onchainkit`:
+
+**Before:**
+```typescript
+import { Wallet } from "@coinbase/onchainkit/wallet";
+// or
+import { ConnectWallet, Wallet, WalletDropdown, WalletDropdownDisconnect } from "@coinbase/onchainkit/wallet";
+// or
+import { Connected } from "@coinbase/onchainkit";
+```
+
+**After:**
+```typescript
+import { WalletConnect } from "./components/WalletConnect";
+```
+
+### 3. Replace Component Usage
+
+**Simple `<Wallet />`:**
+```typescript
+// Before
+<Wallet />
+
+// After
+<WalletConnect />
+```
+
+**Composed wallet with children:**
+```typescript
+// Before
+<Wallet>
+  <ConnectWallet>
+    <Avatar className="h-6 w-6" />
+    <Name />
+  </ConnectWallet>
+  <WalletDropdown>
+    <Identity hasCopyAddressOnClick>
+      <Avatar />
+      <Name />
+      <Address />
+    </Identity>
+    <WalletDropdownDisconnect />
+  </WalletDropdown>
+</Wallet>
+
+// After
+<WalletConnect appName="My App" />
+```
+
+**`<Connected />` conditional rendering:**
+```typescript
+// Before
+import { Connected } from "@coinbase/onchainkit";
+
+<Connected fallback={<p>Please connect</p>}>
+  <p>You are connected</p>
+</Connected>
+
+// After -- use wagmi's useAccount directly
+import { useAccount } from "wagmi";
+
+const { isConnected } = useAccount();
+{isConnected ? <p>You are connected</p> : <p>Please connect</p>}
+```
+
+### 4. Remove MiniKit Usage
+
+If the page uses `useMiniKit` or other MiniKit hooks, remove them:
+
+```typescript
+// Remove these
+import { useMiniKit } from "@coinbase/onchainkit/minikit";
+const { setMiniAppReady, isMiniAppReady } = useMiniKit();
+useEffect(() => {
+  if (!isMiniAppReady) setMiniAppReady();
+}, [setMiniAppReady, isMiniAppReady]);
+```
+
+### 5. Verify
+
+Run `npm run build` and confirm no errors.
+
+## Customization
+
+### Changing the app name
+Pass the `appName` prop to `WalletConnect`:
+```typescript
+<WalletConnect appName="My DApp" />
+```
+
+### Adding more wallet options
+Add entries to the `walletOptions` array in the `WalletModal` component. Use `injected({ target: 'walletName' })` from `wagmi/connectors` for browser extension wallets.
+
+### Changing styles
+The component uses Tailwind utility classes. Modify the `className` strings to match the project's design system. All styling is inline via Tailwind -- no external CSS files needed.
+
+### Using without Tailwind
+If the project doesn't use Tailwind, convert the Tailwind classes to inline styles or CSS modules. The key visual elements are:
+- Fixed overlay with semi-transparent black background
+- Centered card with white background, rounded corners, shadow
+- Primary button (blue) for Base Account
+- Secondary buttons (white/bordered) for other wallets
+- Dark mode support via `dark:` variants
+
+## Common Issues
+
+### "useAccount must be used within WagmiProvider"
+The component is being rendered outside the provider tree. Ensure `WagmiProvider` wraps the entire app in the layout or root provider.
+
+### Modal doesn't close after connecting
+This can happen if the connection is async and the component unmounts. The current implementation calls `onClose()` synchronously after `connect()`. If you need to wait for the connection, use the `onSuccess` callback from `useConnect`.
+
+### baseAccount connector not found
+Ensure wagmi version is >= 2.16. The `baseAccount` connector was added in recent wagmi versions. Check with:
+```bash
+npm ls wagmi
+```


### PR DESCRIPTION
Add skill to migrate @coinbase/onchainkit apps off the library — covers provider, wallet connect modal, and contract transaction components using wagmi hooks. 

Developers can prompt agents by saying: "Migrate my OnchainKit app. Replace the provider, wallet component, and transaction component. Follow the onchainkit-migration skill."