### PR TITLE
Add verifying-contracts-on-basescan skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | [Converting Farcaster Miniapp to App](./skills/convert-farcaster-miniapp-to-app/SKILL.md) | Converts Farcaster Mini App SDK projects into regular Base web apps, with an option to preserve a small separate Farcaster-specific surface when needed. |
 | [Deploying Contracts on Base](./skills/deploying-contracts-on-base/SKILL.md) | Deploys and verifies contracts on Base with Foundry, plus common troubleshooting guidance. |
 | [Running a Base Node](./skills/running-a-base-node/SKILL.md) | Covers production node setup, hardware requirements, networking ports, and syncing guidance. |
+| [Verifying Contracts on Basescan](./skills/verifying-contracts-on-basescan/SKILL.md) | Verifies contracts on Base via the unified Etherscan V2 API (chainid 8453/84532), covering Foundry, Hardhat, manual UI, Sourcify, and common errors. |
 | [Converting MiniKit to Farcaster](./skills/converting-minikit-to-farcaster/SKILL.md) | Migrates Mini Apps from MiniKit (OnchainKit) to native Farcaster SDK with mappings, examples, and pitfalls. |
 | [Migrating an OnchainKit App](./skills/migrating-an-onchainkit-app/SKILL.md) | Migrates apps from @coinbase/onchainkit to standalone wagmi/viem components, replacing the provider, wallet, and transaction components. |
 | [Registering an Agent on Base](./skills/registering-agent-base-dev/SKILL.md) | Registers an agent wallet with the Base builder code API and wires ERC-8021 transaction attribution into viem, ethers, or managed signing services. |

--- a/skills/verifying-contracts-on-basescan/SKILL.md
+++ b/skills/verifying-contracts-on-basescan/SKILL.md
@@ -205,7 +205,7 @@ For Sepolia, replace `--chain 8453` with `--chain 84532`. No `--etherscan-api-ke
 | `Missing or invalid chainid` | V2 endpoint called without `chainid` param | Include `?chainid=8453` or `?chainid=84532` in the verifier URL |
 | `Bytecode does not match` | Compiler version, optimizer runs, or EVM version differs from deployment | Re-verify with exact original settings; inspect `foundry.toml` or Hardhat config |
 | `Constructor arguments not matching` | Args absent or incorrectly encoded | Re-encode with `cast abi-encode "constructor(...)" ...` |
-| `Already Verified` | Contract is already verified | Not an error — check Basescan to confirm the source is visible |
+| `already verified. Skipping verification` | Contract is already verified | Not an error — Foundry skips automatically; check Basescan to confirm source is visible |
 | Library not linked | Linked library not verified or wrong address | Verify the library first, then re-run with `--libraries` |
 | Proxy shows unverified implementation | Implementation contract not marked as proxy | Verify the implementation address, then use the "Is this a Proxy?" button on Basescan |
 

--- a/skills/verifying-contracts-on-basescan/SKILL.md
+++ b/skills/verifying-contracts-on-basescan/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: verifying-contracts-on-basescan
+description: Verifies smart contracts on Base Mainnet and Base Sepolia using the unified Etherscan V2 API (chainid 8453/84532). Use when verifying deployed contracts, configuring etherscan API keys, or troubleshooting verification failures across Foundry, Hardhat, and Basescan UI. Covers phrases like "verify contract on Base", "basescan verification", "forge verify-contract", "etherscan API key Base", "contract not verified", "hardhat verify Base", "sourcify verification", "bytecode mismatch", "constructor args verification", "proxy contract verification", or "already verified".
+---
+
+# Verifying Contracts on Basescan
+
+## Critical: Etherscan V2 API (V1 was sunset August 15, 2025)
+
+The Basescan V1 API (`api.basescan.org/api`) was fully deactivated on **August 15, 2025**. Always use the unified Etherscan V2 API.
+
+| | V1 (deprecated — do not use) | V2 (current) |
+|---|---|---|
+| Mainnet endpoint | `https://api.basescan.org/api` | `https://api.etherscan.io/v2/api?chainid=8453` |
+| Sepolia endpoint | `https://api-sepolia.basescan.org/api` | `https://api.etherscan.io/v2/api?chainid=84532` |
+| API key source | basescan.org | etherscan.io (one key for all chains) |
+
+Typical V1 error: `"You are using a deprecated V1 endpoint, switch to Etherscan API V2"`
+
+## Prerequisites
+
+1. Get an API key at [etherscan.io/apidashboard](https://etherscan.io/apidashboard) — a free account covers all chains including Base
+2. Export it:
+
+```bash
+export ETHERSCAN_API_KEY=your_etherscan_api_key
+```
+
+3. Note the deployed contract address and the exact compiler/optimizer settings used at deploy time
+
+## Security
+
+- **Never commit API keys** — use environment variables or `foundry.toml` with `${ENV_VAR}` references
+- **Never expose `.env` files** — add `.env` to `.gitignore`
+- **Match deployment settings exactly** — compiler version, optimizer runs, and EVM version must match the original deployment; mismatches cause bytecode verification failures
+
+## Foundry
+
+### Verify an already-deployed contract
+
+**Mainnet (chainid 8453):**
+
+```bash
+forge verify-contract \
+  --chain 8453 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+**Sepolia (chainid 84532):**
+
+```bash
+forge verify-contract \
+  --chain 84532 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=84532" \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+Add `--watch` to poll until verification completes:
+
+```bash
+forge verify-contract ... --watch
+```
+
+### Constructor arguments
+
+Encode with `cast abi-encode`, then pass the result to `--constructor-args`:
+
+```bash
+ARGS=$(cast abi-encode "constructor(uint256,address)" 1000 0xYourAddress)
+
+forge verify-contract \
+  --chain 8453 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+  --constructor-args $ARGS \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+### Deploy and verify in one step
+
+For `forge create --verify` and `forge script --verify`, see [Deploying Contracts on Base](../deploying-contracts-on-base/SKILL.md). Configure `foundry.toml` to use the V2 endpoint instead of the deprecated per-chain basescan URLs:
+
+```toml
+[etherscan]
+base = { key = "${ETHERSCAN_API_KEY}", chain = 8453, url = "https://api.etherscan.io/v2/api?chainid=8453" }
+base-sepolia = { key = "${ETHERSCAN_API_KEY}", chain = 84532, url = "https://api.etherscan.io/v2/api?chainid=84532" }
+```
+
+### Linked libraries
+
+Verify the library first, then verify the contract with `--libraries`:
+
+```bash
+forge verify-contract \
+  --chain 8453 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+  --libraries src/lib/MyLib.sol:MyLib:<lib-deployed-address> \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+## Hardhat
+
+Install the plugin:
+
+```bash
+npm install --save-dev @nomicfoundation/hardhat-verify
+```
+
+Configure `hardhat.config.ts`. Use `apiKey` as a **single string** — not an object keyed by network, which is the deprecated V1 pattern that breaks with V2:
+
+```typescript
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-verify";
+
+const config: HardhatUserConfig = {
+  networks: {
+    base: {
+      url: "https://mainnet.base.org",
+      chainId: 8453,
+    },
+    baseSepolia: {
+      url: "https://sepolia.base.org",
+      chainId: 84532,
+    },
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY as string,
+    customChains: [
+      {
+        network: "base",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=8453",
+          browserURL: "https://basescan.org",
+        },
+      },
+      {
+        network: "baseSepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=84532",
+          browserURL: "https://sepolia.basescan.org",
+        },
+      },
+    ],
+  },
+};
+
+export default config;
+```
+
+Verify:
+
+```bash
+# No constructor args
+npx hardhat verify --network base <deployed-address>
+
+# With constructor args (pass values directly)
+npx hardhat verify --network base <deployed-address> "arg1" "arg2"
+
+# Sepolia
+npx hardhat verify --network baseSepolia <deployed-address>
+```
+
+## Manual UI Verification (basescan.org)
+
+Use when tooling is unavailable, the contract was deployed without `--verify`, or for a quick single-file contract.
+
+1. Open [basescan.org](https://basescan.org) (Mainnet) or [sepolia.basescan.org](https://sepolia.basescan.org) (Sepolia)
+2. Search the contract address → **Contract** tab → **Verify and Publish**
+3. Choose compiler type:
+   - **Solidity (Single file)**: flatten first with `forge flatten src/MyContract.sol > flat.sol`
+   - **Solidity (Standard JSON input)**: use the `input` field from the compilation artifact — most reliable for multi-file contracts and imports
+4. Match compiler version and optimizer settings exactly to the deployment
+5. Enter ABI-encoded constructor arguments if the contract constructor takes parameters
+
+## Sourcify (Decentralized Alternative)
+
+[Sourcify](https://sourcify.dev) verifies against IPFS-stored metadata with no centralized API key. Basescan displays a separate badge for Sourcify-verified contracts.
+
+```bash
+forge verify-contract \
+  --chain 8453 \
+  --verifier sourcify \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+For Sepolia, replace `--chain 8453` with `--chain 84532`. No `--etherscan-api-key` required.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `deprecated V1 endpoint` | Using `api.basescan.org/api` | Add `--verifier-url "https://api.etherscan.io/v2/api?chainid=8453"` or update `foundry.toml` |
+| `Invalid API Key` | Wrong key or key from basescan.org only | Use an Etherscan key from etherscan.io |
+| `Missing or invalid chainid` | V2 endpoint called without `chainid` param | Include `?chainid=8453` or `?chainid=84532` in the verifier URL |
+| `Bytecode does not match` | Compiler version, optimizer runs, or EVM version differs from deployment | Re-verify with exact original settings; inspect `foundry.toml` or Hardhat config |
+| `Constructor arguments not matching` | Args absent or incorrectly encoded | Re-encode with `cast abi-encode "constructor(...)" ...` |
+| `Already Verified` | Contract is already verified | Not an error — check Basescan to confirm the source is visible |
+| Library not linked | Linked library not verified or wrong address | Verify the library first, then re-run with `--libraries` |
+| Proxy shows unverified implementation | Implementation contract not marked as proxy | Verify the implementation address, then use the "Is this a Proxy?" button on Basescan |
+
+## References
+
+- [Etherscan V2 Migration Guide](https://docs.etherscan.io/v2-migration)
+- [Etherscan V2 Supported Chains](https://docs.etherscan.io/etherscan-v2/getting-started/supported-chains)
+- [Foundry — forge verify-contract](https://book.getfoundry.sh/reference/forge/forge-verify-contract)
+- [Foundry — Deploying and Verifying](https://book.getfoundry.sh/forge/deploying)
+- [Hardhat Verify Plugin](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify)
+- [Base Docs — Block Explorers](https://docs.base.org/docs/tools/block-explorers)


### PR DESCRIPTION
Closes #35

## Summary

Adds `verifying-contracts-on-basescan` skill covering smart contract verification on Base Mainnet and Base Sepolia.

## Motivation

A common failure mode for both developers and AI coding agents is recommending the deprecated Basescan V1 API instead of the unified Etherscan V2 API. V1 was fully deactivated on August 15, 2025. The exact error it returns:

```
You are using a deprecated V1 endpoint, switch to Etherscan API V2
using https://docs.etherscan.io/v2-migration
```

Stale docs and LLM training data keep surfacing `api.basescan.org/api` and per-chain Basescan keys. This skill is the authoritative reference so agents stop suggesting V1 endpoints.

Verification is also only mentioned in passing inside `deploying-contracts-on-base`, with no coverage of standalone verification, Hardhat, Sourcify, or already-deployed contracts.

## This was tested live on Base Sepolia before opening this PR

- Deployed `SimpleStorage` with a constructor argument
- Verified via **Etherscan V2** (`forge verify-contract --verifier-url "https://api.etherscan.io/v2/api?chainid=84532"`): [`0xA6E4e2977dD3470Fa3E9683B98DC30B888755D0a`](https://sepolia.basescan.org/address/0xa6e4e2977dd3470fa3e9683b98dc30b888755d0a) → `Pass - Verified`
- Verified via **Sourcify** (`--verifier sourcify`, no API key): [`0xF0E6DF13b99525f9144D82f23b9DF860BAB4EE1e`](https://sepolia.basescan.org/address/0xF0E6DF13b99525f9144D82f23b9DF860BAB4EE1e) → `exact_match`
- Confirmed V1 endpoint returns the exact error above
- Confirmed Foundry's `already verified. Skipping verification` behaviour (graceful, not an error — corrected in the skill from the live test)

## Scope

- V1 → V2 migration table with the exact error message
- Foundry `forge verify-contract` (Mainnet/Sepolia, constructor args, `--watch`, linked libraries)
- `foundry.toml` V2 config replacing the deprecated per-chain basescan URLs
- Hardhat `@nomicfoundation/hardhat-verify` — single `apiKey` string + `customChains` pointing to V2
- Manual UI verification on basescan.org (single file vs standard JSON input)
- Sourcify as a decentralised alternative (no API key)
- Common errors table with causes and fixes (8 entries, messages taken from live test output)
- Cross-reference to `deploying-contracts-on-base` for deploy+verify flow — no duplication

## Out of scope

Deployment — that lives in `deploying-contracts-on-base`.

## Checklist

- [x] Scope approved in #35
- [x] Frontmatter and structure match existing skills
- [x] Description optimised for skill triggering
- [x] All chain IDs and endpoints verified against docs.etherscan.io / docs.base.org
- [x] Error messages taken from live test output, not paraphrased
- [x] README "Available Skills" table updated
- [x] Single skill, single commit, no overlap with existing skills