### PR TITLE
fix(minikit-migration): add missing notifications reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base/base-skills)](https://github.com/base/base-skills/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/base-skills)](https://github.com/base/base-skills/graphs/contributors)
-![GitHub repo size](https://img.shields.io/github/repo-size/base/base-skills)
+[![GitHub contributors](https://img.shields.io/github/contributors/base/skills)](https://github.com/base/skills/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/skills)](https://github.com/base/skills/graphs/contributors)
+![GitHub repo size](https://img.shields.io/github/repo-size/base/skills)
 
 <!-- Badge row 2 - links and profiles -->
 
@@ -20,8 +20,8 @@
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/base-skills)](https://github.com/base/base-skills/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base/base-skills.svg)](https://github.com/base/base-skills/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/skills)](https://github.com/base/skills/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base/skills.svg)](https://github.com/base/skills/issues)
 
 ## Available Skills
 
@@ -42,7 +42,7 @@
 Install with [Vercel's Skills CLI](https://skills.sh):
 
 ```bash
-npx skills add base/base-skills
+npx skills add base/skills
 ```
 
 ## Usage

--- a/skills/converting-minikit-to-farcaster/NOTIFICATIONS.md
+++ b/skills/converting-minikit-to-farcaster/NOTIFICATIONS.md
@@ -1,0 +1,54 @@
+# Notifications Migration
+
+MiniKit's `useNotification` hook does not have a direct one-to-one client-side replacement in the Farcaster Mini App SDK.
+
+When migrating notification functionality, move notification sending logic to your backend instead of sending notifications directly from the client.
+
+## Migration Summary
+
+### Before
+
+MiniKit apps may use `useNotification()` from `@coinbase/onchainkit/minikit` inside client components.
+
+### After
+
+Farcaster Mini Apps should trigger a backend endpoint from the client. The backend is responsible for handling notification delivery.
+
+## Recommended Pattern
+
+Create a server endpoint, such as:
+
+`POST /api/send-notification`
+
+Then call that endpoint from your client when a notification should be sent.
+
+Example client-side trigger:
+
+```typescript
+async function sendNotification() {
+  await fetch('/api/send-notification', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      title: 'Hello!',
+      body: 'You have a new message',
+    }),
+  });
+}
+```
+
+## Important Notes
+
+- Do not keep notification credentials or secrets in client-side code.
+- Validate the user and request on the backend before sending notifications.
+- Avoid blindly forwarding arbitrary client-provided notification content.
+- Treat notification sending as a server-side capability.
+
+## Migration Checklist
+
+- Remove `useNotification` imports from `@coinbase/onchainkit/minikit`.
+- Replace direct client notification calls with a backend API call.
+- Add backend validation before sending notifications.
+- Keep any notification tokens, secrets, or credentials server-side.


### PR DESCRIPTION
## Summary

Adds the missing `NOTIFICATIONS.md` reference for the MiniKit to Farcaster migration skill.

## Changes

- Added `skills/converting-minikit-to-farcaster/NOTIFICATIONS.md`
- Documented the recommended migration path for MiniKit notification usage
- Clarified that notification sending should move from client-side MiniKit hooks to a backend endpoint

## Why

[MAPPING.md](cci:7://file:///C:/Users/Zeki/CascadeProjects/skills-research/skills/converting-minikit-to-farcaster/MAPPING.md:0:0-0:0) currently links to `NOTIFICATIONS.md` in the notification migration section, but that file was missing. This caused a broken local reference for users following the migration guide.

Fixes #30 