### PR TITLE
fix(register.sh): handle pretty-printed JSON with space after colon

### DIFF
--- a/skills/build-on-base/scripts/register.sh
+++ b/skills/build-on-base/scripts/register.sh
@@ -18,7 +18,7 @@ RESPONSE=$(curl -sf -X POST "$API_URL" \
   exit 1
 }
 
-BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code":"[^"]*"' | cut -d'"' -f4)
+BUILDER_CODE=$(echo "$RESPONSE" | grep -oE '"builder_code": *"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 
 if [ -z "$BUILDER_CODE" ]; then
   echo "Error: No builder_code in API response" >&2

--- a/skills/build-on-base/scripts/register.sh
+++ b/skills/build-on-base/scripts/register.sh
@@ -18,7 +18,10 @@ RESPONSE=$(curl -sf -X POST "$API_URL" \
   exit 1
 }
 
-BUILDER_CODE=$(echo "$RESPONSE" | grep -oE '"builder_code": *"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+# Match one or more spaces or tabs after the colon (pretty-printers may use either).
+# Fall back to an empty value when the grep pipeline finds nothing, otherwise
+# `set -euo pipefail` aborts the script here and the check below never runs.
+BUILDER_CODE=$(echo "$RESPONSE" | grep -oE '"builder_code":[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"') || BUILDER_CODE=""
 
 if [ -z "$BUILDER_CODE" ]; then
   echo "Error: No builder_code in API response" >&2


### PR DESCRIPTION
Closes #54

This patch fixes the grep pattern in `skills/build-on-base/scripts/register.sh` line 21 so it tolerates the space-after-colon format that the API actually returns (as documented in `references/agents/register.md`).

**Before**:
```bash
BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code":"[^"]*"' | cut -d'"' -f4)
```

The pattern requires no space between the colon and the value, so the pretty-printed format `"builder_code": "bc_..."` matches zero bytes, `BUILDER_CODE` becomes empty, and the script exits 1.

**After**:
```bash
BUILDER_CODE=$(echo "$RESPONSE" | grep -oE '"builder_code": *"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
```

The new pattern uses `grep -E` with a `*`-quantifier between the colon and the opening quote, matching zero or more spaces. A second `grep -oE` extracts the trailing quoted value, then `tr -d '"'` strips the quotes. No new dependencies (still pure POSIX). Both compact and pretty-printed JSON now work.

**Reproduction confirming the fix**:
```bash
# Spaced JSON (current API format)
echo '{"builder_code": "bc_a1b2c3d4"}' | grep -oE '"builder_code": *"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"'
# -> bc_a1b2c3d4 (PASS)

# Compact JSON (legacy)
echo '{"builder_code":"bc_a1b2c3d4"}' | grep -oE '"builder_code": *"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"'
# -> bc_a1b2c3d4 (PASS)
```

Both formats produce identical output, the original bug is gone, and no new dependency is introduced.