### PR TITLE
Add Printr plugin

### DIFF
--- a/skills/base-mcp/plugins/printr.md
+++ b/skills/base-mcp/plugins/printr.md
@@ -1,28 +1,44 @@
 ---
 title: "Printr Plugin"
-description: "Skill plugin reference for launching cross-chain tokens on Printr via its public HTTP API and submitting the unsigned creation calldata through Base MCP send_calls."
+description: "Launch cross-chain tokens on Printr via its public HTTP API → submit the unsigned creation calldata through Base MCP send_calls."
+tags: [token-launches, memecoins, trading]
+name: printr
+version: 0.2.0
+integration: http-api
+chains: [base, arbitrum, optimism, polygon, bsc, avalanche, ethereum]
+requires:
+  shell: none
+  allowlist: [api-preview.printr.money]
+  externalMcp: null
+  cliPackage: null
+auth: none
+risk: [low-liquidity, irreversible]
 ---
 
 # Printr Plugin
 
 > [!IMPORTANT]
-> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any Printr endpoint. This plugin reads from and builds calldata over the Printr public API, then routes the actual launch through Base MCP's `send_calls` tool — it does not require the separate Printr MCP server. The creator address (used both as the launch creator and as the `send_calls` sender) comes from `get_wallets`.
+> Complete the Base MCP onboarding flow in `SKILL.md` before calling any Printr endpoint. This plugin reads and builds calldata over the Printr public API, then routes the launch through Base MCP `send_calls` — it does not require the separate Printr MCP server. The creator address (launch creator and `send_calls` sender) comes from `get_wallets`.
 
-[Printr](https://printr.money) is a cross-chain token launchpad: a creator deploys a new token and seeds its initial liquidity in a single transaction. Printr spans several ecosystems, but this plugin covers only the EVM chains Base MCP can submit to. It quotes and builds an **unsigned EVM transaction** over the Printr HTTP API — Printr returns raw `{ to, calldata, value }` and never executes anything itself, so the user always signs and broadcasts through Base MCP `send_calls`.
+## Overview
 
-No additional MCP server is required.
+[Printr](https://printr.money) is a cross-chain token launchpad: a creator deploys a new token and seeds its initial liquidity in one transaction. Printr spans several ecosystems; this plugin covers only the EVM chains Base MCP can submit to. It quotes and builds an **unsigned EVM transaction** over the Printr HTTP API — Printr returns the raw `{ to, calldata, value }` and never executes anything itself, so the user always signs and broadcasts through Base MCP `send_calls`. Returns **unsigned calldata**, not a semantic tool call.
 
-**Prerequisite:** `api-preview.printr.money` must be on the Base MCP `web_request` allowlist for the read/build calls. If requests are rejected, tell the user the Printr API isn't whitelisted on this instance and fall back to the harness's HTTP/fetch tool if one is available — do not hand-build the launch calldata. The `send_calls` submission needs no allowlist and works on every surface.
+## Surface Routing
 
-**Chains:** `base` (8453), `arbitrum` (42161), `optimism` (10), `polygon` (137), `bsc` (56), `avalanche` (43114), `ethereum` (1). Printr's Solana, Unichain, Monad, Hyperliquid, and Mantle launches are out of scope — Base MCP can't submit to them.
+| Capability | Harness with HTTP/shell (Claude Code, Codex, Cursor) | Chat-only (Claude.ai, ChatGPT) |
+|---|---|---|
+| Read (quote, token lookup) | Harness HTTP tool | `web_request` — needs `api-preview.printr.money` on the allowlist |
+| Build (`POST /print`) | Harness HTTP tool | `web_request` — same allowlist requirement |
+| Submit (launch) | Base MCP `send_calls` | Base MCP `send_calls` (no allowlist) |
 
----
+If `api-preview.printr.money` is not on the Base MCP `web_request` allowlist and the harness has no direct HTTP/fetch tool, tell the user the Printr API isn't whitelisted on this instance and **stop** — do not hand-build the launch calldata. The `send_calls` submission needs no allowlist and works on every surface. Full decision tree (harness HTTP → `web_request` → user-paste) is in [`../references/custom-plugins.md`](../references/custom-plugins.md).
 
-## API
+## Endpoints
 
 Base URL: `https://api-preview.printr.money/v0`
 
-All endpoints are public (no auth) and exchange `application/json`.
+All endpoints are public (no auth) and accept `application/json`. **Errors return `text/plain` with a non-2xx status** (e.g. a malformed body yields `500` with a plain-text reason), not a structured JSON error — branch on the HTTP status, not a JSON error field.
 
 ### `POST /print/quote`
 
@@ -31,16 +47,19 @@ Estimate the cost of a launch before building it. No wallet address required.
 ```json
 {
   "chains": ["eip155:8453"],
-  "initial_buy": "0.1",
-  "graduation_threshold_per_chain_usd": 5000
+  "initial_buy": { "spend_usd": 10 },
+  "graduation_threshold_per_chain_usd": 15000
 }
 ```
 
 - `chains` — CAIP-2 chain IDs to deploy on (`eip155:8453` is Base).
-- `initial_buy` — creator's initial buy in the chain's native token, as a string.
-- `graduation_threshold_per_chain_usd` — bonding-curve graduation target per chain, in USD.
+- `initial_buy` — the creator's initial buy, as a **`VariableInitialBuy` object** selecting exactly one denomination mode (a bare string is rejected):
+  - `{ "spend_native": "<wei>" }` — amount of the chain's native token, as an **atomic wei string** (e.g. `"100000000000000000"` = 0.1 ETH; a decimal like `"0.1"` is rejected).
+  - `{ "spend_usd": <number> }` — USD amount.
+  - `{ "supply_percent": <number> }` — percent of token supply.
+- `graduation_threshold_per_chain_usd` — bonding-curve graduation target per chain, in USD. Integer, **min `15000`, max `1000000`**.
 
-Returns `{ "quote": { … } }` — an itemized per-chain cost breakdown, the total in USD and native token, and the token amount the `initial_buy` yields. Surface the total and the token amount to the user before building.
+Returns `{ "quote": { … } }` — an itemized per-chain cost breakdown (`assets`, `costs` with `cost_asset_atomic` and `cost_usd`) and the token amount the `initial_buy` yields. Surface the total and the token amount to the user before building.
 
 ### `POST /print`
 
@@ -52,17 +71,18 @@ Build the token and return the unsigned creation transaction. This does **not** 
   "name": "My Token",
   "symbol": "MYT",
   "description": "A token launched via Printr",
-  "image": "<base64 JPEG/PNG, max 500KB>",
+  "image": "<raw base64 JPEG/PNG, max 500KB>",
   "chains": ["eip155:8453"],
-  "initial_buy": "0.1",
-  "graduation_threshold_per_chain_usd": 5000,
+  "initial_buy": { "spend_usd": 10 },
+  "graduation_threshold_per_chain_usd": 15000,
   "external_links": { "website": "https://…", "twitter": "https://…" }
 }
 ```
 
 - `creator_accounts` — one CAIP-10 address (`eip155:<chainId>:0x…`) per chain. Use the address from `get_wallets`.
 - `name` (≤32 chars), `symbol` (≤10 chars), `description` (≤500 chars) — token metadata.
-- `image` — base64 JPEG/PNG, max 500KB. Required. PNGs are often too large; prefer a compressed JPEG.
+- `image` — **raw base64** JPEG/PNG, max 500KB. Required. Do **not** include a `data:image/...;base64,` prefix (a data-URL yields `400 illegal base64`). PNGs are often too large; prefer a compressed JPEG.
+- `initial_buy`, `graduation_threshold_per_chain_usd` — same shapes as `/print/quote`.
 - `external_links` — optional.
 
 Returns:
@@ -72,16 +92,17 @@ Returns:
   "token_id": "0x…",
   "payload": {
     "to": "eip155:8453:0x…",
-    "calldata": "0x…",
-    "value": "1000000000000000",
-    "gas_limit": 2500000
+    "calldata": "<base64>",
+    "value": "5706042678300792",
+    "gas_limit": 2500000,
+    "hash": "<base64>"
   },
   "quote": { … }
 }
 ```
 
 - `token_id` — the cross-chain token ID. The trade page is `https://app.printr.money/trade/{token_id}`.
-- `payload` — the unsigned EVM transaction. `to` is a CAIP-10 string; `value` is already in wei. See [Orchestration](#orchestration) for the `send_calls` mapping.
+- `payload` — the unsigned EVM transaction. `to` is a CAIP-10 string; `calldata` is **base64-encoded** (not `0x` hex); `value` is a **decimal wei string**. See [`## Submission`](#submission) for the encoding both fields need before `send_calls`.
 
 ### `GET /tokens/{id}`
 
@@ -91,33 +112,29 @@ Look up a token's metadata, links, and launch state by `token_id`.
 
 Check per-chain deployment status (live, pending, or failed) for a token.
 
----
-
 ## Orchestration
 
 The happy path is quote → build → submit → confirm. Reads and the build call hit the Printr API; the write goes through Base MCP `send_calls`.
 
-```text
-1. get_wallets → creator EVM address (only if not already cached)
-2. POST /print/quote → show total cost + token amount; confirm the user wants to proceed
-3. POST /print → { token_id, payload }
-4. Validate payload (chain prefix, 0x calldata, value matches quote, balance covers value + gas)
-5. send_calls (Base MCP) with the mapped call + chain string
-6. Open the approvalUrl; poll get_request_status only after the user acts
-7. Present https://app.printr.money/trade/{token_id}
-```
+1. `get_wallets` → creator EVM address (only if not already cached); form `eip155:<chainId>:<address>`.
+2. `POST /print/quote` → show total cost + token amount; confirm the user wants to proceed.
+3. `POST /print` → `{ token_id, payload }`.
+4. Validate `payload` (chain prefix on `to`, decode/encode `calldata` and `value` per [`## Submission`](#submission), balance covers `value` + gas).
+5. `send_calls` (Base MCP) with the mapped call + chain string.
+6. Open the approval URL; poll `get_request_status` only after the user acts.
+7. Present `https://app.printr.money/trade/{token_id}`.
 
-Do not auto-launch. Always require an explicit confirmation of name, symbol, chains, and `initial_buy` before building, and explicit approval before submitting — a launch spends real funds and is irreversible.
+Do not auto-launch. Always require explicit confirmation of name, symbol, chains, and `initial_buy` before building, and explicit approval before submitting — a launch spends real funds and is irreversible.
 
-### Launch `send_calls`
+## Submission
 
-The actual launch is a single Base MCP `send_calls` call built from `payload`. `send_calls` is an EIP-5792 batch of unsigned `{ to, value, data }` calls. Map the fields:
+The launch is a single Base MCP `send_calls` call (an EIP-5792 batch of unsigned `{ to, value, data }` calls) built from `payload`. The Printr response is **not** in `send_calls` wire format — both `calldata` and `value` need encoding:
 
 | `send_calls` field | Source | Transform |
 |---|---|---|
 | `to` | `payload.to` | Strip the `eip155:<chainId>:` prefix — keep the raw `0x…` address. |
-| `data` | `payload.calldata` | Pass through (already `0x`-prefixed). |
-| `value` | `payload.value` | Pass through (already in wei). |
+| `data` | `payload.calldata` | **Base64-decode, then hex-encode and `0x`-prefix.** The API returns base64, but `send_calls` requires `0x` hex calldata. |
+| `value` | `payload.value` | **Decimal wei → hex quantity.** `send_calls` requires hex wei (e.g. `5706042678300792` → `0x14459d96e9d078`). |
 
 Derive the `chain` string from the `<chainId>` segment of `payload.to`:
 
@@ -131,24 +148,22 @@ Derive the `chain` string from the `<chainId>` segment of `payload.to`:
 | `eip155:43114` | `avalanche` |
 | `eip155:1` | `ethereum` |
 
-Today `POST /print` returns one creation call per EVM home chain. If it ever returns more than one call (e.g. an ERC-20 approval before the creation), submit them as a single batch with approvals **before** the action, preserving the response order. The approval/polling pattern is in [`../references/approval-mode.md`](../references/approval-mode.md); batching details are in [`../references/batch-calls.md`](../references/batch-calls.md).
-
----
+Today `POST /print` returns one creation call per EVM home chain. If it ever returns more than one call (e.g. an ERC-20 approval before the creation), submit them as a single batch with approvals **before** the action, preserving response order. Approval/polling flow: [`../references/approval-mode.md`](../references/approval-mode.md); batching: [`../references/batch-calls.md`](../references/batch-calls.md).
 
 ## Example Prompts
 
 **Launch a memecoin called Doge Supreme (DSUP) on Base**
 1. `get_wallets` → EVM address; form the creator account `eip155:8453:<address>`.
-2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show total cost and token amount; confirm.
-3. Get a token image (user-supplied or generated) as base64 JPEG/PNG ≤500KB.
+2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` (e.g. `{ "spend_usd": 10 }`) → show total cost and token amount; confirm.
+3. Get a token image (user-supplied or generated) as raw base64 JPEG/PNG ≤500KB (no `data:` prefix).
 4. `POST /print` with name `Doge Supreme`, symbol `DSUP`, description, image, `chains: ["eip155:8453"]` → `{ token_id, payload }`.
-5. Map `payload` to a `send_calls` call (strip `eip155:8453:` from `to`, `data` ← `calldata`, `value` ← `value`), `chain: "base"`.
+5. Map `payload` to a `send_calls` call: strip `eip155:8453:` from `to`; `data` ← `0x` + hex(base64-decode `calldata`); `value` ← hex(`value`); `chain: "base"`.
 6. Open the approval URL; poll `get_request_status` once the user approves.
 7. Present `https://app.printr.money/trade/{token_id}`.
 
 **What would it cost to launch a token on Base and Arbitrum?**
 1. `POST /print/quote` with `chains: ["eip155:8453", "eip155:42161"]` and the proposed `initial_buy`.
-2. Report the per-chain itemized cost and the combined total in USD and native token. Build nothing.
+2. Report the per-chain itemized cost and combined total. Build nothing.
 
 **Did my token deploy on every chain?**
 1. Take the `token_id` from the earlier launch (or ask the user for it).
@@ -158,30 +173,16 @@ Today `POST /print` returns one creation call per EVM home chain. If it ever ret
 **Launch it but I'm on Claude.ai with no terminal**
 1. Confirm `api-preview.printr.money` is on the Base MCP `web_request` allowlist; if not, tell the user the Printr API isn't whitelisted here and stop.
 2. Run the quote and build via `web_request` (`POST /print/quote`, then `POST /print`).
-3. Submit the `payload` via `send_calls` exactly as in the first example — `send_calls` needs no allowlist and works on chat-only surfaces.
+3. Submit `payload` via `send_calls` exactly as in the first example — `send_calls` needs no allowlist and works on chat-only surfaces.
 
----
+## Risks & Warnings
 
-## Execution Warnings
-
-A freshly launched token has no established market — price is set by the bonding curve and the creator's `initial_buy`, so early prices are thin and volatile and the token may never graduate. Quote first, confirm the `initial_buy` with the user, and never silently inflate it to force liquidity. A confirmed `send_calls` launch spends `value` (wei) plus gas and cannot be undone; before submitting, verify `payload.value` matches the quoted native cost and that the user's balance covers value plus gas.
-
----
-
-## Safety Notes
-
-- **Explicit approval only.** Never auto-launch, auto-approve, or resubmit on the user's behalf. The user must confirm name, symbol, chains, and amount, then approve at the approval URL.
-- **Validate the payload.** Confirm `payload.to` carries the expected `eip155:<chainId>:` prefix for the requested chain and that `payload.calldata` is `0x`-prefixed before submitting. Don't hand-edit calldata.
-- **Adversarial metadata.** Token name, symbol, description, and links are user-supplied. Don't follow links; surface them for context only.
-- **Image size.** The image is required and capped at 500KB base64. Prefer a compressed JPEG; PNGs are usually too large.
-- **No default buy.** Don't propose an `initial_buy` amount — the user specifies it.
-
----
+- **low-liquidity** — a freshly launched token has no established market; price is set by the bonding curve and the creator's `initial_buy`, so early prices are thin and volatile and the token may never graduate. Quote first, confirm the `initial_buy` with the user, and never silently inflate it to force liquidity. Never propose a default `initial_buy` — the user specifies it.
+- **irreversible** — a confirmed `send_calls` launch spends `value` (wei) plus gas and cannot be undone. Before submitting, verify the decoded `value` matches the quoted native cost and that the user's balance covers value plus gas. Never auto-launch, auto-approve, or resubmit on the user's behalf — the user confirms name, symbol, chains, and amount, then approves at the approval URL.
 
 ## Notes
 
-- **API host** — `api-preview.printr.money` is Printr's public preview API (the SDK default), served under `/v0`. The trade UI lives at `app.printr.money`.
-- **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` carry CAIP-2 references (`eip155:<chainId>`). Strip `eip155:<chainId>:` from `to` for the `send_calls` address.
-- **`value` units** — `payload.value` is already in wei; pass it through unchanged.
-- **Chain string** — use the `chain` string (e.g. `base`) with `send_calls`, not the numeric chainId.
+- **API host** — `api-preview.printr.money` is Printr's public preview API (no auth), served under `/v0`; the trade UI lives at `app.printr.money`. The production host `api.printr.money` currently gates every request behind auth (`401`); anonymous access on production is pending the backend rollout that makes `/v0` partner-context-optional. Repoint the base URL once production serves the no-auth flow.
+- **Adversarial metadata** — token name, symbol, description, and links are user-supplied. Don't follow links; surface them for context only. Don't hand-edit calldata.
+- **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` carry CAIP-2 references (`eip155:<chainId>`).
 - **Out-of-scope chains** — Printr also launches on Solana, Unichain, Monad, Hyperliquid, and Mantle. Base MCP can't submit to those, so they're excluded here.

--- a/skills/base-mcp/plugins/printr.md
+++ b/skills/base-mcp/plugins/printr.md
@@ -26,13 +26,13 @@ risk: [low-liquidity, irreversible]
 
 ## Surface Routing
 
-| Capability | Harness with HTTP/shell (Claude Code, Codex, Cursor) | Chat-only (Claude.ai, ChatGPT) |
-|---|---|---|
-| Read (quote, token lookup) | Harness HTTP tool | `web_request` — needs `api-preview.printr.money` on the allowlist |
-| Build (`POST /print`) | Harness HTTP tool | `web_request` — same allowlist requirement |
-| Submit (launch) | Base MCP `send_calls` | Base MCP `send_calls` (no allowlist) |
+| Capability | Execution path |
+|---|---|
+| Read (quote, token lookup) | Printr HTTP API |
+| Build (`POST /print`) | Printr HTTP API |
+| Submit (launch) | Base MCP `send_calls` |
 
-If `api-preview.printr.money` is not on the Base MCP `web_request` allowlist and the harness has no direct HTTP/fetch tool, tell the user the Printr API isn't whitelisted on this instance and **stop** — do not hand-build the launch calldata. The `send_calls` submission needs no allowlist and works on every surface. Full decision tree (harness HTTP → `web_request` → user-paste) is in [`../references/custom-plugins.md`](../references/custom-plugins.md).
+Reads and the build call go over HTTP; the launch is always submitted through Base MCP `send_calls`, which works on every surface. Per-surface HTTP routing and the chat-only fallback are handled centrally — see [`../references/custom-plugins.md`](../references/custom-plugins.md). If the Printr API can't be reached on the current surface, tell the user and **stop** — never hand-build the launch calldata.
 
 ## Endpoints
 
@@ -47,8 +47,8 @@ Estimate the cost of a launch before building it. No wallet address required.
 ```json
 {
   "chains": ["eip155:8453"],
-  "initial_buy": { "spend_usd": 10 },
-  "graduation_threshold_per_chain_usd": 15000
+  "initial_buy": { "spend_usd": <amount> },
+  "graduation_threshold_per_chain_usd": <usd>
 }
 ```
 
@@ -73,8 +73,8 @@ Build the token and return the unsigned creation transaction. This does **not** 
   "description": "A token launched via Printr",
   "image": "<raw base64 JPEG/PNG, max 500KB>",
   "chains": ["eip155:8453"],
-  "initial_buy": { "spend_usd": 10 },
-  "graduation_threshold_per_chain_usd": 15000,
+  "initial_buy": { "spend_usd": <amount> },
+  "graduation_threshold_per_chain_usd": <usd>,
   "external_links": { "website": "https://…", "twitter": "https://…" }
 }
 ```
@@ -154,12 +154,12 @@ Today `POST /print` returns one creation call per EVM home chain. If it ever ret
 
 **Launch a memecoin called Doge Supreme (DSUP) on Base**
 1. `get_wallets` → EVM address; form the creator account `eip155:8453:<address>`.
-2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` (e.g. `{ "spend_usd": 10 }`) → show total cost and token amount; confirm.
+2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show total cost and token amount; confirm.
 3. Get a token image (user-supplied or generated) as raw base64 JPEG/PNG ≤500KB (no `data:` prefix).
 4. `POST /print` with name `Doge Supreme`, symbol `DSUP`, description, image, `chains: ["eip155:8453"]` → `{ token_id, payload }`.
 5. Map `payload` to a `send_calls` call: strip `eip155:8453:` from `to`; `data` ← `0x` + hex(base64-decode `calldata`); `value` ← hex(`value`); `chain: "base"`.
 6. Open the approval URL; poll `get_request_status` once the user approves.
-7. Present `https://app.printr.money/trade/{token_id}`.
+7. Point the user to `https://app.printr.money/trade/{token_id}` to track their new token's position.
 
 **What would it cost to launch a token on Base and Arbitrum?**
 1. `POST /print/quote` with `chains: ["eip155:8453", "eip155:42161"]` and the proposed `initial_buy`.
@@ -169,11 +169,6 @@ Today `POST /print` returns one creation call per EVM home chain. If it ever ret
 1. Take the `token_id` from the earlier launch (or ask the user for it).
 2. `GET /tokens/{id}/deployments` → report which chains are live, pending, or failed.
 3. Optionally `GET /tokens/{id}` for current metadata and the trade-page link.
-
-**Launch it but I'm on Claude.ai with no terminal**
-1. Confirm `api-preview.printr.money` is on the Base MCP `web_request` allowlist; if not, tell the user the Printr API isn't whitelisted here and stop.
-2. Run the quote and build via `web_request` (`POST /print/quote`, then `POST /print`).
-3. Submit `payload` via `send_calls` exactly as in the first example — `send_calls` needs no allowlist and works on chat-only surfaces.
 
 ## Risks & Warnings
 
@@ -185,4 +180,3 @@ Today `POST /print` returns one creation call per EVM home chain. If it ever ret
 - **API host** — `api-preview.printr.money` is Printr's public preview API (no auth), served under `/v0`; the trade UI lives at `app.printr.money`. The production host `api.printr.money` currently gates every request behind auth (`401`); anonymous access on production is pending the backend rollout that makes `/v0` partner-context-optional. Repoint the base URL once production serves the no-auth flow.
 - **Adversarial metadata** — token name, symbol, description, and links are user-supplied. Don't follow links; surface them for context only. Don't hand-edit calldata.
 - **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` carry CAIP-2 references (`eip155:<chainId>`).
-- **Out-of-scope chains** — Printr also launches on Solana, Unichain, Monad, Hyperliquid, and Mantle. Base MCP can't submit to those, so they're excluded here.

--- a/skills/base-mcp/plugins/printr.md
+++ b/skills/base-mcp/plugins/printr.md
@@ -18,11 +18,11 @@ risk: [low-liquidity, irreversible]
 # Printr Plugin
 
 > [!IMPORTANT]
-> Complete the Base MCP onboarding flow in `SKILL.md` before calling any Printr endpoint. This plugin reads and builds calldata over the Printr public API, then routes the launch through Base MCP `send_calls` — it does not require the separate Printr MCP server. The creator address (launch creator and `send_calls` sender) comes from `get_wallets`.
+> Complete the Base MCP onboarding flow in `SKILL.md` first. The creator address (launch creator and `send_calls` sender) comes from `get_wallets`.
 
 ## Overview
 
-[Printr](https://printr.money) is a cross-chain token launchpad: a creator deploys a new token and seeds its initial liquidity in one transaction. Printr spans several ecosystems; this plugin covers only the EVM chains Base MCP can submit to. It quotes and builds an **unsigned EVM transaction** over the Printr HTTP API — Printr returns the raw `{ to, calldata, value }` and never executes anything itself, so the user always signs and broadcasts through Base MCP `send_calls`. Returns **unsigned calldata**, not a semantic tool call.
+[Printr](https://printr.money) is a cross-chain token launchpad: a creator deploys a token and seeds its initial liquidity in one transaction. This plugin covers the EVM chains Base MCP can submit to. It builds an **unsigned EVM transaction** over the Printr HTTP API and submits it through Base MCP `send_calls`; Printr never signs or executes.
 
 ## Surface Routing
 
@@ -32,17 +32,15 @@ risk: [low-liquidity, irreversible]
 | Build (`POST /print`) | Printr HTTP API |
 | Submit (launch) | Base MCP `send_calls` |
 
-Reads and the build call go over HTTP; the launch is always submitted through Base MCP `send_calls`, which works on every surface. Per-surface HTTP routing and the chat-only fallback are handled centrally — see [`../references/custom-plugins.md`](../references/custom-plugins.md). If the Printr API can't be reached on the current surface, tell the user and **stop** — never hand-build the launch calldata.
+Per-surface HTTP routing and the chat-only fallback are handled centrally, see [`../references/custom-plugins.md`](../references/custom-plugins.md). If the Printr API is unreachable on the current surface, tell the user and **stop**; never hand-build the launch calldata.
 
 ## Endpoints
 
-Base URL: `https://api-preview.printr.money/v0`
-
-All endpoints are public (no auth) and accept `application/json`. **Errors return `text/plain` with a non-2xx status** (e.g. a malformed body yields `500` with a plain-text reason), not a structured JSON error — branch on the HTTP status, not a JSON error field.
+Base URL: `https://api-preview.printr.money/v0`. Public (no auth), `application/json`. **Errors return `text/plain` with a non-2xx status**, not a JSON error object; branch on the HTTP status.
 
 ### `POST /print/quote`
 
-Estimate the cost of a launch before building it. No wallet address required.
+Estimate launch cost. No wallet address required.
 
 ```json
 {
@@ -52,18 +50,18 @@ Estimate the cost of a launch before building it. No wallet address required.
 }
 ```
 
-- `chains` — CAIP-2 chain IDs to deploy on (`eip155:8453` is Base).
-- `initial_buy` — the creator's initial buy, as a **`VariableInitialBuy` object** selecting exactly one denomination mode (a bare string is rejected):
-  - `{ "spend_native": "<wei>" }` — amount of the chain's native token, as an **atomic wei string** (e.g. `"100000000000000000"` = 0.1 ETH; a decimal like `"0.1"` is rejected).
+- `chains` — CAIP-2 chain IDs (`eip155:8453` is Base).
+- `initial_buy` — a **`VariableInitialBuy` object** with exactly one mode (a bare string is rejected):
+  - `{ "spend_native": "<wei>" }` — native token as an **atomic wei string** (`"0.1"` is rejected; use `"100000000000000000"`).
   - `{ "spend_usd": <number> }` — USD amount.
-  - `{ "supply_percent": <number> }` — percent of token supply.
-- `graduation_threshold_per_chain_usd` — bonding-curve graduation target per chain, in USD. Integer, **min `15000`, max `1000000`**.
+  - `{ "supply_percent": <number> }` — percent of supply.
+- `graduation_threshold_per_chain_usd` — per-chain graduation target, USD integer, **min `15000`, max `1000000`**.
 
-Returns `{ "quote": { … } }` — an itemized per-chain cost breakdown (`assets`, `costs` with `cost_asset_atomic` and `cost_usd`) and the token amount the `initial_buy` yields. Surface the total and the token amount to the user before building.
+Returns `{ "quote": { … } }` with per-chain `costs` (`cost_asset_atomic`, `cost_usd`) and the token amount yielded. Surface the total and token amount before building.
 
 ### `POST /print`
 
-Build the token and return the unsigned creation transaction. This does **not** deploy anything — it returns calldata you submit via `send_calls`.
+Build the token; returns unsigned calldata. Does **not** deploy.
 
 ```json
 {
@@ -79,104 +77,71 @@ Build the token and return the unsigned creation transaction. This does **not** 
 }
 ```
 
-- `creator_accounts` — one CAIP-10 address (`eip155:<chainId>:0x…`) per chain. Use the address from `get_wallets`.
-- `name` (≤32 chars), `symbol` (≤10 chars), `description` (≤500 chars) — token metadata.
-- `image` — **raw base64** JPEG/PNG, max 500KB. Required. Do **not** include a `data:image/...;base64,` prefix (a data-URL yields `400 illegal base64`). PNGs are often too large; prefer a compressed JPEG.
-- `initial_buy`, `graduation_threshold_per_chain_usd` — same shapes as `/print/quote`.
-- `external_links` — optional.
-
-Returns:
+- `creator_accounts` — one CAIP-10 address (`eip155:<chainId>:0x…`) per chain, from `get_wallets`.
+- `name` (≤32), `symbol` (≤10), `description` (≤500 chars).
+- `image` — **raw base64**, max 500KB, no `data:` prefix (a data-URL yields `400 illegal base64`).
+- `initial_buy`, `graduation_threshold_per_chain_usd` — same as `/print/quote`. `external_links` optional.
 
 ```json
 {
   "token_id": "0x…",
-  "payload": {
-    "to": "eip155:8453:0x…",
-    "calldata": "<base64>",
-    "value": "5706042678300792",
-    "gas_limit": 2500000,
-    "hash": "<base64>"
-  },
+  "payload": { "to": "eip155:8453:0x…", "calldata": "<base64>", "value": "<decimal wei>", "gas_limit": 2500000, "hash": "<base64>" },
   "quote": { … }
 }
 ```
 
-- `token_id` — the cross-chain token ID. The trade page is `https://app.printr.money/trade/{token_id}`.
-- `payload` — the unsigned EVM transaction. `to` is a CAIP-10 string; `calldata` is **base64-encoded** (not `0x` hex); `value` is a **decimal wei string**. See [`## Submission`](#submission) for the encoding both fields need before `send_calls`.
+`payload.calldata` is **base64** (not `0x` hex) and `payload.value` is a **decimal wei string**; both need encoding before `send_calls` (see [`## Submission`](#submission)). Trade page: `https://app.printr.money/trade/{token_id}`.
 
-### `GET /tokens/{id}`
+### `GET /tokens/{id}` · `GET /tokens/{id}/deployments`
 
-Look up a token's metadata, links, and launch state by `token_id`.
-
-### `GET /tokens/{id}/deployments`
-
-Check per-chain deployment status (live, pending, or failed) for a token.
+Token metadata and launch state; per-chain deployment status (live, pending, failed).
 
 ## Orchestration
 
-The happy path is quote → build → submit → confirm. Reads and the build call hit the Printr API; the write goes through Base MCP `send_calls`.
-
-1. `get_wallets` → creator EVM address (only if not already cached); form `eip155:<chainId>:<address>`.
-2. `POST /print/quote` → show total cost + token amount; confirm the user wants to proceed.
+1. `get_wallets` → creator EVM address; form `eip155:<chainId>:<address>`.
+2. `POST /print/quote` → show total cost + token amount; user confirms.
 3. `POST /print` → `{ token_id, payload }`.
-4. Validate `payload` (chain prefix on `to`, decode/encode `calldata` and `value` per [`## Submission`](#submission), balance covers `value` + gas).
-5. `send_calls` (Base MCP) with the mapped call + chain string.
-6. Open the approval URL; poll `get_request_status` only after the user acts.
-7. Present `https://app.printr.money/trade/{token_id}`.
-
-Do not auto-launch. Always require explicit confirmation of name, symbol, chains, and `initial_buy` before building, and explicit approval before submitting — a launch spends real funds and is irreversible.
+4. Map `payload` → `send_calls` (see [`## Submission`](#submission)); verify `value` against the quote and that the balance covers `value` + gas.
+5. `send_calls` → approval URL; user approves; poll `get_request_status` → confirmed.
+6. Point the user to `https://app.printr.money/trade/{token_id}`.
 
 ## Submission
 
-The launch is a single Base MCP `send_calls` call (an EIP-5792 batch of unsigned `{ to, value, data }` calls) built from `payload`. The Printr response is **not** in `send_calls` wire format — both `calldata` and `value` need encoding:
+Build one `send_calls` call (EIP-5792 batch of `{ to, value, data }`) from `payload`. `calldata` and `value` are not in wire format and need encoding:
 
 | `send_calls` field | Source | Transform |
 |---|---|---|
-| `to` | `payload.to` | Strip the `eip155:<chainId>:` prefix — keep the raw `0x…` address. |
-| `data` | `payload.calldata` | **Base64-decode, then hex-encode and `0x`-prefix.** The API returns base64, but `send_calls` requires `0x` hex calldata. |
-| `value` | `payload.value` | **Decimal wei → hex quantity.** `send_calls` requires hex wei (e.g. `5706042678300792` → `0x14459d96e9d078`). |
+| `to` | `payload.to` | Strip the `eip155:<chainId>:` prefix → raw `0x…`. |
+| `data` | `payload.calldata` | Base64-decode → hex → `0x`-prefix. |
+| `value` | `payload.value` | Decimal wei → hex (e.g. `5706042678300792` → `0x14459d96e9d078`). |
 
-Derive the `chain` string from the `<chainId>` segment of `payload.to`:
+Derive `chain` from the `<chainId>` in `payload.to`: `8453`→`base`, `42161`→`arbitrum`, `10`→`optimism`, `137`→`polygon`, `56`→`bsc`, `43114`→`avalanche`, `1`→`ethereum`.
 
-| CAIP-2 | `chain` |
-|---|---|
-| `eip155:8453` | `base` |
-| `eip155:42161` | `arbitrum` |
-| `eip155:10` | `optimism` |
-| `eip155:137` | `polygon` |
-| `eip155:56` | `bsc` |
-| `eip155:43114` | `avalanche` |
-| `eip155:1` | `ethereum` |
-
-Today `POST /print` returns one creation call per EVM home chain. If it ever returns more than one call (e.g. an ERC-20 approval before the creation), submit them as a single batch with approvals **before** the action, preserving response order. Approval/polling flow: [`../references/approval-mode.md`](../references/approval-mode.md); batching: [`../references/batch-calls.md`](../references/batch-calls.md).
+`POST /print` returns one creation call per home chain today. If it returns more (e.g. an approval before the creation), batch them in response order, approvals first. Refs: [`../references/approval-mode.md`](../references/approval-mode.md), [`../references/batch-calls.md`](../references/batch-calls.md).
 
 ## Example Prompts
 
 **Launch a memecoin called Doge Supreme (DSUP) on Base**
-1. `get_wallets` → EVM address; form the creator account `eip155:8453:<address>`.
-2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show total cost and token amount; confirm.
-3. Get a token image (user-supplied or generated) as raw base64 JPEG/PNG ≤500KB (no `data:` prefix).
-4. `POST /print` with name `Doge Supreme`, symbol `DSUP`, description, image, `chains: ["eip155:8453"]` → `{ token_id, payload }`.
-5. Map `payload` to a `send_calls` call: strip `eip155:8453:` from `to`; `data` ← `0x` + hex(base64-decode `calldata`); `value` ← hex(`value`); `chain: "base"`.
-6. Open the approval URL; poll `get_request_status` once the user approves.
-7. Point the user to `https://app.printr.money/trade/{token_id}` to track their new token's position.
+1. `get_wallets` → form `eip155:8453:<address>`.
+2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show cost + token amount; confirm.
+3. Get a token image as raw base64 JPEG/PNG ≤500KB (no `data:` prefix).
+4. `POST /print` (name `Doge Supreme`, symbol `DSUP`, image, `chains: ["eip155:8453"]`) → `{ token_id, payload }`.
+5. Map `payload` → `send_calls` (`chain: "base"`); user approves; poll `get_request_status`.
+6. Point the user to `https://app.printr.money/trade/{token_id}`.
 
-**What would it cost to launch a token on Base and Arbitrum?**
-1. `POST /print/quote` with `chains: ["eip155:8453", "eip155:42161"]` and the proposed `initial_buy`.
-2. Report the per-chain itemized cost and combined total. Build nothing.
+**What would it cost to launch on Base and Arbitrum?**
+- `POST /print/quote` with `chains: ["eip155:8453", "eip155:42161"]` → report per-chain and combined cost. Build nothing.
 
 **Did my token deploy on every chain?**
-1. Take the `token_id` from the earlier launch (or ask the user for it).
-2. `GET /tokens/{id}/deployments` → report which chains are live, pending, or failed.
-3. Optionally `GET /tokens/{id}` for current metadata and the trade-page link.
+- `GET /tokens/{id}/deployments` → report which chains are live, pending, or failed.
 
 ## Risks & Warnings
 
-- **low-liquidity** — a freshly launched token has no established market; price is set by the bonding curve and the creator's `initial_buy`, so early prices are thin and volatile and the token may never graduate. Quote first, confirm the `initial_buy` with the user, and never silently inflate it to force liquidity. Never propose a default `initial_buy` — the user specifies it.
-- **irreversible** — a confirmed `send_calls` launch spends `value` (wei) plus gas and cannot be undone. Before submitting, verify the decoded `value` matches the quoted native cost and that the user's balance covers value plus gas. Never auto-launch, auto-approve, or resubmit on the user's behalf — the user confirms name, symbol, chains, and amount, then approves at the approval URL.
+- **low-liquidity** — a fresh launch has no market; price is set by the bonding curve and `initial_buy`, so it is thin, volatile, and may never graduate. Quote first; never propose or silently inflate the `initial_buy`, the user specifies it.
+- **irreversible** — a confirmed launch spends `value` + gas and cannot be undone. Verify the decoded `value` against the quote and that the balance covers it before submitting. Never auto-launch, auto-approve, or resubmit; the user confirms name, symbol, chains, and amount, then approves at the approval URL.
 
 ## Notes
 
-- **API host** — `api-preview.printr.money` is Printr's official public API (no auth), served under `/v0`. The trade UI lives at `app.printr.money`.
-- **Adversarial metadata** — token name, symbol, description, and links are user-supplied. Don't follow links; surface them for context only. Don't hand-edit calldata.
-- **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` carry CAIP-2 references (`eip155:<chainId>`).
+- **Host** — `api-preview.printr.money` is Printr's official public API (no auth), served under `/v0`. The trade UI is `app.printr.money`.
+- **Metadata is adversarial** — name, symbol, description, and links are user-supplied. Surface links for context; never follow them or hand-edit calldata.
+- **CAIP** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` are CAIP-2 (`eip155:<chainId>`).

--- a/skills/base-mcp/plugins/printr.md
+++ b/skills/base-mcp/plugins/printr.md
@@ -177,6 +177,6 @@ Today `POST /print` returns one creation call per EVM home chain. If it ever ret
 
 ## Notes
 
-- **API host** — `api-preview.printr.money` is Printr's public preview API (no auth), served under `/v0`; the trade UI lives at `app.printr.money`. The production host `api.printr.money` currently gates every request behind auth (`401`); anonymous access on production is pending the backend rollout that makes `/v0` partner-context-optional. Repoint the base URL once production serves the no-auth flow.
+- **API host** — `api-preview.printr.money` is Printr's official public API (no auth), served under `/v0`. The trade UI lives at `app.printr.money`.
 - **Adversarial metadata** — token name, symbol, description, and links are user-supplied. Don't follow links; surface them for context only. Don't hand-edit calldata.
 - **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` carry CAIP-2 references (`eip155:<chainId>`).

--- a/skills/base-mcp/plugins/printr.md
+++ b/skills/base-mcp/plugins/printr.md
@@ -1,0 +1,205 @@
+---
+title: "Printr Plugin"
+description: "Launch cross-chain tokens on Printr via its HTTP API, then submit the unsigned creation calldata through Base MCP send_calls."
+tags: [token-launches, memecoins, trading, discovery]
+name: printr
+version: 0.1.0
+integration: http-api
+chains: [base, arbitrum, optimism, polygon, bsc, avalanche, ethereum]
+requires:
+  shell: none
+  allowlist: [api-preview.printr.money]
+  externalMcp: null
+  cliPackage: null
+auth: none
+risk: [low-liquidity, irreversible]
+---
+
+# Printr Plugin
+
+> [!IMPORTANT]
+> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any Printr endpoint. The user's wallet address — required as the creator account and as the `send_calls` sender — is fetched lazily via `get_wallets` when needed. No Printr API key or login is required.
+
+## Overview
+
+Printr is a cross-chain token launchpad: it lets a creator deploy a new token and seed its initial liquidity in a single transaction. Printr supports several ecosystems, but this plugin covers only the EVM subset that Base MCP can submit to — `base`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`, and `ethereum` (Printr's Solana, Unichain, Monad, Hyperliquid, and Mantle support is out of scope here). The plugin reads cost estimates and builds an **unsigned EVM transaction payload** over the Printr HTTP API, then submits that payload as a `send_calls` batch through Base MCP. Printr returns raw `{ to, calldata, value }` calldata — it never executes the transaction itself, so the user always signs and broadcasts through Base MCP.
+
+## Surface Routing
+
+Printr is a plain HTTP API plus a `send_calls` submission, so no shell or CLI is ever required. The Printr API host must be reachable for the read/build steps; the actual onchain write always goes through Base MCP `send_calls`, which works on every surface.
+
+| Capability | Harness with HTTP/shell (Claude Code, Codex, Cursor) | Chat-only / shell-less (Claude.ai, ChatGPT) |
+|---|---|---|
+| Quote a launch (read) | Harness HTTP tool → `POST /print/quote` | Base MCP `web_request` → `POST /print/quote` |
+| Build a token (build calldata) | Harness HTTP tool → `POST /print` | Base MCP `web_request` → `POST /print` |
+| Look up a token / deployments (read) | Harness HTTP tool → `GET /tokens/{id}`, `GET /tokens/{id}/deployments` | Base MCP `web_request` → same GETs |
+| Submit the launch (write) | Base MCP `send_calls` | Base MCP `send_calls` |
+
+On a shell-less / chat-only surface, `api-preview.printr.money` **must** be on the Base MCP `web_request` allowlist for the read/build steps to reach it. If `web_request` rejects that host, inform the user that the Printr API is not yet whitelisted on this MCP instance and stop — do not attempt to hand-build the launch calldata. The submission step (`send_calls`) is unaffected and needs no allowlist. The full execution decision tree (harness HTTP → `web_request` → user-paste, and the GET-only constraint on consumer surfaces) lives in [custom-plugins.md](../references/custom-plugins.md).
+
+## Endpoints
+
+All Printr endpoints are public (no auth) and are served under the `/v0` prefix on the Printr API host. Send and receive `application/json`.
+
+Base URL: `https://api-preview.printr.money/v0`
+
+### `POST /print/quote`
+
+Estimate the cost of a launch before building it. No wallet address required.
+
+Request body:
+
+```json
+{
+  "chains": ["eip155:8453"],
+  "initial_buy": "0.1",
+  "graduation_threshold_per_chain_usd": 5000
+}
+```
+
+- `chains` — array of CAIP-2 chain IDs to deploy on (e.g. `eip155:8453` for Base).
+- `initial_buy` — creator's initial buy amount in the chain's native token (string).
+- `graduation_threshold_per_chain_usd` — bonding-curve graduation target per chain, in USD.
+
+Response: `{ "quote": { … } }` — an itemized cost breakdown per chain plus the total cost in USD and native tokens, and the number of tokens the `initial_buy` yields.
+
+### `POST /print`
+
+Build the token and return the unsigned creation transaction. This does **not** deploy anything — it returns calldata you submit via `send_calls`.
+
+Request body (superset of the quote body):
+
+```json
+{
+  "creator_accounts": ["eip155:8453:0xCreatorAddress"],
+  "name": "My Token",
+  "symbol": "MYT",
+  "description": "A token launched via Printr",
+  "image": "<base64-encoded image, max 500KB, JPEG/PNG>",
+  "chains": ["eip155:8453"],
+  "initial_buy": "0.1",
+  "graduation_threshold_per_chain_usd": 5000,
+  "external_links": { "website": "https://…", "twitter": "https://…" }
+}
+```
+
+- `creator_accounts` — one CAIP-10 address (`eip155:<chainId>:0x…`) per chain being deployed to. Use the address from `get_wallets`.
+- `name` (≤32 chars), `symbol` (≤10 chars), `description` (≤500 chars) — token metadata.
+- `image` — base64-encoded JPEG/PNG, max 500KB. Required by the launchpad.
+- `chains`, `initial_buy`, `graduation_threshold_per_chain_usd`, `external_links` — as above; `external_links` is optional.
+
+Response (EVM home chain):
+
+```json
+{
+  "token_id": "0x…",
+  "payload": {
+    "to": "eip155:8453:0x…",
+    "calldata": "0x…",
+    "value": "1000000000000000",
+    "gas_limit": 2500000
+  },
+  "quote": { … }
+}
+```
+
+- `token_id` — the cross-chain token ID (hex). The trade page is `https://app.printr.money/trade/{token_id}` — present this to the user after the launch confirms.
+- `payload` — the unsigned EVM transaction (see [`## Submission`](#submission) for the `send_calls` mapping). `to` is a CAIP-10 string; `value` is already in wei.
+
+### `GET /tokens/{id}`
+
+Look up a token's details by its `token_id`. Returns metadata, links, and current launch state.
+
+### `GET /tokens/{id}/deployments`
+
+Check per-chain deployment status for a token (which target chains are live, pending, or failed).
+
+## Orchestration
+
+The happy path goes quote → build → submit → confirm. Reads and the build call hit the Printr HTTP API; the write goes through Base MCP `send_calls`.
+
+1. **Get the creator address.** Call `get_wallets` and take the user's EVM address. This is both the `creator_accounts` entry (as CAIP-10, `eip155:<chainId>:<address>`) and the `send_calls` sender.
+2. **Quote (optional but recommended).** `POST /print/quote` with `chains`, `initial_buy`, and `graduation_threshold_per_chain_usd`. Show the user the total cost in USD and native token, and the expected token amount from the initial buy. Confirm the user wants to proceed.
+3. **Build the token.** `POST /print` with the full body (creator account, name, symbol, description, base64 image, chains, initial buy, graduation threshold, optional links). Receive `{ token_id, payload, quote }`.
+4. **Validate before submit.** Confirm `payload.to` carries the expected `eip155:<chainId>:` prefix matching the requested chain, that `payload.calldata` is `0x`-prefixed, and that `payload.value` (wei) matches the quoted native-token cost. Confirm the user's balance covers `value` plus gas.
+5. **Submit via `send_calls`.** Map the payload (see [`## Submission`](#submission)) and call `send_calls` with the matching chain string. This returns an approval URL and a request ID.
+6. **Confirm.** The user approves at the returned approval URL (present as "Approve Transaction" — see [approval-mode.md](../references/approval-mode.md)). Poll `get_request_status(requestId)` until confirmed.
+7. **Surface the trade page.** Once confirmed, give the user `https://app.printr.money/trade/{token_id}`. Optionally call `GET /tokens/{id}/deployments` to report per-chain status.
+
+## Submission
+
+Target Base MCP tool: **`send_calls`** — an EIP-5792 batch of unsigned `{ to, value, data }` calls. Printr's `POST /print` response carries a single EVM call in `payload`; map it as follows:
+
+| `send_calls` call field | Source in Printr `payload` | Transform |
+|---|---|---|
+| `to` | `payload.to` | Strip the CAIP-10 prefix `eip155:<chainId>:` — keep the raw `0x…` address. |
+| `data` | `payload.calldata` | Pass through (already `0x`-prefixed hex). |
+| `value` | `payload.value` | Pass through (already in wei). |
+
+Derive the `send_calls` `chain` string from the `<chainId>` segment of `payload.to` (the CAIP-2 chain reference), mapping it to the Base MCP chain string:
+
+| CAIP-2 chain ID | Base MCP `chain` |
+|---|---|
+| `eip155:8453` | `base` |
+| `eip155:42161` | `arbitrum` |
+| `eip155:10` | `optimism` |
+| `eip155:137` | `polygon` |
+| `eip155:56` | `bsc` |
+| `eip155:43114` | `avalanche` |
+| `eip155:1` | `ethereum` |
+
+Batching: if the launch ever returns more than one call (e.g. an ERC-20 approval ahead of the creation), submit them as a single `send_calls` batch with approvals **before** the action, preserving the response order. Today `POST /print` returns one creation call per EVM home chain. After submission, follow the approval/polling flow in [approval-mode.md](../references/approval-mode.md).
+
+## Example Prompts
+
+### "Launch a memecoin called Doge Supreme (DSUP) on Base"
+
+1. `get_wallets` → EVM address; form the creator account `eip155:8453:<address>`.
+2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show total cost; confirm.
+3. Obtain a token image (user-supplied or generated) as base64 JPEG/PNG ≤500KB.
+4. `POST /print` with name `Doge Supreme`, symbol `DSUP`, description, image, `chains: ["eip155:8453"]` → `{ token_id, payload }`.
+5. Map `payload` to a `send_calls` call (strip the `eip155:8453:` prefix from `to`, `data` ← `calldata`, `value` ← `value`), `chain: "base"`.
+6. User approves at the approval URL → `get_request_status(requestId)` until confirmed.
+7. Present `https://app.printr.money/trade/{token_id}`.
+
+### "What would it cost to launch a token on Base and Arbitrum?"
+
+1. `POST /print/quote` with `chains: ["eip155:8453", "eip155:42161"]` and the proposed `initial_buy`.
+2. Report the per-chain itemized cost and the combined total in USD and native tokens; no transaction is built or submitted.
+
+### "Did my token deploy on every chain?"
+
+1. Take the `token_id` from the earlier launch (or ask the user for it).
+2. `GET /tokens/{id}/deployments` → report which target chains are live, pending, or failed.
+3. Optionally `GET /tokens/{id}` for current metadata and the trade-page link.
+
+### "Launch it but I'm on Claude.ai with no terminal"
+
+1. Confirm `api-preview.printr.money` is on the Base MCP `web_request` allowlist; if not, tell the user the Printr API isn't whitelisted on this instance and stop.
+2. Run the quote and build via `web_request` (`POST /print/quote`, then `POST /print`).
+3. Submit the resulting `payload` via `send_calls` exactly as in the first example — `send_calls` needs no allowlist and works on chat-only surfaces.
+
+## Risks & Warnings
+
+- **low-liquidity** — A freshly launched token has no established market: price is set by the bonding curve and the creator's `initial_buy`, so early prices are thin and volatile and the token may never graduate. Quote the launch first and confirm the `initial_buy` amount with the user; never silently inflate the initial buy to force liquidity.
+- **irreversible** — A confirmed `send_calls` launch deploys the token and spends the `value` (in wei) plus gas; it cannot be undone. Before submitting, verify `payload.value` matches the quoted native-token cost and that the user's balance covers value plus gas, and require explicit user approval at the approval URL. Never auto-approve or resubmit on the user's behalf.
+
+## Notes
+
+- **API host** — `api-preview.printr.money` is Printr's public preview API host (the SDK default). All paths are served under `/v0` (e.g. `https://api-preview.printr.money/v0/print`). The app/trade UI lives at `app.printr.money`.
+- **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and the payload's `to` carry CAIP-2 chain references (`eip155:<chainId>`). Strip `eip155:<chainId>:` from `to` to get the raw `0x` address for `send_calls`.
+- **`value` units** — `payload.value` is already in wei; pass it through to `send_calls` unchanged.
+- **Image** — required, base64-encoded JPEG/PNG, max 500KB. PNGs are often too large; prefer a compressed JPEG.
+- **Out-of-scope chains** — Printr also launches on Solana, Unichain, Monad, Hyperliquid, and Mantle. Base MCP does not submit to those, so they are excluded from this plugin's `chains`.
+
+### EVM chain reference
+
+| Chain | CAIP-2 | Base MCP `chain` |
+|---|---|---|
+| Base | `eip155:8453` | `base` |
+| Arbitrum | `eip155:42161` | `arbitrum` |
+| Optimism | `eip155:10` | `optimism` |
+| Polygon | `eip155:137` | `polygon` |
+| BSC | `eip155:56` | `bsc` |
+| Avalanche | `eip155:43114` | `avalanche` |
+| Ethereum | `eip155:1` | `ethereum` |

--- a/skills/base-mcp/plugins/printr.md
+++ b/skills/base-mcp/plugins/printr.md
@@ -1,53 +1,32 @@
 ---
 title: "Printr Plugin"
-description: "Launch cross-chain tokens on Printr via its HTTP API, then submit the unsigned creation calldata through Base MCP send_calls."
-tags: [token-launches, memecoins, trading, discovery]
-name: printr
-version: 0.1.0
-integration: http-api
-chains: [base, arbitrum, optimism, polygon, bsc, avalanche, ethereum]
-requires:
-  shell: none
-  allowlist: [api-preview.printr.money]
-  externalMcp: null
-  cliPackage: null
-auth: none
-risk: [low-liquidity, irreversible]
+description: "Skill plugin reference for launching cross-chain tokens on Printr via its public HTTP API and submitting the unsigned creation calldata through Base MCP send_calls."
 ---
 
 # Printr Plugin
 
 > [!IMPORTANT]
-> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any Printr endpoint. The user's wallet address — required as the creator account and as the `send_calls` sender — is fetched lazily via `get_wallets` when needed. No Printr API key or login is required.
+> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any Printr endpoint. This plugin reads from and builds calldata over the Printr public API, then routes the actual launch through Base MCP's `send_calls` tool — it does not require the separate Printr MCP server. The creator address (used both as the launch creator and as the `send_calls` sender) comes from `get_wallets`.
 
-## Overview
+[Printr](https://printr.money) is a cross-chain token launchpad: a creator deploys a new token and seeds its initial liquidity in a single transaction. Printr spans several ecosystems, but this plugin covers only the EVM chains Base MCP can submit to. It quotes and builds an **unsigned EVM transaction** over the Printr HTTP API — Printr returns raw `{ to, calldata, value }` and never executes anything itself, so the user always signs and broadcasts through Base MCP `send_calls`.
 
-Printr is a cross-chain token launchpad: it lets a creator deploy a new token and seed its initial liquidity in a single transaction. Printr supports several ecosystems, but this plugin covers only the EVM subset that Base MCP can submit to — `base`, `arbitrum`, `optimism`, `polygon`, `bsc`, `avalanche`, and `ethereum` (Printr's Solana, Unichain, Monad, Hyperliquid, and Mantle support is out of scope here). The plugin reads cost estimates and builds an **unsigned EVM transaction payload** over the Printr HTTP API, then submits that payload as a `send_calls` batch through Base MCP. Printr returns raw `{ to, calldata, value }` calldata — it never executes the transaction itself, so the user always signs and broadcasts through Base MCP.
+No additional MCP server is required.
 
-## Surface Routing
+**Prerequisite:** `api-preview.printr.money` must be on the Base MCP `web_request` allowlist for the read/build calls. If requests are rejected, tell the user the Printr API isn't whitelisted on this instance and fall back to the harness's HTTP/fetch tool if one is available — do not hand-build the launch calldata. The `send_calls` submission needs no allowlist and works on every surface.
 
-Printr is a plain HTTP API plus a `send_calls` submission, so no shell or CLI is ever required. The Printr API host must be reachable for the read/build steps; the actual onchain write always goes through Base MCP `send_calls`, which works on every surface.
+**Chains:** `base` (8453), `arbitrum` (42161), `optimism` (10), `polygon` (137), `bsc` (56), `avalanche` (43114), `ethereum` (1). Printr's Solana, Unichain, Monad, Hyperliquid, and Mantle launches are out of scope — Base MCP can't submit to them.
 
-| Capability | Harness with HTTP/shell (Claude Code, Codex, Cursor) | Chat-only / shell-less (Claude.ai, ChatGPT) |
-|---|---|---|
-| Quote a launch (read) | Harness HTTP tool → `POST /print/quote` | Base MCP `web_request` → `POST /print/quote` |
-| Build a token (build calldata) | Harness HTTP tool → `POST /print` | Base MCP `web_request` → `POST /print` |
-| Look up a token / deployments (read) | Harness HTTP tool → `GET /tokens/{id}`, `GET /tokens/{id}/deployments` | Base MCP `web_request` → same GETs |
-| Submit the launch (write) | Base MCP `send_calls` | Base MCP `send_calls` |
+---
 
-On a shell-less / chat-only surface, `api-preview.printr.money` **must** be on the Base MCP `web_request` allowlist for the read/build steps to reach it. If `web_request` rejects that host, inform the user that the Printr API is not yet whitelisted on this MCP instance and stop — do not attempt to hand-build the launch calldata. The submission step (`send_calls`) is unaffected and needs no allowlist. The full execution decision tree (harness HTTP → `web_request` → user-paste, and the GET-only constraint on consumer surfaces) lives in [custom-plugins.md](../references/custom-plugins.md).
-
-## Endpoints
-
-All Printr endpoints are public (no auth) and are served under the `/v0` prefix on the Printr API host. Send and receive `application/json`.
+## API
 
 Base URL: `https://api-preview.printr.money/v0`
+
+All endpoints are public (no auth) and exchange `application/json`.
 
 ### `POST /print/quote`
 
 Estimate the cost of a launch before building it. No wallet address required.
-
-Request body:
 
 ```json
 {
@@ -57,17 +36,15 @@ Request body:
 }
 ```
 
-- `chains` — array of CAIP-2 chain IDs to deploy on (e.g. `eip155:8453` for Base).
-- `initial_buy` — creator's initial buy amount in the chain's native token (string).
+- `chains` — CAIP-2 chain IDs to deploy on (`eip155:8453` is Base).
+- `initial_buy` — creator's initial buy in the chain's native token, as a string.
 - `graduation_threshold_per_chain_usd` — bonding-curve graduation target per chain, in USD.
 
-Response: `{ "quote": { … } }` — an itemized cost breakdown per chain plus the total cost in USD and native tokens, and the number of tokens the `initial_buy` yields.
+Returns `{ "quote": { … } }` — an itemized per-chain cost breakdown, the total in USD and native token, and the token amount the `initial_buy` yields. Surface the total and the token amount to the user before building.
 
 ### `POST /print`
 
 Build the token and return the unsigned creation transaction. This does **not** deploy anything — it returns calldata you submit via `send_calls`.
-
-Request body (superset of the quote body):
 
 ```json
 {
@@ -75,7 +52,7 @@ Request body (superset of the quote body):
   "name": "My Token",
   "symbol": "MYT",
   "description": "A token launched via Printr",
-  "image": "<base64-encoded image, max 500KB, JPEG/PNG>",
+  "image": "<base64 JPEG/PNG, max 500KB>",
   "chains": ["eip155:8453"],
   "initial_buy": "0.1",
   "graduation_threshold_per_chain_usd": 5000,
@@ -83,12 +60,12 @@ Request body (superset of the quote body):
 }
 ```
 
-- `creator_accounts` — one CAIP-10 address (`eip155:<chainId>:0x…`) per chain being deployed to. Use the address from `get_wallets`.
+- `creator_accounts` — one CAIP-10 address (`eip155:<chainId>:0x…`) per chain. Use the address from `get_wallets`.
 - `name` (≤32 chars), `symbol` (≤10 chars), `description` (≤500 chars) — token metadata.
-- `image` — base64-encoded JPEG/PNG, max 500KB. Required by the launchpad.
-- `chains`, `initial_buy`, `graduation_threshold_per_chain_usd`, `external_links` — as above; `external_links` is optional.
+- `image` — base64 JPEG/PNG, max 500KB. Required. PNGs are often too large; prefer a compressed JPEG.
+- `external_links` — optional.
 
-Response (EVM home chain):
+Returns:
 
 ```json
 {
@@ -103,42 +80,48 @@ Response (EVM home chain):
 }
 ```
 
-- `token_id` — the cross-chain token ID (hex). The trade page is `https://app.printr.money/trade/{token_id}` — present this to the user after the launch confirms.
-- `payload` — the unsigned EVM transaction (see [`## Submission`](#submission) for the `send_calls` mapping). `to` is a CAIP-10 string; `value` is already in wei.
+- `token_id` — the cross-chain token ID. The trade page is `https://app.printr.money/trade/{token_id}`.
+- `payload` — the unsigned EVM transaction. `to` is a CAIP-10 string; `value` is already in wei. See [Orchestration](#orchestration) for the `send_calls` mapping.
 
 ### `GET /tokens/{id}`
 
-Look up a token's details by its `token_id`. Returns metadata, links, and current launch state.
+Look up a token's metadata, links, and launch state by `token_id`.
 
 ### `GET /tokens/{id}/deployments`
 
-Check per-chain deployment status for a token (which target chains are live, pending, or failed).
+Check per-chain deployment status (live, pending, or failed) for a token.
+
+---
 
 ## Orchestration
 
-The happy path goes quote → build → submit → confirm. Reads and the build call hit the Printr HTTP API; the write goes through Base MCP `send_calls`.
+The happy path is quote → build → submit → confirm. Reads and the build call hit the Printr API; the write goes through Base MCP `send_calls`.
 
-1. **Get the creator address.** Call `get_wallets` and take the user's EVM address. This is both the `creator_accounts` entry (as CAIP-10, `eip155:<chainId>:<address>`) and the `send_calls` sender.
-2. **Quote (optional but recommended).** `POST /print/quote` with `chains`, `initial_buy`, and `graduation_threshold_per_chain_usd`. Show the user the total cost in USD and native token, and the expected token amount from the initial buy. Confirm the user wants to proceed.
-3. **Build the token.** `POST /print` with the full body (creator account, name, symbol, description, base64 image, chains, initial buy, graduation threshold, optional links). Receive `{ token_id, payload, quote }`.
-4. **Validate before submit.** Confirm `payload.to` carries the expected `eip155:<chainId>:` prefix matching the requested chain, that `payload.calldata` is `0x`-prefixed, and that `payload.value` (wei) matches the quoted native-token cost. Confirm the user's balance covers `value` plus gas.
-5. **Submit via `send_calls`.** Map the payload (see [`## Submission`](#submission)) and call `send_calls` with the matching chain string. This returns an approval URL and a request ID.
-6. **Confirm.** The user approves at the returned approval URL (present as "Approve Transaction" — see [approval-mode.md](../references/approval-mode.md)). Poll `get_request_status(requestId)` until confirmed.
-7. **Surface the trade page.** Once confirmed, give the user `https://app.printr.money/trade/{token_id}`. Optionally call `GET /tokens/{id}/deployments` to report per-chain status.
+```text
+1. get_wallets → creator EVM address (only if not already cached)
+2. POST /print/quote → show total cost + token amount; confirm the user wants to proceed
+3. POST /print → { token_id, payload }
+4. Validate payload (chain prefix, 0x calldata, value matches quote, balance covers value + gas)
+5. send_calls (Base MCP) with the mapped call + chain string
+6. Open the approvalUrl; poll get_request_status only after the user acts
+7. Present https://app.printr.money/trade/{token_id}
+```
 
-## Submission
+Do not auto-launch. Always require an explicit confirmation of name, symbol, chains, and `initial_buy` before building, and explicit approval before submitting — a launch spends real funds and is irreversible.
 
-Target Base MCP tool: **`send_calls`** — an EIP-5792 batch of unsigned `{ to, value, data }` calls. Printr's `POST /print` response carries a single EVM call in `payload`; map it as follows:
+### Launch `send_calls`
 
-| `send_calls` call field | Source in Printr `payload` | Transform |
+The actual launch is a single Base MCP `send_calls` call built from `payload`. `send_calls` is an EIP-5792 batch of unsigned `{ to, value, data }` calls. Map the fields:
+
+| `send_calls` field | Source | Transform |
 |---|---|---|
-| `to` | `payload.to` | Strip the CAIP-10 prefix `eip155:<chainId>:` — keep the raw `0x…` address. |
-| `data` | `payload.calldata` | Pass through (already `0x`-prefixed hex). |
+| `to` | `payload.to` | Strip the `eip155:<chainId>:` prefix — keep the raw `0x…` address. |
+| `data` | `payload.calldata` | Pass through (already `0x`-prefixed). |
 | `value` | `payload.value` | Pass through (already in wei). |
 
-Derive the `send_calls` `chain` string from the `<chainId>` segment of `payload.to` (the CAIP-2 chain reference), mapping it to the Base MCP chain string:
+Derive the `chain` string from the `<chainId>` segment of `payload.to`:
 
-| CAIP-2 chain ID | Base MCP `chain` |
+| CAIP-2 | `chain` |
 |---|---|
 | `eip155:8453` | `base` |
 | `eip155:42161` | `arbitrum` |
@@ -148,58 +131,57 @@ Derive the `send_calls` `chain` string from the `<chainId>` segment of `payload.
 | `eip155:43114` | `avalanche` |
 | `eip155:1` | `ethereum` |
 
-Batching: if the launch ever returns more than one call (e.g. an ERC-20 approval ahead of the creation), submit them as a single `send_calls` batch with approvals **before** the action, preserving the response order. Today `POST /print` returns one creation call per EVM home chain. After submission, follow the approval/polling flow in [approval-mode.md](../references/approval-mode.md).
+Today `POST /print` returns one creation call per EVM home chain. If it ever returns more than one call (e.g. an ERC-20 approval before the creation), submit them as a single batch with approvals **before** the action, preserving the response order. The approval/polling pattern is in [`../references/approval-mode.md`](../references/approval-mode.md); batching details are in [`../references/batch-calls.md`](../references/batch-calls.md).
+
+---
 
 ## Example Prompts
 
-### "Launch a memecoin called Doge Supreme (DSUP) on Base"
-
+**Launch a memecoin called Doge Supreme (DSUP) on Base**
 1. `get_wallets` → EVM address; form the creator account `eip155:8453:<address>`.
-2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show total cost; confirm.
-3. Obtain a token image (user-supplied or generated) as base64 JPEG/PNG ≤500KB.
+2. `POST /print/quote` with `chains: ["eip155:8453"]` and the user's `initial_buy` → show total cost and token amount; confirm.
+3. Get a token image (user-supplied or generated) as base64 JPEG/PNG ≤500KB.
 4. `POST /print` with name `Doge Supreme`, symbol `DSUP`, description, image, `chains: ["eip155:8453"]` → `{ token_id, payload }`.
-5. Map `payload` to a `send_calls` call (strip the `eip155:8453:` prefix from `to`, `data` ← `calldata`, `value` ← `value`), `chain: "base"`.
-6. User approves at the approval URL → `get_request_status(requestId)` until confirmed.
+5. Map `payload` to a `send_calls` call (strip `eip155:8453:` from `to`, `data` ← `calldata`, `value` ← `value`), `chain: "base"`.
+6. Open the approval URL; poll `get_request_status` once the user approves.
 7. Present `https://app.printr.money/trade/{token_id}`.
 
-### "What would it cost to launch a token on Base and Arbitrum?"
-
+**What would it cost to launch a token on Base and Arbitrum?**
 1. `POST /print/quote` with `chains: ["eip155:8453", "eip155:42161"]` and the proposed `initial_buy`.
-2. Report the per-chain itemized cost and the combined total in USD and native tokens; no transaction is built or submitted.
+2. Report the per-chain itemized cost and the combined total in USD and native token. Build nothing.
 
-### "Did my token deploy on every chain?"
-
+**Did my token deploy on every chain?**
 1. Take the `token_id` from the earlier launch (or ask the user for it).
-2. `GET /tokens/{id}/deployments` → report which target chains are live, pending, or failed.
+2. `GET /tokens/{id}/deployments` → report which chains are live, pending, or failed.
 3. Optionally `GET /tokens/{id}` for current metadata and the trade-page link.
 
-### "Launch it but I'm on Claude.ai with no terminal"
-
-1. Confirm `api-preview.printr.money` is on the Base MCP `web_request` allowlist; if not, tell the user the Printr API isn't whitelisted on this instance and stop.
+**Launch it but I'm on Claude.ai with no terminal**
+1. Confirm `api-preview.printr.money` is on the Base MCP `web_request` allowlist; if not, tell the user the Printr API isn't whitelisted here and stop.
 2. Run the quote and build via `web_request` (`POST /print/quote`, then `POST /print`).
-3. Submit the resulting `payload` via `send_calls` exactly as in the first example — `send_calls` needs no allowlist and works on chat-only surfaces.
+3. Submit the `payload` via `send_calls` exactly as in the first example — `send_calls` needs no allowlist and works on chat-only surfaces.
 
-## Risks & Warnings
+---
 
-- **low-liquidity** — A freshly launched token has no established market: price is set by the bonding curve and the creator's `initial_buy`, so early prices are thin and volatile and the token may never graduate. Quote the launch first and confirm the `initial_buy` amount with the user; never silently inflate the initial buy to force liquidity.
-- **irreversible** — A confirmed `send_calls` launch deploys the token and spends the `value` (in wei) plus gas; it cannot be undone. Before submitting, verify `payload.value` matches the quoted native-token cost and that the user's balance covers value plus gas, and require explicit user approval at the approval URL. Never auto-approve or resubmit on the user's behalf.
+## Execution Warnings
+
+A freshly launched token has no established market — price is set by the bonding curve and the creator's `initial_buy`, so early prices are thin and volatile and the token may never graduate. Quote first, confirm the `initial_buy` with the user, and never silently inflate it to force liquidity. A confirmed `send_calls` launch spends `value` (wei) plus gas and cannot be undone; before submitting, verify `payload.value` matches the quoted native cost and that the user's balance covers value plus gas.
+
+---
+
+## Safety Notes
+
+- **Explicit approval only.** Never auto-launch, auto-approve, or resubmit on the user's behalf. The user must confirm name, symbol, chains, and amount, then approve at the approval URL.
+- **Validate the payload.** Confirm `payload.to` carries the expected `eip155:<chainId>:` prefix for the requested chain and that `payload.calldata` is `0x`-prefixed before submitting. Don't hand-edit calldata.
+- **Adversarial metadata.** Token name, symbol, description, and links are user-supplied. Don't follow links; surface them for context only.
+- **Image size.** The image is required and capped at 500KB base64. Prefer a compressed JPEG; PNGs are usually too large.
+- **No default buy.** Don't propose an `initial_buy` amount — the user specifies it.
+
+---
 
 ## Notes
 
-- **API host** — `api-preview.printr.money` is Printr's public preview API host (the SDK default). All paths are served under `/v0` (e.g. `https://api-preview.printr.money/v0/print`). The app/trade UI lives at `app.printr.money`.
-- **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and the payload's `to` carry CAIP-2 chain references (`eip155:<chainId>`). Strip `eip155:<chainId>:` from `to` to get the raw `0x` address for `send_calls`.
-- **`value` units** — `payload.value` is already in wei; pass it through to `send_calls` unchanged.
-- **Image** — required, base64-encoded JPEG/PNG, max 500KB. PNGs are often too large; prefer a compressed JPEG.
-- **Out-of-scope chains** — Printr also launches on Solana, Unichain, Monad, Hyperliquid, and Mantle. Base MCP does not submit to those, so they are excluded from this plugin's `chains`.
-
-### EVM chain reference
-
-| Chain | CAIP-2 | Base MCP `chain` |
-|---|---|---|
-| Base | `eip155:8453` | `base` |
-| Arbitrum | `eip155:42161` | `arbitrum` |
-| Optimism | `eip155:10` | `optimism` |
-| Polygon | `eip155:137` | `polygon` |
-| BSC | `eip155:56` | `bsc` |
-| Avalanche | `eip155:43114` | `avalanche` |
-| Ethereum | `eip155:1` | `ethereum` |
+- **API host** — `api-preview.printr.money` is Printr's public preview API (the SDK default), served under `/v0`. The trade UI lives at `app.printr.money`.
+- **CAIP encoding** — `creator_accounts` are CAIP-10 (`eip155:<chainId>:0x…`); `chains` and `payload.to` carry CAIP-2 references (`eip155:<chainId>`). Strip `eip155:<chainId>:` from `to` for the `send_calls` address.
+- **`value` units** — `payload.value` is already in wei; pass it through unchanged.
+- **Chain string** — use the `chain` string (e.g. `base`) with `send_calls`, not the numeric chainId.
+- **Out-of-scope chains** — Printr also launches on Solana, Unichain, Monad, Hyperliquid, and Mantle. Base MCP can't submit to those, so they're excluded here.


### PR DESCRIPTION
## What

Adds a Base MCP plugin for [Printr](https://printr.money), a cross-chain token launchpad. The plugin quotes and builds an unsigned EVM creation transaction over Printr's public HTTP API (`api-preview.printr.money/v0`, no auth), then submits the raw `{ to, value, data }` through Base MCP `send_calls`, so the user signs via their Base Account. `integration: http-api`, no extra MCP install.

`http-api`, not `external-mcp`: Printr ships its own MCP server, but this plugin talks to the public API directly so the write always routes through `send_calls` (the smart-wallet approval gate) rather than Printr's own signer.

## Changes

**`plugins/printr.md`**: `http-api`, `auth: none`, chains `base, arbitrum, optimism, polygon, bsc, avalanche, ethereum`.
- Full spec frontmatter plus `## Surface Routing`, `## Endpoints`, `## Orchestration`, `## Submission`, `## Risks & Warnings`.
- `send_calls` mapping: `to` strips the CAIP-2 prefix; `calldata` is base64-decoded to `0x` hex; `value` is decimal-wei to hex.
- `initial_buy` is a `VariableInitialBuy` object (`spend_native` wei / `spend_usd` / `supply_percent`); `graduation_threshold_per_chain_usd` is at least 15000; `image` is raw base64 (no `data:` prefix).
