### PR TITLE
feat: add KyberSwap plugin for Base MCP

### DIFF
--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -61,6 +61,7 @@ Plugins currently maintained alongside this skill (the **native plugins**):
 | Morpho | [plugins/morpho.md](plugins/morpho.md) |
 | Moonwell | [plugins/moonwell.md](plugins/moonwell.md) |
 | Uniswap | [plugins/uniswap.md](plugins/uniswap.md) |
+| KyberSwap | [plugins/kyberswap.md](plugins/kyberswap.md) |
 | Avantis (hybrid) | [plugins/avantis.md](plugins/avantis.md) |
 | Virtuals | [plugins/virtuals.md](plugins/virtuals.md) |
 | Aerodrome (CLI-only) | [plugins/aerodrome.md](plugins/aerodrome.md) |

--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -61,7 +61,6 @@ Plugins currently maintained alongside this skill (the **native plugins**):
 | Morpho | [plugins/morpho.md](plugins/morpho.md) |
 | Moonwell | [plugins/moonwell.md](plugins/moonwell.md) |
 | Uniswap | [plugins/uniswap.md](plugins/uniswap.md) |
-| KyberSwap | [plugins/kyberswap.md](plugins/kyberswap.md) |
 | Avantis (hybrid) | [plugins/avantis.md](plugins/avantis.md) |
 | Virtuals | [plugins/virtuals.md](plugins/virtuals.md) |
 | Aerodrome (CLI-only) | [plugins/aerodrome.md](plugins/aerodrome.md) |

--- a/skills/base-mcp/plugins/kyberswap.md
+++ b/skills/base-mcp/plugins/kyberswap.md
@@ -231,7 +231,7 @@ Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=
 **Swap 0.1 ETH to USDC on Arbitrum**
 
 1. `get_wallets` → address
-2. `web_request GET /api/v1/routes` — tokenIn=`0xEeee...eEEE`, tokenOut=USDC on arbitrum=`0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8`, amountIn=`100000000000000000`, chain=`arbitrum`
+2. `web_request GET /api/v1/routes` — tokenIn=`0xEeee...eEEE`, tokenOut=USDC on arbitrum=`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`, amountIn=`100000000000000000`, chain=`arbitrum`
 3. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue=`0xde0b6b3a7640000` (non-zero, native input)
 4. No approval needed for native ETH
 5. `send_calls("arbitrum", [swap_call])` with value=transactionValue
@@ -242,12 +242,12 @@ Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=
 
 | Tolerance | Level | Action |
 |---|---|---|
-| ≤ 50 bps (0.5%) | Normal | Proceed. |
-| > 50 and ≤ 200 bps | Elevated | Mention the value and ask the user to confirm. |
-| > 200 and ≤ 500 bps | High | Warn that the trade can fill significantly below quote and is a likely sandwich target. Require explicit confirmation. |
-| > 500 bps | Very high | Strongly warn; do not submit without the user re-confirming the exact number. |
+| ≤ 1% (100 bps) | Normal | Proceed. |
+| > 1% and ≤ 5% | Elevated | Mention the value and ask the user to confirm. |
+| > 5% and ≤ 20% | High | Warn that the trade can fill significantly below quote and is a likely sandwich target. Require explicit confirmation. |
+| > 20% | Very high | Strongly warn; do not submit without the user re-confirming the exact number. |
 
-Default: use `50` bps for common pairs (ETH/USDC, WBTC/ETH), `100` bps for long-tail or volatile tokens. If the user did not specify a value, prefer `autoSlippage` behavior by omitting the param and letting the API use its default.
+If the user does not specify slippage, use `50` bps for common pairs (ETH/USDC, WBTC/ETH) and `100` bps for long-tail or volatile tokens. Always pass an explicit value — the API defaults to 0 bps if `slippageTolerance` is omitted, which will cause most trades to fail.
 
 ---
 

--- a/skills/base-mcp/plugins/kyberswap.md
+++ b/skills/base-mcp/plugins/kyberswap.md
@@ -1,54 +1,52 @@
 ---
 title: "KyberSwap Plugin"
-description: "Skill plugin for swapping tokens on KyberSwap through Base MCP — best-rate aggregation across 50+ DEXes on 7 chains."
+description: "DEX aggregation on KyberSwap via HTTP API → send_calls across 7 chains, best-rate routing through 50+ liquidity sources."
+tags: [dex, swap, liquidity]
+name: kyberswap
+version: 0.2.0
+integration: http-api
+chains: [base, ethereum, arbitrum, optimism, polygon, bsc, avalanche]
+requires:
+  shell: none
+  allowlist: [aggregator-api.kyberswap.com, token-api.kyberswap.com]
+  externalMcp: null
+  cliPackage: null
+auth: none
+risk: [slippage]
 ---
 
 # KyberSwap Plugin
 
 > [!IMPORTANT]
-> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any KyberSwap endpoint. The user's wallet address — passed as `sender` in every swap call — is fetched lazily when needed.
+> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any KyberSwap endpoint. The user's wallet address is fetched lazily when needed.
 
-KyberSwap is a DEX aggregator that routes trades across 50+ liquidity sources (Uniswap V2/V3/V4, Curve, Balancer, and others) to find the best execution price. Use it when the user wants the best rate across all available liquidity — not just a single protocol's pools.
+## Overview
 
-No additional MCP server is required.
+KyberSwap is a DEX aggregator that routes trades across 50+ liquidity sources (Uniswap V2/V3/V4, Curve, Balancer, and others) to find the best execution price across 7 chains. The plugin calls the KyberSwap Aggregator HTTP API to fetch a route quote and build unsigned calldata, then submits the result to Base MCP's `send_calls`. Use KyberSwap when the user wants the best rate across all available liquidity — not just a single protocol's pools.
 
-**Prerequisite:** `aggregator-api.kyberswap.com` and `token-api.kyberswap.com` must be in the MCP server's `web_request` allowlist. If requests are rejected by the allowlist, inform the user.
+## Surface Routing
 
-**Router address (same on all supported chains):** `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
+| Capability | Harness surface (Claude Code, Cursor) | Chat-only surface (Claude.ai, ChatGPT) |
+|---|---|---|
+| GET /routes (quote) | Harness HTTP tool — no allowlist needed | `web_request` — requires `aggregator-api.kyberswap.com` allowlisted |
+| POST /route/build (calldata) | Harness HTTP tool — no allowlist needed | `web_request` — requires `aggregator-api.kyberswap.com` allowlisted |
+| Token resolution | Harness HTTP tool — no allowlist needed | `web_request` — requires `token-api.kyberswap.com` allowlisted |
+| Submit swap | `send_calls` — all surfaces | `send_calls` — all surfaces |
 
----
+On chat-only surfaces where the allowlist is not configured: inform the user that the swap cannot proceed and direct them to the KyberSwap web UI at `kyberswap.com`. Do **not** improvise a workaround. For the full decision tree, see [references/custom-plugins.md](references/custom-plugins.md).
 
-## Orchestration Pattern
-
-```
-web_request GET /api/v1/routes
-  → { data: { routeSummary, routerAddress, amountOut, amountOutUsd, gasUsd } }
-      ↓
-web_request POST /api/v1/route/build
-  → { data: { encodedSwapData, transactionValue, routerAddress } }
-      ↓
-send_calls(chain, [approval_call?, swap_call])
-  → approvalUrl + requestId
-      ↓
-User approves at the returned approval URL
-      ↓
-get_request_status(requestId) → confirmed
-```
-
-Include an ERC-20 approval call before the swap whenever `tokenIn` is not a native token. Batch both calls together so the user approves once.
-
----
-
-## Swap Flow
+## Endpoints
 
 Base URL: `https://aggregator-api.kyberswap.com/{chain}`
 
 Chain slugs: `base` · `ethereum` · `arbitrum` · `optimism` · `polygon` · `bsc` · `avalanche`
 
-### 1. `GET /api/v1/routes`
+### GET /api/v1/routes
+
+Fetches the best route and returns a `routeSummary` required verbatim in the build step.
 
 ```
-https://aggregator-api.kyberswap.com/{chain}/api/v1/routes
+GET https://aggregator-api.kyberswap.com/{chain}/api/v1/routes
   ?tokenIn={address}
   &tokenOut={address}
   &amountIn={amountInWei}
@@ -59,11 +57,11 @@ https://aggregator-api.kyberswap.com/{chain}/api/v1/routes
 
 | Param | Required | Notes |
 |---|---|---|
-| `tokenIn` | ✅ | Token address. Use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` for native (ETH, BNB, MATIC, etc.) |
+| `tokenIn` | ✅ | Token address. Native token: `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` |
 | `tokenOut` | ✅ | Token address |
-| `amountIn` | ✅ | Amount in base units — plain integer string, no decimals, no scientific notation. Multiply the human amount by `10^decimals`: 1 ETH = `1000000000000000000`, 100 USDC = `100000000` |
+| `amountIn` | ✅ | Amount in base units — plain integer string. 1 ETH = `1000000000000000000`, 100 USDC = `100000000` |
 | `to` | recommended | Recipient wallet address |
-| `slippageTolerance` | recommended | Basis points (50 = 0.5%). See [Slippage Warnings](#slippage-warnings) |
+| `slippageTolerance` | recommended | Basis points (50 = 0.5%). See [Risks & Warnings](#risks--warnings) |
 | `source` | recommended | Pass `base-mcp` for attribution |
 
 Response shape:
@@ -71,7 +69,7 @@ Response shape:
 ```json
 {
   "data": {
-    "routeSummary": { "...": "keep this object verbatim for the build step" },
+    "routeSummary": { "...": "pass verbatim to build step" },
     "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
     "amountIn": "100000000",
     "amountInUsd": "100.00",
@@ -83,11 +81,11 @@ Response shape:
 }
 ```
 
-Keep the **complete `routeSummary` object** exactly as returned — it is required verbatim in the build step body.
+Keep the complete `routeSummary` object exactly as returned — it is required verbatim in the build step.
 
-### 2. `POST /api/v1/route/build`
+### POST /api/v1/route/build
 
-Use `web_request` with `method: POST`:
+Builds encoded swap calldata from a previously fetched route.
 
 ```json
 {
@@ -122,138 +120,155 @@ Response shape:
 }
 ```
 
-`transactionValue` is a hex wei string — pass it directly as `value` in the swap call. It is non-zero only for native token input (e.g. `"0xde0b6b3a7640000"` for 1 ETH).
+`transactionValue` is a hex wei string — pass directly as `value` in the swap call. Non-zero only for native token input (e.g. `"0xde0b6b3a7640000"` for 1 ETH).
 
-### 3. ERC-20 Approval
+### GET /api/v1/public/tokens (token resolution)
 
-For ERC-20 `tokenIn`, always include a standard `approve` call before the swap. Skip this step only for native tokens (ETH, BNB, MATIC, AVAX, etc.).
-
-Function: `approve(address spender, uint256 amount)`
-- `spender`: `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
-- `amount`: `amountIn` value from the GET routes response (exact amount, in base units)
-
-Calldata encoding:
-```
-selector:  0x095ea7b3
-spender:   000000000000000000000000 + {router without 0x}
-amount:    {amountIn as 32-byte hex, left-padded with zeros}
-
-Example (approve 100 USDC = 100000000):
-0x095ea7b3
-  0000000000000000000000006131b5fae19ea4f9d964eac0408e4408b66337b5
-  0000000000000000000000000000000000000000000000000000000005f5e100
-```
-
-Approval call shape:
-```json
-{ "to": "<tokenIn address>", "value": "0x0", "data": "<approve calldata>" }
-```
-
-**USDT on Ethereum mainnet**: if the existing allowance is non-zero, the approve call will revert. Send a zero-approval first (`amount = 0x0...0`), then send the real approval.
-
-### 4. `send_calls`
-
-For ERC-20 `tokenIn` — batch approval + swap:
-
-```json
-{
-  "chain": "base",
-  "calls": [
-    { "to": "<tokenIn address>", "value": "0x0", "data": "<approve calldata>" },
-    { "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5", "value": "<transactionValue>", "data": "<encodedSwapData>" }
-  ]
-}
-```
-
-For native `tokenIn` — swap only:
-
-```json
-{
-  "chain": "base",
-  "calls": [
-    { "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5", "value": "<transactionValue>", "data": "<encodedSwapData>" }
-  ]
-}
-```
-
-Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`) — not numeric chainIds.
-
-### Swap Orchestration
+Resolve a token symbol to its contract address when not in the known-addresses table in `## Notes`.
 
 ```
-1. get_wallets → walletAddress
-2. web_request GET /api/v1/routes → routeSummary, amountOut, gasUsd
-3. web_request POST /api/v1/route/build → encodedSwapData, transactionValue
-4. Build calls array:
-     native tokenIn  → [swap_call]
-     ERC-20 tokenIn  → [approval_call, swap_call]
-5. send_calls(chain, calls)
-6. Open approvalUrl if requested; do not approve unless the user explicitly asks
-7. get_request_status only after the user acts
-```
-
----
-
-## Token Resolution
-
-For common tokens on Base:
-
-| Token | Address |
-|---|---|
-| ETH (native) | `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` |
-| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
-| WETH | `0x4200000000000000000000000000000000000006` |
-| DAI | `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb` |
-| cbBTC | `0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf` |
-
-For unknown tokens, resolve via the KyberSwap token API:
-
-```
-web_request: https://token-api.kyberswap.com/api/v1/public/tokens?chainIds={chainId}&name={symbol}&isWhitelisted=true
+GET https://token-api.kyberswap.com/api/v1/public/tokens
+  ?chainIds={chainId}
+  &name={symbol}
+  &isWhitelisted=true
 ```
 
 Pick the result with exact `symbol` match and highest `marketCap`. If no whitelisted match, retry without `isWhitelisted`.
 
 Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=56, avalanche=43114
 
----
+## Orchestration
+
+### Swap
+
+1. `get_wallets` → `walletAddress`.
+2. Resolve token symbols to addresses — use the `## Notes` table first, then the token-api endpoint.
+3. Compute `amountIn` in base units: multiply human amount by `10^decimals` (ETH=18, USDC=6, WBTC=8).
+4. Determine slippage: default `50` bps for common pairs, `100` bps for long-tail tokens. Apply thresholds in `## Risks & Warnings` before proceeding.
+5. `GET /api/v1/routes` → `routeSummary`, `amountOut`, `amountOutUsd`, `gasUsd`. Show the quoted output and gas cost to the user; confirm before proceeding.
+6. `POST /api/v1/route/build` → `encodedSwapData`, `transactionValue`, `routerAddress`.
+7. Build calls array:
+   - **Native tokenIn** → `[swap_call]`
+   - **ERC-20 tokenIn** → `[approval_call, swap_call]` — always include approval, no allowance check needed.
+   - **USDT on Ethereum** — if existing allowance is non-zero, prepend a zero-approval call before the real approval.
+8. `send_calls(chain, calls)` → `approvalUrl`, `requestId`.
+9. Present `approvalUrl` to the user. Do not auto-approve. Call `get_request_status(requestId)` only after the user acts.
+
+## Submission
+
+Target tool: **`send_calls`**
+
+Map POST /route/build output into `send_calls` as follows:
+
+**ERC-20 tokenIn — approval + swap batch:**
+
+```json
+{
+  "chain": "<chain string>",
+  "calls": [
+    {
+      "to": "<tokenIn address>",
+      "value": "0x0",
+      "data": "<ERC-20 approve calldata>"
+    },
+    {
+      "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
+      "value": "<transactionValue>",
+      "data": "<encodedSwapData>"
+    }
+  ]
+}
+```
+
+**Native tokenIn — swap only:**
+
+```json
+{
+  "chain": "<chain string>",
+  "calls": [
+    {
+      "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
+      "value": "<transactionValue>",
+      "data": "<encodedSwapData>"
+    }
+  ]
+}
+```
+
+**ERC-20 approval calldata encoding:**
+
+```
+Function: approve(address spender, uint256 amount)
+Selector: 0x095ea7b3
+spender:  000000000000000000000000{router without 0x}
+amount:   {amountIn as 32-byte hex, left-padded with zeros}
+
+Example — approve 100 USDC (amountIn = 100000000 = 0x5F5E100):
+0x095ea7b3
+  0000000000000000000000006131b5fae19ea4f9d964eac0408e4408b66337b5
+  0000000000000000000000000000000000000000000000000000000005f5e100
+```
+
+Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`) — not numeric chain IDs. After `send_calls` returns an approval URL, follow the flow in [references/approval-mode.md](references/approval-mode.md).
 
 ## Example Prompts
 
-**Swap 100 USDC to ETH on Base**
+**"Swap 100 USDC to ETH on Base"**
 
-1. `get_wallets` → address
-2. `web_request GET /api/v1/routes` — tokenIn=`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (USDC, 6 dec), tokenOut=`0xEeee...eEEE`, amountIn=`100000000`, chain=`base`
-3. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue=`0x0`
-4. Build approval calldata: approve router to spend `100000000` USDC
-5. `send_calls("base", [approval_call, swap_call])`
+1. `get_wallets` → address.
+2. `GET /api/v1/routes` on `base` — tokenIn=`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (USDC, 6 dec), tokenOut=`0xEeee...eEEE`, amountIn=`100000000`.
+3. Show quoted output and gas to user; confirm.
+4. `POST /api/v1/route/build` → encodedSwapData, transactionValue=`0x0`.
+5. Encode approve calldata: router spends `100000000` USDC.
+6. `send_calls("base", [approval_call, swap_call])`.
 
-**Swap 0.1 ETH to USDC on Arbitrum**
+**"Swap 0.1 ETH to USDC on Arbitrum"**
 
-1. `get_wallets` → address
-2. `web_request GET /api/v1/routes` — tokenIn=`0xEeee...eEEE`, tokenOut=USDC on arbitrum=`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`, amountIn=`100000000000000000`, chain=`arbitrum`
-3. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue=`0xde0b6b3a7640000` (non-zero, native input)
-4. No approval needed for native ETH
-5. `send_calls("arbitrum", [swap_call])` with value=transactionValue
+1. `get_wallets` → address.
+2. `GET /api/v1/routes` on `arbitrum` — tokenIn=`0xEeee...eEEE`, tokenOut=`0xaf88d065e77c8cC2239327C5EDb3A432268e5831` (USDC), amountIn=`100000000000000000`.
+3. Show quoted output and gas to user; confirm.
+4. `POST /api/v1/route/build` → encodedSwapData, transactionValue=`0xde0b6b3a7640000` (non-zero, native input).
+5. No approval needed — native ETH.
+6. `send_calls("arbitrum", [swap_call])` with value=transactionValue.
 
----
+**"What's the best rate to swap 500 MATIC to USDC on Polygon?"** *(read-only)*
 
-## Slippage Warnings
+1. `get_wallets` → address.
+2. `GET /api/v1/routes` on `polygon` — tokenIn=`0xEeee...eEEE`, tokenOut=`0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` (USDC), amountIn=`500000000000000000000`.
+3. Return `amountOutUsd` and `gasUsd` to the user — no transaction submitted.
 
-| Tolerance | Level | Action |
-|---|---|---|
-| ≤ 1% (100 bps) | Normal | Proceed. |
-| > 1% and ≤ 5% | Elevated | Mention the value and ask the user to confirm. |
-| > 5% and ≤ 20% | High | Warn that the trade can fill significantly below quote and is a likely sandwich target. Require explicit confirmation. |
-| > 20% | Very high | Strongly warn; do not submit without the user re-confirming the exact number. |
+## Risks & Warnings
 
-If the user does not specify slippage, use `50` bps for common pairs (ETH/USDC, WBTC/ETH) and `100` bps for long-tail or volatile tokens. Always pass an explicit value — the API defaults to 0 bps if `slippageTolerance` is omitted, which will cause most trades to fail.
+- **Slippage** — Swaps can fill materially worse than the quoted price if market conditions shift between quote and execution. Apply the following thresholds:
 
----
+  | Tolerance | Level | Action |
+  |---|---|---|
+  | ≤ 100 bps (1%) | Normal | Proceed. |
+  | > 100 and ≤ 500 bps (5%) | Elevated | Mention the value and ask the user to confirm. |
+  | > 500 and ≤ 2000 bps (20%) | High | Warn that the trade can fill significantly below quote and is a likely sandwich target. Require explicit confirmation. |
+  | > 2000 bps | Very high | Strongly warn; do not submit without the user re-confirming the exact number. |
+
+  If the user does not specify slippage, default to `50` bps for common pairs (ETH/USDC, WBTC/ETH) and `100` bps for long-tail or volatile tokens. Always pass an explicit value — the API defaults to 0 bps if `slippageTolerance` is omitted, causing most trades to fail.
 
 ## Notes
 
-- Native token sentinel (ETH/BNB/MATIC/AVAX/etc.): `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
-- Router address is the same on all chains: `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
-- KyberSwap splits trades across multiple pools when beneficial — `routeSummary` may describe a multi-hop or split route. Pass it as-is; do not modify it.
-- USDC on Base: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` · WETH on Base: `0x4200000000000000000000000000000000000006`
+**Router address (same on all supported chains):** `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
+
+**Native token sentinel (ETH/BNB/MATIC/AVAX/etc.):** `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+
+**Common token addresses:**
+
+| Token | Chain | Address |
+|---|---|---|
+| USDC | Base | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| USDC | Arbitrum | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
+| USDC | Ethereum | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| USDC | Optimism | `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85` |
+| USDC | Polygon | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
+| WETH | Base | `0x4200000000000000000000000000000000000006` |
+| DAI | Base | `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb` |
+| cbBTC | Base | `0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf` |
+
+KyberSwap splits trades across multiple pools when beneficial — `routeSummary` may describe a multi-hop or split route. Pass it as-is; do not modify it.
+
+USDT on Ethereum: if existing allowance is non-zero, the approve call will revert — send a zero-approval first (`amount = 0x0...0`), then the real approval.

--- a/skills/base-mcp/plugins/kyberswap.md
+++ b/skills/base-mcp/plugins/kyberswap.md
@@ -33,7 +33,7 @@ KyberSwap is a DEX aggregator that routes trades across 50+ liquidity sources (U
 | Token resolution | Harness HTTP tool — no allowlist needed | `web_request` — requires `token-api.kyberswap.com` allowlisted |
 | Submit swap | `send_calls` — all surfaces | `send_calls` — all surfaces |
 
-On chat-only surfaces where the allowlist is not configured: inform the user that the swap cannot proceed and direct them to the KyberSwap web UI at `kyberswap.com`. Do **not** improvise a workaround. For the full decision tree, see [references/custom-plugins.md](references/custom-plugins.md).
+On chat-only surfaces where the allowlist is not configured: inform the user that the swap cannot proceed and direct them to the KyberSwap web UI at `kyberswap.com`. Do **not** improvise a workaround. For the full decision tree, see [../references/custom-plugins.md](../references/custom-plugins.md).
 
 ## Endpoints
 
@@ -69,14 +69,16 @@ Response shape:
 ```json
 {
   "data": {
-    "routeSummary": { "...": "pass verbatim to build step" },
-    "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
-    "amountIn": "100000000",
-    "amountInUsd": "100.00",
-    "amountOut": "38650000000000000",
-    "amountOutUsd": "99.71",
-    "gas": "300000",
-    "gasUsd": "0.29"
+    "routeSummary": {
+      "amountIn": "100000000",
+      "amountInUsd": "100.00",
+      "amountOut": "38650000000000000",
+      "amountOutUsd": "99.71",
+      "gas": "300000",
+      "gasUsd": "0.29",
+      "...": "other fields — pass verbatim to build step"
+    },
+    "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5"
   }
 }
 ```
@@ -113,14 +115,14 @@ Response shape:
     "amountIn": "100000000",
     "amountOut": "38650000000000000",
     "gas": "300000",
-    "transactionValue": "0x0",
+    "transactionValue": "0",
     "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
-    "encodedSwapData": "0x..."
+    "data": "0x..."
   }
 }
 ```
 
-`transactionValue` is a hex wei string — pass directly as `value` in the swap call. Non-zero only for native token input (e.g. `"0xde0b6b3a7640000"` for 1 ETH).
+`transactionValue` is a **decimal** wei string (e.g. `"0"` for ERC-20 input, `"10000000000000000"` for 0.01 ETH). Hex-encode it before passing as `value` in `send_calls`: `"0x" + BigInt(transactionValue).toString(16)`. Non-zero only for native token input.
 
 ### GET /api/v1/public/tokens (token resolution)
 
@@ -146,7 +148,7 @@ Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=
 3. Compute `amountIn` in base units: multiply human amount by `10^decimals` (ETH=18, USDC=6, WBTC=8).
 4. Determine slippage: default `50` bps for common pairs, `100` bps for long-tail tokens. Apply thresholds in `## Risks & Warnings` before proceeding.
 5. `GET /api/v1/routes` → `routeSummary`, `amountOut`, `amountOutUsd`, `gasUsd`. Show the quoted output and gas cost to the user; confirm before proceeding.
-6. `POST /api/v1/route/build` → `encodedSwapData`, `transactionValue`, `routerAddress`.
+6. `POST /api/v1/route/build` → `data` (swap calldata), `transactionValue`, `routerAddress`. Verify `routerAddress` equals `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5` — abort and warn the user if it differs.
 7. Build calls array:
    - **Native tokenIn** → `[swap_call]`
    - **ERC-20 tokenIn** → `[approval_call, swap_call]` — always include approval, no allowance check needed.
@@ -173,8 +175,8 @@ Map POST /route/build output into `send_calls` as follows:
     },
     {
       "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
-      "value": "<transactionValue>",
-      "data": "<encodedSwapData>"
+      "value": "<hex(transactionValue)>",
+      "data": "<data from /route/build response>"
     }
   ]
 }
@@ -188,12 +190,14 @@ Map POST /route/build output into `send_calls` as follows:
   "calls": [
     {
       "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
-      "value": "<transactionValue>",
-      "data": "<encodedSwapData>"
+      "value": "<hex(transactionValue)>",
+      "data": "<data from /route/build response>"
     }
   ]
 }
 ```
+
+`hex(transactionValue)`: `"0x" + BigInt(transactionValue).toString(16)` — `transactionValue` is a decimal wei string from the API.
 
 **ERC-20 approval calldata encoding:**
 
@@ -209,7 +213,7 @@ Example — approve 100 USDC (amountIn = 100000000 = 0x5F5E100):
   0000000000000000000000000000000000000000000000000000000005f5e100
 ```
 
-Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`) — not numeric chain IDs. After `send_calls` returns an approval URL, follow the flow in [references/approval-mode.md](references/approval-mode.md).
+Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`) — not numeric chain IDs. After `send_calls` returns an approval URL, follow the flow in [../references/approval-mode.md](../references/approval-mode.md).
 
 ## Example Prompts
 
@@ -218,7 +222,7 @@ Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `
 1. `get_wallets` → address.
 2. `GET /api/v1/routes` on `base` — tokenIn=`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (USDC, 6 dec), tokenOut=`0xEeee...eEEE`, amountIn=`100000000`.
 3. Show quoted output and gas to user; confirm.
-4. `POST /api/v1/route/build` → encodedSwapData, transactionValue=`0x0`.
+4. `POST /api/v1/route/build` → `data` (swap calldata), `transactionValue`=`"0"` → hex-encode to `"0x0"`.
 5. Encode approve calldata: router spends `100000000` USDC.
 6. `send_calls("base", [approval_call, swap_call])`.
 
@@ -227,7 +231,7 @@ Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `
 1. `get_wallets` → address.
 2. `GET /api/v1/routes` on `arbitrum` — tokenIn=`0xEeee...eEEE`, tokenOut=`0xaf88d065e77c8cC2239327C5EDb3A432268e5831` (USDC), amountIn=`100000000000000000`.
 3. Show quoted output and gas to user; confirm.
-4. `POST /api/v1/route/build` → encodedSwapData, transactionValue=`0xde0b6b3a7640000` (non-zero, native input).
+4. `POST /api/v1/route/build` → `data` (swap calldata), `transactionValue`=`"10000000000000000"` → hex-encode to `"0xde0b6b3a7640000"` (non-zero, native input).
 5. No approval needed — native ETH.
 6. `send_calls("arbitrum", [swap_call])` with value=transactionValue.
 

--- a/skills/base-mcp/plugins/kyberswap.md
+++ b/skills/base-mcp/plugins/kyberswap.md
@@ -18,16 +18,32 @@ No additional MCP server is required.
 
 ---
 
+## Orchestration Pattern
+
+```
+web_request GET /api/v1/routes
+  → { data: { routeSummary, routerAddress, amountOut, amountOutUsd, gasUsd } }
+      ↓
+web_request POST /api/v1/route/build
+  → { data: { encodedSwapData, transactionValue, routerAddress } }
+      ↓
+send_calls(chain, [approval_call?, swap_call])
+  → approvalUrl + requestId
+      ↓
+User approves at the returned approval URL
+      ↓
+get_request_status(requestId) → confirmed
+```
+
+Include an ERC-20 approval call before the swap whenever `tokenIn` is not a native token. Batch both calls together so the user approves once.
+
+---
+
 ## Swap Flow
 
 Base URL: `https://aggregator-api.kyberswap.com/{chain}`
 
 Chain slugs: `base` · `ethereum` · `arbitrum` · `optimism` · `polygon` · `bsc` · `avalanche`
-
-```
-GET  /api/v1/routes       →  best route + quote (read-only)
-POST /api/v1/route/build  →  unsigned swap transaction calldata
-```
 
 ### 1. `GET /api/v1/routes`
 
@@ -45,7 +61,7 @@ https://aggregator-api.kyberswap.com/{chain}/api/v1/routes
 |---|---|---|
 | `tokenIn` | ✅ | Token address. Use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` for native (ETH, BNB, MATIC, etc.) |
 | `tokenOut` | ✅ | Token address |
-| `amountIn` | ✅ | Integer string in base units — no decimals, no scientific notation |
+| `amountIn` | ✅ | Amount in base units — plain integer string, no decimals, no scientific notation. Multiply the human amount by `10^decimals`: 1 ETH = `1000000000000000000`, 100 USDC = `100000000` |
 | `to` | recommended | Recipient wallet address |
 | `slippageTolerance` | recommended | Basis points (50 = 0.5%). See [Slippage Warnings](#slippage-warnings) |
 | `source` | recommended | Pass `base-mcp` for attribution |
@@ -55,49 +71,50 @@ Response shape:
 ```json
 {
   "data": {
-    "routeSummary": { ... },
+    "routeSummary": { "...": "keep this object verbatim for the build step" },
     "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
-    "amountIn": "...",
-    "amountInUsd": "...",
-    "amountOut": "...",
-    "amountOutUsd": "...",
-    "gas": "...",
-    "gasUsd": "..."
+    "amountIn": "100000000",
+    "amountInUsd": "100.00",
+    "amountOut": "38650000000000000",
+    "amountOutUsd": "99.71",
+    "gas": "300000",
+    "gasUsd": "0.29"
   }
 }
 ```
 
-Keep the **complete `routeSummary` object** — it is required verbatim for the build step.
+Keep the **complete `routeSummary` object** exactly as returned — it is required verbatim in the build step body.
 
 ### 2. `POST /api/v1/route/build`
 
-```
-https://aggregator-api.kyberswap.com/{chain}/api/v1/route/build
-```
-
-Request body:
+Use `web_request` with `method: POST`:
 
 ```json
 {
-  "routeSummary": { ... },
-  "sender": "<walletAddress>",
-  "recipient": "<walletAddress>",
-  "slippageTolerance": 50,
-  "deadline": "<unix_timestamp + 1200>",
-  "source": "base-mcp"
+  "url": "https://aggregator-api.kyberswap.com/{chain}/api/v1/route/build",
+  "method": "POST",
+  "headers": { "content-type": "application/json", "x-client-id": "base-mcp" },
+  "body": {
+    "routeSummary": { "...": "complete object from GET response" },
+    "sender": "<walletAddress>",
+    "recipient": "<walletAddress>",
+    "slippageTolerance": 50,
+    "deadline": "<current unix timestamp + 1200>",
+    "source": "base-mcp"
+  }
 }
 ```
 
-Pass `routeSummary` exactly as returned from the GET step — do not modify or truncate it.
+Do not modify or truncate `routeSummary`. Routes expire in ~30 seconds — if this step fails with "return amount is not enough", re-fetch the route and retry.
 
 Response shape:
 
 ```json
 {
   "data": {
-    "amountIn": "...",
-    "amountOut": "...",
-    "gas": "...",
+    "amountIn": "100000000",
+    "amountOut": "38650000000000000",
+    "gas": "300000",
     "transactionValue": "0x0",
     "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
     "encodedSwapData": "0x..."
@@ -105,40 +122,50 @@ Response shape:
 }
 ```
 
-### 3. ERC-20 Approval Check
+`transactionValue` is a hex wei string — pass it directly as `value` in the swap call. It is non-zero only for native token input (e.g. `"0xde0b6b3a7640000"` for 1 ETH).
 
-Before calling send_calls, check whether the router has enough allowance for `tokenIn`:
+### 3. ERC-20 Approval
 
-- **Native tokens** (ETH, BNB, MATIC, AVAX, etc.): no approval needed — proceed directly to send_calls.
-- **ERC-20 tokens**: if current allowance < `amountIn`, include a standard ERC-20 approve call in the batch.
+For ERC-20 `tokenIn`, always include a standard `approve` call before the swap. Skip this step only for native tokens (ETH, BNB, MATIC, AVAX, etc.).
 
-Approval call:
+Function: `approve(address spender, uint256 amount)`
+- `spender`: `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
+- `amount`: `amountIn` value from the GET routes response (exact amount, in base units)
 
-```json
-{
-  "to": "<tokenIn contract address>",
-  "value": "0x0",
-  "data": "<approve(address,uint256) selector + ABI-encoded (router, amountInWei)>"
-}
+Calldata encoding:
+```
+selector:  0x095ea7b3
+spender:   000000000000000000000000 + {router without 0x}
+amount:    {amountIn as 32-byte hex, left-padded with zeros}
+
+Example (approve 100 USDC = 100000000):
+0x095ea7b3
+  0000000000000000000000006131b5fae19ea4f9d964eac0408e4408b66337b5
+  0000000000000000000000000000000000000000000000000000000005f5e100
 ```
 
-`approve` selector: `0x095ea7b3`
+Approval call shape:
+```json
+{ "to": "<tokenIn address>", "value": "0x0", "data": "<approve calldata>" }
+```
+
+**USDT on Ethereum mainnet**: if the existing allowance is non-zero, the approve call will revert. Send a zero-approval first (`amount = 0x0...0`), then send the real approval.
 
 ### 4. `send_calls`
 
-Batch approval (if needed) and swap into a single user approval:
+For ERC-20 `tokenIn` — batch approval + swap:
 
 ```json
 {
   "chain": "base",
   "calls": [
-    { "to": "<tokenIn address>", "value": "0x0", "data": "<approval calldata>" },
+    { "to": "<tokenIn address>", "value": "0x0", "data": "<approve calldata>" },
     { "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5", "value": "<transactionValue>", "data": "<encodedSwapData>" }
   ]
 }
 ```
 
-For native token input (no approval):
+For native `tokenIn` — swap only:
 
 ```json
 {
@@ -156,12 +183,11 @@ Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `
 ```
 1. get_wallets → walletAddress
 2. web_request GET /api/v1/routes → routeSummary, amountOut, gasUsd
-3. Check approval:
-     native token? → skip
-     ERC-20 allowance ≥ amountIn? → skip
-     otherwise → prepare approval calldata
-4. web_request POST /api/v1/route/build → encodedSwapData, transactionValue
-5. send_calls(chain, [approval_call?, swap_call])
+3. web_request POST /api/v1/route/build → encodedSwapData, transactionValue
+4. Build calls array:
+     native tokenIn  → [swap_call]
+     ERC-20 tokenIn  → [approval_call, swap_call]
+5. send_calls(chain, calls)
 6. Open approvalUrl if requested; do not approve unless the user explicitly asks
 7. get_request_status only after the user acts
 ```
@@ -180,13 +206,13 @@ For common tokens on Base:
 | DAI | `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb` |
 | cbBTC | `0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf` |
 
-For unknown tokens, resolve via the KyberSwap token API (GET):
+For unknown tokens, resolve via the KyberSwap token API:
 
 ```
 web_request: https://token-api.kyberswap.com/api/v1/public/tokens?chainIds={chainId}&name={symbol}&isWhitelisted=true
 ```
 
-Pick the result with exact `symbol` match and highest `marketCap`.
+Pick the result with exact `symbol` match and highest `marketCap`. If no whitelisted match, retry without `isWhitelisted`.
 
 Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=56, avalanche=43114
 
@@ -197,18 +223,18 @@ Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=
 **Swap 100 USDC to ETH on Base**
 
 1. `get_wallets` → address
-2. `web_request GET /api/v1/routes` tokenIn=`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, tokenOut=`0xEeee...eEEE`, amountIn=`100000000`, chain=`base`
-3. USDC is ERC-20: prepare approval calldata for router
-4. `web_request POST /api/v1/route/build` → encodedSwapData
-5. `send_calls` batching approval + swap
+2. `web_request GET /api/v1/routes` — tokenIn=`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (USDC, 6 dec), tokenOut=`0xEeee...eEEE`, amountIn=`100000000`, chain=`base`
+3. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue=`0x0`
+4. Build approval calldata: approve router to spend `100000000` USDC
+5. `send_calls("base", [approval_call, swap_call])`
 
 **Swap 0.1 ETH to USDC on Arbitrum**
 
 1. `get_wallets` → address
-2. `web_request GET /api/v1/routes` tokenIn=`0xEeee...eEEE`, tokenOut=USDC on arbitrum, amountIn=`100000000000000000`, chain=`arbitrum`
-3. Native token: no approval needed
-4. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue (non-zero hex)
-5. `send_calls` with value=transactionValue
+2. `web_request GET /api/v1/routes` — tokenIn=`0xEeee...eEEE`, tokenOut=USDC on arbitrum=`0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8`, amountIn=`100000000000000000`, chain=`arbitrum`
+3. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue=`0xde0b6b3a7640000` (non-zero, native input)
+4. No approval needed for native ETH
+5. `send_calls("arbitrum", [swap_call])` with value=transactionValue
 
 ---
 
@@ -221,9 +247,7 @@ Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=
 | > 200 and ≤ 500 bps | High | Warn that the trade can fill significantly below quote and is a likely sandwich target. Require explicit confirmation. |
 | > 500 bps | Very high | Strongly warn; do not submit without the user re-confirming the exact number. |
 
-If the user does not specify slippage: use `50` bps for common pairs (ETH/USDC, WBTC/ETH), `100` bps for long-tail or volatile tokens.
-
-If the build step returns error code `4227` with "return amount is not enough", the price moved since the route was fetched — re-fetch the route and retry before adjusting slippage.
+Default: use `50` bps for common pairs (ETH/USDC, WBTC/ETH), `100` bps for long-tail or volatile tokens. If the user did not specify a value, prefer `autoSlippage` behavior by omitting the param and letting the API use its default.
 
 ---
 
@@ -231,7 +255,5 @@ If the build step returns error code `4227` with "return amount is not enough", 
 
 - Native token sentinel (ETH/BNB/MATIC/AVAX/etc.): `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
 - Router address is the same on all chains: `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
-- `transactionValue` from the build response is a hex wei string — pass it directly as `value` in send_calls. It is non-zero only for native token input.
-- Routes expire in ~30 seconds. If the build step fails with "return amount not enough", re-fetch the route and retry.
-- USDT on Ethereum mainnet requires setting allowance to 0 before a new non-zero approval. If approval fails, suggest revoking first.
-- KyberSwap splits trades across multiple DEX pools when beneficial — the `routeSummary` may describe a multi-hop or split route. Pass it as-is to the build endpoint.
+- KyberSwap splits trades across multiple pools when beneficial — `routeSummary` may describe a multi-hop or split route. Pass it as-is; do not modify it.
+- USDC on Base: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` · WETH on Base: `0x4200000000000000000000000000000000000006`

--- a/skills/base-mcp/plugins/kyberswap.md
+++ b/skills/base-mcp/plugins/kyberswap.md
@@ -1,0 +1,237 @@
+---
+title: "KyberSwap Plugin"
+description: "Skill plugin for swapping tokens on KyberSwap through Base MCP — best-rate aggregation across 50+ DEXes on 7 chains."
+---
+
+# KyberSwap Plugin
+
+> [!IMPORTANT]
+> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any KyberSwap endpoint. The user's wallet address — passed as `sender` in every swap call — is fetched lazily when needed.
+
+KyberSwap is a DEX aggregator that routes trades across 50+ liquidity sources (Uniswap V2/V3/V4, Curve, Balancer, and others) to find the best execution price. Use it when the user wants the best rate across all available liquidity — not just a single protocol's pools.
+
+No additional MCP server is required.
+
+**Prerequisite:** `aggregator-api.kyberswap.com` and `token-api.kyberswap.com` must be in the MCP server's `web_request` allowlist. If requests are rejected by the allowlist, inform the user.
+
+**Router address (same on all supported chains):** `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
+
+---
+
+## Swap Flow
+
+Base URL: `https://aggregator-api.kyberswap.com/{chain}`
+
+Chain slugs: `base` · `ethereum` · `arbitrum` · `optimism` · `polygon` · `bsc` · `avalanche`
+
+```
+GET  /api/v1/routes       →  best route + quote (read-only)
+POST /api/v1/route/build  →  unsigned swap transaction calldata
+```
+
+### 1. `GET /api/v1/routes`
+
+```
+https://aggregator-api.kyberswap.com/{chain}/api/v1/routes
+  ?tokenIn={address}
+  &tokenOut={address}
+  &amountIn={amountInWei}
+  &to={walletAddress}
+  &slippageTolerance={bps}
+  &source=base-mcp
+```
+
+| Param | Required | Notes |
+|---|---|---|
+| `tokenIn` | ✅ | Token address. Use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` for native (ETH, BNB, MATIC, etc.) |
+| `tokenOut` | ✅ | Token address |
+| `amountIn` | ✅ | Integer string in base units — no decimals, no scientific notation |
+| `to` | recommended | Recipient wallet address |
+| `slippageTolerance` | recommended | Basis points (50 = 0.5%). See [Slippage Warnings](#slippage-warnings) |
+| `source` | recommended | Pass `base-mcp` for attribution |
+
+Response shape:
+
+```json
+{
+  "data": {
+    "routeSummary": { ... },
+    "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
+    "amountIn": "...",
+    "amountInUsd": "...",
+    "amountOut": "...",
+    "amountOutUsd": "...",
+    "gas": "...",
+    "gasUsd": "..."
+  }
+}
+```
+
+Keep the **complete `routeSummary` object** — it is required verbatim for the build step.
+
+### 2. `POST /api/v1/route/build`
+
+```
+https://aggregator-api.kyberswap.com/{chain}/api/v1/route/build
+```
+
+Request body:
+
+```json
+{
+  "routeSummary": { ... },
+  "sender": "<walletAddress>",
+  "recipient": "<walletAddress>",
+  "slippageTolerance": 50,
+  "deadline": "<unix_timestamp + 1200>",
+  "source": "base-mcp"
+}
+```
+
+Pass `routeSummary` exactly as returned from the GET step — do not modify or truncate it.
+
+Response shape:
+
+```json
+{
+  "data": {
+    "amountIn": "...",
+    "amountOut": "...",
+    "gas": "...",
+    "transactionValue": "0x0",
+    "routerAddress": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
+    "encodedSwapData": "0x..."
+  }
+}
+```
+
+### 3. ERC-20 Approval Check
+
+Before calling send_calls, check whether the router has enough allowance for `tokenIn`:
+
+- **Native tokens** (ETH, BNB, MATIC, AVAX, etc.): no approval needed — proceed directly to send_calls.
+- **ERC-20 tokens**: if current allowance < `amountIn`, include a standard ERC-20 approve call in the batch.
+
+Approval call:
+
+```json
+{
+  "to": "<tokenIn contract address>",
+  "value": "0x0",
+  "data": "<approve(address,uint256) selector + ABI-encoded (router, amountInWei)>"
+}
+```
+
+`approve` selector: `0x095ea7b3`
+
+### 4. `send_calls`
+
+Batch approval (if needed) and swap into a single user approval:
+
+```json
+{
+  "chain": "base",
+  "calls": [
+    { "to": "<tokenIn address>", "value": "0x0", "data": "<approval calldata>" },
+    { "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5", "value": "<transactionValue>", "data": "<encodedSwapData>" }
+  ]
+}
+```
+
+For native token input (no approval):
+
+```json
+{
+  "chain": "base",
+  "calls": [
+    { "to": "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5", "value": "<transactionValue>", "data": "<encodedSwapData>" }
+  ]
+}
+```
+
+Use chain name strings (`base`, `ethereum`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`) — not numeric chainIds.
+
+### Swap Orchestration
+
+```
+1. get_wallets → walletAddress
+2. web_request GET /api/v1/routes → routeSummary, amountOut, gasUsd
+3. Check approval:
+     native token? → skip
+     ERC-20 allowance ≥ amountIn? → skip
+     otherwise → prepare approval calldata
+4. web_request POST /api/v1/route/build → encodedSwapData, transactionValue
+5. send_calls(chain, [approval_call?, swap_call])
+6. Open approvalUrl if requested; do not approve unless the user explicitly asks
+7. get_request_status only after the user acts
+```
+
+---
+
+## Token Resolution
+
+For common tokens on Base:
+
+| Token | Address |
+|---|---|
+| ETH (native) | `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| WETH | `0x4200000000000000000000000000000000000006` |
+| DAI | `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb` |
+| cbBTC | `0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf` |
+
+For unknown tokens, resolve via the KyberSwap token API (GET):
+
+```
+web_request: https://token-api.kyberswap.com/api/v1/public/tokens?chainIds={chainId}&name={symbol}&isWhitelisted=true
+```
+
+Pick the result with exact `symbol` match and highest `marketCap`.
+
+Chain IDs: base=8453, ethereum=1, arbitrum=42161, optimism=10, polygon=137, bsc=56, avalanche=43114
+
+---
+
+## Example Prompts
+
+**Swap 100 USDC to ETH on Base**
+
+1. `get_wallets` → address
+2. `web_request GET /api/v1/routes` tokenIn=`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, tokenOut=`0xEeee...eEEE`, amountIn=`100000000`, chain=`base`
+3. USDC is ERC-20: prepare approval calldata for router
+4. `web_request POST /api/v1/route/build` → encodedSwapData
+5. `send_calls` batching approval + swap
+
+**Swap 0.1 ETH to USDC on Arbitrum**
+
+1. `get_wallets` → address
+2. `web_request GET /api/v1/routes` tokenIn=`0xEeee...eEEE`, tokenOut=USDC on arbitrum, amountIn=`100000000000000000`, chain=`arbitrum`
+3. Native token: no approval needed
+4. `web_request POST /api/v1/route/build` → encodedSwapData, transactionValue (non-zero hex)
+5. `send_calls` with value=transactionValue
+
+---
+
+## Slippage Warnings
+
+| Tolerance | Level | Action |
+|---|---|---|
+| ≤ 50 bps (0.5%) | Normal | Proceed. |
+| > 50 and ≤ 200 bps | Elevated | Mention the value and ask the user to confirm. |
+| > 200 and ≤ 500 bps | High | Warn that the trade can fill significantly below quote and is a likely sandwich target. Require explicit confirmation. |
+| > 500 bps | Very high | Strongly warn; do not submit without the user re-confirming the exact number. |
+
+If the user does not specify slippage: use `50` bps for common pairs (ETH/USDC, WBTC/ETH), `100` bps for long-tail or volatile tokens.
+
+If the build step returns error code `4227` with "return amount is not enough", the price moved since the route was fetched — re-fetch the route and retry before adjusting slippage.
+
+---
+
+## Notes
+
+- Native token sentinel (ETH/BNB/MATIC/AVAX/etc.): `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+- Router address is the same on all chains: `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`
+- `transactionValue` from the build response is a hex wei string — pass it directly as `value` in send_calls. It is non-zero only for native token input.
+- Routes expire in ~30 seconds. If the build step fails with "return amount not enough", re-fetch the route and retry.
+- USDT on Ethereum mainnet requires setting allowance to 0 before a new non-zero approval. If approval fails, suggest revoking first.
+- KyberSwap splits trades across multiple DEX pools when beneficial — the `routeSummary` may describe a multi-hop or split route. Pass it as-is to the build endpoint.


### PR DESCRIPTION
## Summary

This PR adds a KyberSwap plugin to the Base MCP skill, allowing AI assistants to route swaps through KyberSwap's DEX aggregator.

**KyberSwap** aggregates liquidity from 50+ DEX sources (Uniswap V2/V3/V4, Curve, Balancer, and others) to find best execution price across all available pools — complementing the existing Uniswap plugin for users who want best-rate aggregation rather than single-protocol execution.

## What's included

- `skills/base-mcp/plugins/kyberswap.md` — plugin spec following the standard four-section pattern
- `skills/base-mcp/SKILL.md` — KyberSwap added to the native plugins table

## Plugin capabilities

- **Swap flow**: GET best route → POST build unsigned calldata → `send_calls`
- **ERC-20 approval batching**: approval + swap in a single user approval action
- **Native token support**: ETH, BNB, MATIC, AVAX (no approval needed)
- **Token resolution**: via KyberSwap token API (GET only)
- **Slippage warnings**: following Base MCP conventions (50/200/500 bps thresholds)

## Chains supported

Full overlap with Base MCP chain list: **Base, Ethereum, Arbitrum, Optimism, Polygon, BNB Chain, Avalanche**

Router address is the same on all chains: `0x6131B5fae19EA4f9D964eAc0408E4408b66337b5`

## Allowlist request

Requesting `web_request` allowlist for:
- `aggregator-api.kyberswap.com` — swap routes (GET) and build (POST)
- `token-api.kyberswap.com` — token resolution (GET)

## References

- KyberSwap Aggregator API docs: https://docs.kyberswap.com/kyberswap-solutions/kyberswap-aggregator/aggregator-api-specification/evm-swaps
- KyberSwap protocol: https://kyberswap.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)