### PR TITLE
docs: add common workflow examples to build-on-base skill

### DIFF
--- a/skills/build-on-base/SKILL.md
+++ b/skills/build-on-base/SKILL.md
@@ -72,6 +72,29 @@ Read the reference for your task:
 - **Base Account reference**: [docs.base.org/base-account](https://docs.base.org/base-account)
 - **Base chain docs**: [docs.base.org](https://docs.base.org)
 
+## Common Development Workflows
+
+### Deploy a Contract
+
+1. Configure Base Sepolia RPC
+2. Fund your deployer wallet using the faucet
+3. Deploy using `forge create`
+4. Verify on BaseScan
+
+### Accept USDC Payments
+
+1. Install `@base-org/account`
+2. Use Base Pay to create a payment request
+3. Verify payment status server-side
+4. Fulfill the order after confirmation
+
+### Register an AI Agent
+
+1. Register the agent wallet
+2. Obtain a Builder Code
+3. Add ERC-8021 attribution
+4. Verify attribution is included in transactions
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

Adds practical workflow examples to the build-on-base skill documentation.

## Changes

* Added a contract deployment workflow example
* Added a Base Pay USDC payment workflow example
* Added an AI agent registration workflow example

## Motivation

These examples help developers quickly understand common Base development workflows and provide more practical guidance alongside the existing reference documentation.
