### PR TITLE
Add registering-an-erc-8004-agent-on-base skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | [Converting Farcaster Miniapp to App](./skills/convert-farcaster-miniapp-to-app/SKILL.md) | Converts Farcaster Mini App SDK projects into regular Base web apps, with an option to preserve a small separate Farcaster-specific surface when needed. |
 | [Deploying Contracts on Base](./skills/deploying-contracts-on-base/SKILL.md) | Deploys and verifies contracts on Base with Foundry, plus common troubleshooting guidance. |
 | [Running a Base Node](./skills/running-a-base-node/SKILL.md) | Covers production node setup, hardware requirements, networking ports, and syncing guidance. |
+| [Verifying Contracts on Basescan](./skills/verifying-contracts-on-basescan/SKILL.md) | Verifies contracts on Base via the unified Etherscan V2 API (chainid 8453/84532), covering Foundry, Hardhat, manual UI, Sourcify, and common errors. |
 | [Converting MiniKit to Farcaster](./skills/converting-minikit-to-farcaster/SKILL.md) | Migrates Mini Apps from MiniKit (OnchainKit) to native Farcaster SDK with mappings, examples, and pitfalls. |
 | [Migrating an OnchainKit App](./skills/migrating-an-onchainkit-app/SKILL.md) | Migrates apps from @coinbase/onchainkit to standalone wagmi/viem components, replacing the provider, wallet, and transaction components. |
 | [Registering an Agent on Base](./skills/registering-agent-base-dev/SKILL.md) | Registers an agent wallet with the Base builder code API and wires ERC-8021 transaction attribution into viem, ethers, or managed signing services. |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 | [Deploying Contracts on Base](./skills/deploying-contracts-on-base/SKILL.md) | Deploys and verifies contracts on Base with Foundry, plus common troubleshooting guidance. |
 | [Running a Base Node](./skills/running-a-base-node/SKILL.md) | Covers production node setup, hardware requirements, networking ports, and syncing guidance. |
 | [Verifying Contracts on Basescan](./skills/verifying-contracts-on-basescan/SKILL.md) | Verifies contracts on Base via the unified Etherscan V2 API (chainid 8453/84532), covering Foundry, Hardhat, manual UI, Sourcify, and common errors. |
+| [Registering an ERC-8004 Agent on Base](./skills/registering-an-erc-8004-agent-on-base/SKILL.md) | Registers trustless agents in the ERC-8004 Identity Registry on Base Mainnet and Sepolia, covering agent registration files, agentURI hosting, and agentWallet binding via EIP-712. |
 | [Converting MiniKit to Farcaster](./skills/converting-minikit-to-farcaster/SKILL.md) | Migrates Mini Apps from MiniKit (OnchainKit) to native Farcaster SDK with mappings, examples, and pitfalls. |
 | [Migrating an OnchainKit App](./skills/migrating-an-onchainkit-app/SKILL.md) | Migrates apps from @coinbase/onchainkit to standalone wagmi/viem components, replacing the provider, wallet, and transaction components. |
 | [Registering an Agent on Base](./skills/registering-agent-base-dev/SKILL.md) | Registers an agent wallet with the Base builder code API and wires ERC-8021 transaction attribution into viem, ethers, or managed signing services. |

--- a/skills/registering-an-erc-8004-agent-on-base/SKILL.md
+++ b/skills/registering-an-erc-8004-agent-on-base/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: registering-an-erc-8004-agent-on-base
+description: "Invoke this skill when an agent or developer needs to register an ERC-8004 agent identity on Base. This skill contains the canonical IdentityRegistry addresses for Base Mainnet and Sepolia that LLM training data frequently gets wrong — you MUST load it to register correctly. Covers register(), setAgentURI(), setAgentWallet(), the registration file schema, and read-back verification. Use when building agent identity, setting up agentId, publishing agentURI, binding agentWallet, or reading agent data on Base Mainnet (chainId 8453) or Base Sepolia (chainId 84532). Covers phrases like 'register ERC-8004 agent', 'agent identity on Base', 'agentId', 'agentURI', 'identity registry', 'trustless agent', 'agent registration file', or 'ERC-8004'."
+---
+
+# ERC-8004 Agent Registration
+
+[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) defines three on-chain registries for autonomous agents: **Identity**, **Reputation**, and **Validation**. This skill covers **Identity only**. Each registered agent receives an ERC-721 `agentId` and an optional `agentURI` pointing to a registration file.
+
+## Canonical Addresses (Base)
+
+| Network | IdentityRegistry | Chain ID |
+|---------|-----------------|----------|
+| Base Mainnet | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` | 8453 |
+| Base Sepolia | `0x8004A818BFB912233c491871b3d84c89A494BD9e` | 84532 |
+
+Same vanity addresses on every supported chain. Always use these — do not guess or use any other address.
+
+## Pre-flight: Check for Existing Registration
+
+Before registering, check whether the owner already has an agent:
+
+```bash
+cast call <IDENTITY_REGISTRY> "balanceOf(address)(uint256)" <OWNER_ADDRESS> \
+  --rpc-url https://sepolia.base.org
+```
+
+If the result is `> 0`, the owner already has registered agents. Ask for the existing `agentId` before proceeding — do not register a duplicate unless intentional.
+
+## Phase 1 — Build the Registration File
+
+The `agentURI` must resolve to a JSON document with this structure (source: `ERC8004SPEC.md`):
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "MyAgent",
+  "description": "What the agent does, how to interact with it, pricing if applicable",
+  "image": "https://example.com/agent.png",
+  "services": [
+    { "name": "A2A",  "endpoint": "https://agent.example/.well-known/agent-card.json", "version": "0.3.0" },
+    { "name": "MCP",  "endpoint": "https://mcp.agent.example/", "version": "2025-06-18" }
+  ],
+  "x402Support": false,
+  "active": true,
+  "registrations": [
+    {
+      "agentId": 42,
+      "agentRegistry": "eip155:84532:0x8004A818BFB912233c491871b3d84c89A494BD9e"
+    }
+  ],
+  "supportedTrust": ["reputation"]
+}
+```
+
+`agentRegistry` format: `eip155:{chainId}:{identityRegistryAddress}`. Use `8453` for Mainnet, `84532` for Sepolia.
+
+If the `agentId` is not known yet (registering with no URI first), use `0` as a placeholder and update with `setAgentURI()` after minting.
+
+## Phase 2 — Host the Registration File
+
+| Option | URI format | When to use |
+|--------|-----------|-------------|
+| IPFS | `ipfs://{cid}` | Production — immutable, content-addressed |
+| HTTPS | `https://example.com/agent.json` | Simple; requires keeping the endpoint live |
+| On-chain | `data:application/json;base64,{base64}` | Maximum censorship-resistance; higher gas |
+
+To encode on-chain:
+```bash
+echo '{"type":"https://eips.ethereum.org/EIPS/eip-8004#registration-v1",...}' \
+  | base64 -w0 | xargs -I{} echo "data:application/json;base64,{}"
+```
+
+## Phase 3 — Register On-Chain
+
+### viem (TypeScript)
+
+```typescript
+import { createWalletClient, createPublicClient, http, parseAbi } from "viem";
+import { baseSepolia } from "viem/chains"; // use `base` for Mainnet
+import { privateKeyToAccount } from "viem/accounts";
+
+const IDENTITY_REGISTRY = "0x8004A818BFB912233c491871b3d84c89A494BD9e";
+const abi = parseAbi([
+  "function register() returns (uint256 agentId)",
+  "function register(string agentURI) returns (uint256 agentId)",
+  "function setAgentURI(uint256 agentId, string newURI) external",
+  "function ownerOf(uint256 tokenId) view returns (address)",
+  "function tokenURI(uint256 tokenId) view returns (string)",
+  "function getAgentWallet(uint256 agentId) view returns (address)",
+]);
+
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+const client  = createWalletClient({ account, chain: baseSepolia, transport: http() });
+
+// Option A: register with URI in one step
+const hash = await client.writeContract({
+  address: IDENTITY_REGISTRY, abi,
+  functionName: "register",
+  args: ["ipfs://your-cid"],
+});
+
+// Option B: register first, set URI after (use when agentId must appear in the file)
+const hash2   = await client.writeContract({ address: IDENTITY_REGISTRY, abi, functionName: "register", args: [] });
+// ... get agentId from Registered event, build file with real agentId, then:
+await client.writeContract({ address: IDENTITY_REGISTRY, abi, functionName: "setAgentURI", args: [agentId, "ipfs://final-cid"] });
+```
+
+> **Note**: `register(agentURI, metadata[])` accepts extra on-chain metadata. Do **not** pass `agentWallet` in the metadata array — it is reserved and the call will revert.
+
+### cast (Foundry)
+
+```bash
+# Sepolia
+cast send 0x8004A818BFB912233c491871b3d84c89A494BD9e \
+  "register(string)(uint256)" "ipfs://your-cid" \
+  --rpc-url https://sepolia.base.org --private-key $PRIVATE_KEY
+
+# Mainnet
+cast send 0x8004A169FB4a3325136EB29fA0ceB6D2e539a432 \
+  "register(string)(uint256)" "ipfs://your-cid" \
+  --rpc-url https://mainnet.base.org --private-key $PRIVATE_KEY
+```
+
+The returned value is the `agentId`. Store it — every subsequent call requires it.
+
+## Phase 4 (Optional) — Bind agentWallet
+
+`agentWallet` is set automatically to the owner's address on `register()`. To change it, `newWallet` must sign an EIP-712 message. The **caller** must be the agent owner or operator; the **signature** must come from `newWallet`.
+
+```typescript
+import { signTypedData } from "viem/accounts";
+
+const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+
+const signature = await signTypedData({
+  privateKey: newWalletPrivateKey,
+  domain: {
+    name: "ERC8004IdentityRegistry",
+    version: "1",
+    chainId: 84532,                                           // 8453 for Mainnet
+    verifyingContract: IDENTITY_REGISTRY,
+  },
+  types: {
+    AgentWalletSet: [
+      { name: "agentId",   type: "uint256" },
+      { name: "newWallet", type: "address" },
+      { name: "owner",     type: "address" },                // current agent owner
+      { name: "deadline",  type: "uint256" },
+    ],
+  },
+  primaryType: "AgentWalletSet",
+  message: { agentId: BigInt(agentId), newWallet, owner: agentOwnerAddress, deadline },
+});
+
+await client.writeContract({
+  address: IDENTITY_REGISTRY,
+  abi: parseAbi(["function setAgentWallet(uint256,address,uint256,bytes) external"]),
+  functionName: "setAgentWallet",
+  args: [BigInt(agentId), newWallet, deadline, signature],
+});
+```
+
+For ERC-1271 smart wallets, `isValidSignature` is called on `newWallet` instead of ECDSA recovery — no code change needed, the contract handles both. On transfer, `agentWallet` is automatically cleared and must be re-set by the new owner.
+
+## Read-back
+
+```typescript
+const owner  = await publicClient.readContract({ address: IDENTITY_REGISTRY, abi, functionName: "ownerOf",        args: [agentId] });
+const uri    = await publicClient.readContract({ address: IDENTITY_REGISTRY, abi, functionName: "tokenURI",       args: [agentId] });
+const wallet = await publicClient.readContract({ address: IDENTITY_REGISTRY, abi, functionName: "getAgentWallet", args: [agentId] });
+```
+
+Explorers: [basescan.org](https://basescan.org) (Mainnet) · [sepolia.basescan.org](https://sepolia.basescan.org) (Sepolia)
+
+## Key Facts
+
+- `agentId` is the ERC-721 `tokenId` — an auto-incremented integer, **not** a wallet address
+- `agentRegistry` identifier: `eip155:{chainId}:{identityRegistryAddress}`
+- An agent can be registered on multiple chains simultaneously
+- Contract version: 2.0.0 — token name "AgentIdentity"
+
+## Out of Scope
+
+- **Reputation Registry** — stable, reserved for a sibling skill
+- **Validation Registry** — spec authors flag it as under active TEE community revision
+- **x402 payment integration** — see [ERC-8004 spec](https://eips.ethereum.org/EIPS/eip-8004) for examples
+
+## References
+
+- [ERC-8004 Specification](https://eips.ethereum.org/EIPS/eip-8004)
+- [erc-8004/erc-8004-contracts](https://github.com/erc-8004/erc-8004-contracts)
+- [8004.org/build](https://www.8004.org/build)
+- [Base Docs](https://docs.base.org)

--- a/skills/verifying-contracts-on-basescan/SKILL.md
+++ b/skills/verifying-contracts-on-basescan/SKILL.md
@@ -205,7 +205,7 @@ For Sepolia, replace `--chain 8453` with `--chain 84532`. No `--etherscan-api-ke
 | `Missing or invalid chainid` | V2 endpoint called without `chainid` param | Include `?chainid=8453` or `?chainid=84532` in the verifier URL |
 | `Bytecode does not match` | Compiler version, optimizer runs, or EVM version differs from deployment | Re-verify with exact original settings; inspect `foundry.toml` or Hardhat config |
 | `Constructor arguments not matching` | Args absent or incorrectly encoded | Re-encode with `cast abi-encode "constructor(...)" ...` |
-| `Already Verified` | Contract is already verified | Not an error — check Basescan to confirm the source is visible |
+| `already verified. Skipping verification` | Contract is already verified | Not an error — Foundry skips automatically; check Basescan to confirm source is visible |
 | Library not linked | Linked library not verified or wrong address | Verify the library first, then re-run with `--libraries` |
 | Proxy shows unverified implementation | Implementation contract not marked as proxy | Verify the implementation address, then use the "Is this a Proxy?" button on Basescan |
 

--- a/skills/verifying-contracts-on-basescan/SKILL.md
+++ b/skills/verifying-contracts-on-basescan/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: verifying-contracts-on-basescan
+description: Verifies smart contracts on Base Mainnet and Base Sepolia using the unified Etherscan V2 API (chainid 8453/84532). Use when verifying deployed contracts, configuring etherscan API keys, or troubleshooting verification failures across Foundry, Hardhat, and Basescan UI. Covers phrases like "verify contract on Base", "basescan verification", "forge verify-contract", "etherscan API key Base", "contract not verified", "hardhat verify Base", "sourcify verification", "bytecode mismatch", "constructor args verification", "proxy contract verification", or "already verified".
+---
+
+# Verifying Contracts on Basescan
+
+## Critical: Etherscan V2 API (V1 was sunset August 15, 2025)
+
+The Basescan V1 API (`api.basescan.org/api`) was fully deactivated on **August 15, 2025**. Always use the unified Etherscan V2 API.
+
+| | V1 (deprecated — do not use) | V2 (current) |
+|---|---|---|
+| Mainnet endpoint | `https://api.basescan.org/api` | `https://api.etherscan.io/v2/api?chainid=8453` |
+| Sepolia endpoint | `https://api-sepolia.basescan.org/api` | `https://api.etherscan.io/v2/api?chainid=84532` |
+| API key source | basescan.org | etherscan.io (one key for all chains) |
+
+Typical V1 error: `"You are using a deprecated V1 endpoint, switch to Etherscan API V2"`
+
+## Prerequisites
+
+1. Get an API key at [etherscan.io/apidashboard](https://etherscan.io/apidashboard) — a free account covers all chains including Base
+2. Export it:
+
+```bash
+export ETHERSCAN_API_KEY=your_etherscan_api_key
+```
+
+3. Note the deployed contract address and the exact compiler/optimizer settings used at deploy time
+
+## Security
+
+- **Never commit API keys** — use environment variables or `foundry.toml` with `${ENV_VAR}` references
+- **Never expose `.env` files** — add `.env` to `.gitignore`
+- **Match deployment settings exactly** — compiler version, optimizer runs, and EVM version must match the original deployment; mismatches cause bytecode verification failures
+
+## Foundry
+
+### Verify an already-deployed contract
+
+**Mainnet (chainid 8453):**
+
+```bash
+forge verify-contract \
+  --chain 8453 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+**Sepolia (chainid 84532):**
+
+```bash
+forge verify-contract \
+  --chain 84532 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=84532" \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+Add `--watch` to poll until verification completes:
+
+```bash
+forge verify-contract ... --watch
+```
+
+### Constructor arguments
+
+Encode with `cast abi-encode`, then pass the result to `--constructor-args`:
+
+```bash
+ARGS=$(cast abi-encode "constructor(uint256,address)" 1000 0xYourAddress)
+
+forge verify-contract \
+  --chain 8453 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+  --constructor-args $ARGS \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+### Deploy and verify in one step
+
+For `forge create --verify` and `forge script --verify`, see [Deploying Contracts on Base](../deploying-contracts-on-base/SKILL.md). Configure `foundry.toml` to use the V2 endpoint instead of the deprecated per-chain basescan URLs:
+
+```toml
+[etherscan]
+base = { key = "${ETHERSCAN_API_KEY}", chain = 8453, url = "https://api.etherscan.io/v2/api?chainid=8453" }
+base-sepolia = { key = "${ETHERSCAN_API_KEY}", chain = 84532, url = "https://api.etherscan.io/v2/api?chainid=84532" }
+```
+
+### Linked libraries
+
+Verify the library first, then verify the contract with `--libraries`:
+
+```bash
+forge verify-contract \
+  --chain 8453 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+  --libraries src/lib/MyLib.sol:MyLib:<lib-deployed-address> \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+## Hardhat
+
+Install the plugin:
+
+```bash
+npm install --save-dev @nomicfoundation/hardhat-verify
+```
+
+Configure `hardhat.config.ts`. Use `apiKey` as a **single string** — not an object keyed by network, which is the deprecated V1 pattern that breaks with V2:
+
+```typescript
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-verify";
+
+const config: HardhatUserConfig = {
+  networks: {
+    base: {
+      url: "https://mainnet.base.org",
+      chainId: 8453,
+    },
+    baseSepolia: {
+      url: "https://sepolia.base.org",
+      chainId: 84532,
+    },
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY as string,
+    customChains: [
+      {
+        network: "base",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=8453",
+          browserURL: "https://basescan.org",
+        },
+      },
+      {
+        network: "baseSepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=84532",
+          browserURL: "https://sepolia.basescan.org",
+        },
+      },
+    ],
+  },
+};
+
+export default config;
+```
+
+Verify:
+
+```bash
+# No constructor args
+npx hardhat verify --network base <deployed-address>
+
+# With constructor args (pass values directly)
+npx hardhat verify --network base <deployed-address> "arg1" "arg2"
+
+# Sepolia
+npx hardhat verify --network baseSepolia <deployed-address>
+```
+
+## Manual UI Verification (basescan.org)
+
+Use when tooling is unavailable, the contract was deployed without `--verify`, or for a quick single-file contract.
+
+1. Open [basescan.org](https://basescan.org) (Mainnet) or [sepolia.basescan.org](https://sepolia.basescan.org) (Sepolia)
+2. Search the contract address → **Contract** tab → **Verify and Publish**
+3. Choose compiler type:
+   - **Solidity (Single file)**: flatten first with `forge flatten src/MyContract.sol > flat.sol`
+   - **Solidity (Standard JSON input)**: use the `input` field from the compilation artifact — most reliable for multi-file contracts and imports
+4. Match compiler version and optimizer settings exactly to the deployment
+5. Enter ABI-encoded constructor arguments if the contract constructor takes parameters
+
+## Sourcify (Decentralized Alternative)
+
+[Sourcify](https://sourcify.dev) verifies against IPFS-stored metadata with no centralized API key. Basescan displays a separate badge for Sourcify-verified contracts.
+
+```bash
+forge verify-contract \
+  --chain 8453 \
+  --verifier sourcify \
+  <deployed-address> \
+  src/MyContract.sol:MyContract
+```
+
+For Sepolia, replace `--chain 8453` with `--chain 84532`. No `--etherscan-api-key` required.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `deprecated V1 endpoint` | Using `api.basescan.org/api` | Add `--verifier-url "https://api.etherscan.io/v2/api?chainid=8453"` or update `foundry.toml` |
+| `Invalid API Key` | Wrong key or key from basescan.org only | Use an Etherscan key from etherscan.io |
+| `Missing or invalid chainid` | V2 endpoint called without `chainid` param | Include `?chainid=8453` or `?chainid=84532` in the verifier URL |
+| `Bytecode does not match` | Compiler version, optimizer runs, or EVM version differs from deployment | Re-verify with exact original settings; inspect `foundry.toml` or Hardhat config |
+| `Constructor arguments not matching` | Args absent or incorrectly encoded | Re-encode with `cast abi-encode "constructor(...)" ...` |
+| `Already Verified` | Contract is already verified | Not an error — check Basescan to confirm the source is visible |
+| Library not linked | Linked library not verified or wrong address | Verify the library first, then re-run with `--libraries` |
+| Proxy shows unverified implementation | Implementation contract not marked as proxy | Verify the implementation address, then use the "Is this a Proxy?" button on Basescan |
+
+## References
+
+- [Etherscan V2 Migration Guide](https://docs.etherscan.io/v2-migration)
+- [Etherscan V2 Supported Chains](https://docs.etherscan.io/etherscan-v2/getting-started/supported-chains)
+- [Foundry — forge verify-contract](https://book.getfoundry.sh/reference/forge/forge-verify-contract)
+- [Foundry — Deploying and Verifying](https://book.getfoundry.sh/forge/deploying)
+- [Hardhat Verify Plugin](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify)
+- [Base Docs — Block Explorers](https://docs.base.org/docs/tools/block-explorers)


### PR DESCRIPTION
Closes #36

## Summary

Adds `registering-an-erc-8004-agent-on-base` skill — a behavioral, phase-based registration flow for the ERC-8004 Identity Registry on Base Mainnet and Sepolia, following the same agent-behavioral pattern as `registering-agent-base-dev`.

## Motivation

AI coding agents consistently produce wrong information about ERC-8004: stale contract addresses, treating the three registries as one contract, confusing `agentId` (an ERC-721 tokenId) with wallet addresses. A skill with the canonical addresses and a "you MUST load this skill" signal in the description fixes this at the routing layer before a wrong call gets made.

[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) is co-authored by Erik Reppel (Coinbase), Marco De Rossi (MetaMask), Davide Crapis (EF), and Jordan Ellis (Google). The Identity Registry is live on Base Mainnet with **>256,000 agents registered**. Contracts verified on-chain (version 2.0.0, "AgentIdentity" ERC-721) before opening this PR.

`registering-agent-base-dev` covers ERC-8021 (builder-code attribution) — a completely different standard. Zero overlap.

## This was tested live on Base Sepolia before opening this PR

Full end-to-end flow executed against `0x8004A818BFB912233c491871b3d84c89A494BD9e`:

- `balanceOf` pre-flight check → `0` (no prior registration)
- `register()` with no URI → **agentId 6199** (from `Registered` event)
- Built registration file JSON with real agentId, encoded as `data:application/json;base64,...`
- `setAgentURI(6199, dataURI)` → confirmed on-chain
- `ownerOf(6199)`, `tokenURI(6199)` (decoded JSON), `getAgentWallet(6199)` — all read back correctly
- `balanceOf` post-registration → `1`

The EIP-712 typed data for `setAgentWallet` was verified against the contract source: `AgentWalletSet(uint256 agentId, address newWallet, address owner, uint256 deadline)` — the `owner` field is required and frequently missing from third-party documentation.

## Scope

- Pre-flight check before registering
- Agent registration file schema (per `ERC8004SPEC.md`)
- IPFS / HTTPS / data-URI hosting
- `register()` overloads in viem + `cast` one-liners for both networks
- `setAgentURI()` for post-mint URI updates
- `setAgentWallet()` with correct EIP-712 typed data (EOA + ERC-1271)
- Read paths: `ownerOf`, `tokenURI`, `getAgentWallet`
- Key facts and out-of-scope notice

## Out of scope

- Reputation Registry — reserved for a sibling skill
- Validation Registry — spec authors flag it as under active TEE community revision
- x402 payment integration

## Checklist

- [x] Scope approved in #36
- [x] Frontmatter and structure match existing skills; behavioral pattern follows `registering-agent-base-dev`
- [x] Description optimised for skill triggering with "MUST load" signal
- [x] Contract addresses verified on-chain and against `erc-8004/erc-8004-contracts` README
- [x] Registration file schema verified against `ERC8004SPEC.md`
- [x] EIP-712 type hash verified against contract source
- [x] Full registration flow tested live on Base Sepolia (agentId 6199)
- [x] README "Available Skills" table updated
- [x] Single skill, single commit, no overlap with existing skills