### PR TITLE
feat(plugin-spec): support local (stdio) MCP provisioning

### DIFF
--- a/skills/base-mcp/references/plugin-spec.md
+++ b/skills/base-mcp/references/plugin-spec.md
@@ -37,7 +37,7 @@ All optional. Defaults: `shell: none`, `allowlist: []`, `externalMcp: null`, `cl
 |---|---|---|
 | `requires.shell` | `required \| optional \| none` | Whether shell/terminal access is needed. |
 | `requires.allowlist` | string[] | Hosts that must be in the Base MCP `web_request` allowlist. |
-| `requires.externalMcp` | `{ name, transport: http\|sse, url } \| { name, transport: stdio, command, args, env? } \| null` | Separate MCP server the plugin depends on. `transport: http \| sse` (remote, hosted) needs `url`; `transport: stdio` (local, launched on the user's machine) needs `command`, `args`, and optional `env`. See [MCP Provisioning](#mcp-provisioning). |
+| `requires.externalMcp` | `{ name, transport?: http\|sse, url } \| { name, transport: stdio, command, args, env? } \| null` | Separate MCP server the plugin depends on. `transport: http \| sse` (remote, hosted) needs `url`; `transport: stdio` (local, launched on the user's machine) needs `command`, `args`, and optional `env`. `transport` is **optional for remote MCPs** and defaults to `http` when `url` is present (so the legacy `{ name, url }` shape stays valid); it is **required for `stdio`**. See [MCP Provisioning](#mcp-provisioning). |
 | `requires.cliPackage` | string \| null | npx/uvx invocation for a CLI the agent **shells out to per call** (e.g. `npx @morpho-org/cli@latest`). This is **not** for an MCP server you register once — use `externalMcp` with `transport: stdio` for that. |
 | `auth` | `none \| api-key \| siwe-jwt \| oauth-on-install` | Auth model used by the plugin's external services. |
 | `risk` | string[] | Risk tags that trigger `## Risks & Warnings`. See the tag list below. |
@@ -64,7 +64,7 @@ Derive every value from the protocol's actual behavior — don't copy another pl
   - `none` — the plugin never needs a shell (pure HTTP API or external MCP).
 - **`requires.allowlist`** — every external host the plugin fetches over HTTP. These must be on the Base MCP `web_request` allowlist for chat-only surfaces to reach them. Leave `[]` for `cli-only` and `external-mcp` plugins that make no direct HTTP calls.
 - **`requires.externalMcp`** — set when the plugin depends on a separate MCP server; otherwise `null`. Pick the `transport` first, then fill the matching fields (full schema and guardrails in [MCP Provisioning](#mcp-provisioning)):
-  - **Remote MCP** (`transport: http` or `sse`) — a hosted server the agent connects to over the network. Provide `url` (e.g. `https://mcp.opensea.io/mcp`). This is the lower-trust case: the server runs on the partner's infra, not the user's machine.
+  - **Remote MCP** (`transport: http` or `sse`) — a hosted server the agent connects to over the network. Provide `url` (e.g. `https://mcp.opensea.io/mcp`). This is the lower-trust case: the server runs on the partner's infra, not the user's machine. `transport` is optional here and **defaults to `http` when `url` is present**, so the legacy `{ name, url }` shape remains valid; set `transport: sse` explicitly when needed.
   - **Local MCP** (`transport: stdio`) — a server **launched on the user's machine** (typically via `npx`/`uvx`). Provide `command`, `args` (with a **pinned** version, never `@latest`), and `env` (required env-var **names only**, never values). A local MCP is **arbitrary code execution on the user's machine**, so it also requires the `local-exec` risk tag and a `## Surface Routing` stop on shell-less surfaces.
 - **`requires.cliPackage`** — the exact invocation string for a CLI the agent **shells out to per call** (e.g. `npx @morpho-org/cli@latest`, or a full `uvx --from <spec> <cmd>` command); otherwise `null`. If the package is an **MCP server** (registered once and then queried as tools, not invoked per call), leave `cliPackage: null` and use `requires.externalMcp` with `transport: stdio` instead.
 - **`auth`**:
@@ -166,6 +166,10 @@ risk: [local-exec]                           # required for any stdio MCP
 ### `## Installation` content
 
 Provide a copy-pasteable MCP client config snippet for the common harnesses (Claude Code, Codex, Cursor / JSON-config) — and, for remote MCPs that support it, Claude.ai / ChatGPT connectors. For local (`stdio`) MCPs the snippet is the standard `command`/`args`/`env` client entry; show the pinned version and name each required env var (without values). CLIs invoked per call via `npx`/`uvx` need no install step — say so and show the invocation instead.
+
+### Backwards compatibility
+
+This schema is **additive**. The pre-`transport` shape `externalMcp: { name, url }` is still valid and is read as a remote `http` MCP (`transport` defaults to `http` when `url` is present). Existing `external-mcp` plugins need no change to keep working; add `transport` on the next meaningful edit (and bump `version`), the same way heading-name synonyms are migrated. New plugins should set `transport` explicitly, and `stdio` always requires it. A future validator should treat a missing `transport` as an inferred default (warn), not an error.
 
 ---
 

--- a/skills/base-mcp/references/plugin-spec.md
+++ b/skills/base-mcp/references/plugin-spec.md
@@ -37,8 +37,8 @@ All optional. Defaults: `shell: none`, `allowlist: []`, `externalMcp: null`, `cl
 |---|---|---|
 | `requires.shell` | `required \| optional \| none` | Whether shell/terminal access is needed. |
 | `requires.allowlist` | string[] | Hosts that must be in the Base MCP `web_request` allowlist. |
-| `requires.externalMcp` | `{ name, url } \| null` | Separate MCP server the plugin depends on. |
-| `requires.cliPackage` | string \| null | npx/uvx invocation string (e.g. `@morpho-org/cli@latest`). |
+| `requires.externalMcp` | `{ name, transport, … } \| null` | Separate MCP server the plugin depends on. `transport: http \| sse` (remote, hosted) needs `url`; `transport: stdio` (local, launched on the user's machine) needs `command`, `args`, and optional `env`. See [MCP Provisioning](#mcp-provisioning). |
+| `requires.cliPackage` | string \| null | npx/uvx invocation for a CLI the agent **shells out to per call** (e.g. `npx @morpho-org/cli@latest`). This is **not** for an MCP server you register once — use `externalMcp` with `transport: stdio` for that. |
 | `auth` | `none \| api-key \| siwe-jwt \| oauth-on-install` | Auth model used by the plugin's external services. |
 | `risk` | string[] | Risk tags that trigger `## Risks & Warnings`. See the tag list below. |
 
@@ -63,8 +63,10 @@ Derive every value from the protocol's actual behavior — don't copy another pl
   - `optional` — a shell unlocks a richer path (a CLI, or a tx-builder), but the plugin still works without one via an HTTP/MCP/UI fallback.
   - `none` — the plugin never needs a shell (pure HTTP API or external MCP).
 - **`requires.allowlist`** — every external host the plugin fetches over HTTP. These must be on the Base MCP `web_request` allowlist for chat-only surfaces to reach them. Leave `[]` for `cli-only` and `external-mcp` plugins that make no direct HTTP calls.
-- **`requires.externalMcp`** — `{ name, url }` when the plugin depends on a separate MCP server; otherwise `null`.
-- **`requires.cliPackage`** — the exact invocation string for the CLI (e.g. `npx @morpho-org/cli@latest`, or a full `uvx --from <spec> <cmd>` command); otherwise `null`.
+- **`requires.externalMcp`** — set when the plugin depends on a separate MCP server; otherwise `null`. Pick the `transport` first, then fill the matching fields (full schema and guardrails in [MCP Provisioning](#mcp-provisioning)):
+  - **Remote MCP** (`transport: http` or `sse`) — a hosted server the agent connects to over the network. Provide `url` (e.g. `https://mcp.opensea.io/mcp`). This is the lower-trust case: the server runs on the partner's infra, not the user's machine.
+  - **Local MCP** (`transport: stdio`) — a server **launched on the user's machine** (typically via `npx`/`uvx`). Provide `command`, `args` (with a **pinned** version, never `@latest`), and `env` (required env-var **names only**, never values). A local MCP is **arbitrary code execution on the user's machine**, so it also requires the `local-exec` risk tag and a `## Surface Routing` stop on shell-less surfaces.
+- **`requires.cliPackage`** — the exact invocation string for a CLI the agent **shells out to per call** (e.g. `npx @morpho-org/cli@latest`, or a full `uvx --from <spec> <cmd>` command); otherwise `null`. If the package is an **MCP server** (registered once and then queried as tools, not invoked per call), leave `cliPackage: null` and use `requires.externalMcp` with `transport: stdio` instead.
 - **`auth`**:
   - `none` — public endpoints, no credentials.
   - `api-key` — a static API key / header is required on requests.
@@ -78,6 +80,7 @@ Derive every value from the protocol's actual behavior — don't copy another pl
   | `low-liquidity` | Thin markets — price impact, failed fills, rug risk (e.g. fresh token launches). |
   | `pii` | The plugin handles personal/sensitive data (emails, card numbers, OTPs, 3DS codes). |
   | `irreversible` | Actions can't be undone once submitted (most onchain writes; flag when worth emphasizing). |
+  | `local-exec` | The plugin runs partner code on the user's machine — a local (`transport: stdio`) MCP server or a `cliPackage`. Required whenever `externalMcp.transport: stdio` is set. |
 
 ### Example frontmatter
 
@@ -110,9 +113,59 @@ The `integration` field classifies how the plugin reaches Base MCP. Choose the m
 |---|---|---|---|
 | `cli-only` | All calls go through a shell CLI. No HTTP API, no external MCP. | `## Commands`; `shell: required`; `cliPackage` set | Aerodrome |
 | `http-api` | Plugin calls an HTTP API (via `web_request` or harness HTTP tool) to read data or build calldata. | `## Endpoints`; list `allowlist` hosts | Moonwell, Uniswap, Bankr |
-| `external-mcp` | Plugin relies on a separate MCP server. The agent reads that MCP's own tool catalog — this plugin file does **not** enumerate its tools. | `## Detection` + `## Installation`; `externalMcp` set; **omit** `## Endpoints`/`## Commands` | Virtuals |
+| `external-mcp` | Plugin relies on a separate MCP server — **remote** (hosted, `transport: http\|sse`) or **local** (launched on the user's machine, `transport: stdio`). The agent reads that MCP's own tool catalog — this plugin file does **not** enumerate its tools. | `## Detection` + `## Installation`; `externalMcp` set (+ `local-exec` risk for `stdio`); **omit** `## Endpoints`/`## Commands` | Virtuals (remote), Veil (local stdio) |
 | `semantic-base-tool` | Plugin composes Base MCP's higher-level semantic tools (`swap`, `send`) rather than producing raw calldata. | `## Submission` names the semantic tool | *(future)* |
 | `hybrid` | Combines two or more paths with surface-dependent routing. | union of the above; document the routing matrix in `## Surface Routing` | Avantis, Morpho |
+
+---
+
+## MCP Provisioning
+
+`external-mcp` plugins (and `hybrid` plugins with an MCP path) depend on a separate MCP server. That server is reached one of two ways, set by `externalMcp.transport`. Choose the transport first; it determines the rest of the `externalMcp` object, the `## Installation` snippet, and the risk tags.
+
+### Remote MCP (`transport: http | sse`)
+
+A hosted server the agent connects to over the network. The partner runs it on their own infrastructure.
+
+```yaml
+requires:
+  externalMcp:
+    name: opensea
+    transport: http          # or sse
+    url: https://mcp.opensea.io/mcp
+  shell: none
+auth: oauth-on-install       # or api-key / none, as the server requires
+```
+
+- `url` is required; `command`/`args`/`env` are omitted.
+- No code runs on the user's machine, so no `local-exec` risk is implied (other risks still apply on their own merits).
+- Works on chat-only surfaces if the harness supports remote MCP connectors; otherwise `## Surface Routing` states the fallback.
+
+### Local MCP (`transport: stdio`)
+
+A server **launched on the user's machine**, typically via `npx`/`uvx`, communicating over stdio. The harness registers it once in its MCP client config.
+
+```yaml
+requires:
+  externalMcp:
+    name: veil-cash
+    transport: stdio
+    command: npx
+    args: ["-y", "@veil-cash/mcp@1.2.3"]   # PIN the version — never @latest
+    env: [VEIL_KEY]                          # required env-var NAMES only — never values
+  shell: required
+risk: [local-exec]                           # required for any stdio MCP
+```
+
+- `command` + `args` are required; `url` is omitted.
+- **Pin the version.** A floating `@latest` lets the partner ship new code to every user with no review — pin an exact version and bump it in a tracked PR (same discipline as `version`).
+- **`env` lists names only.** Never put secret values in the plugin file; the user provisions them. Document what each is and how to obtain it in `## Auth`.
+- **`local-exec` risk is mandatory.** Running a partner package is arbitrary code execution on the user's machine — a categorically larger trust surface than a remote MCP or an `http-api` plugin. `## Risks & Warnings` must spell out that the user is installing and running third-party code.
+- **`## Surface Routing` must stop on shell-less / consumer surfaces.** A local MCP only runs where there is a shell and a user-managed MCP config (e.g. Claude Code, Codex, Cursor). On Claude.ai / ChatGPT the agent must stop and tell the user the integration requires a local install — it must not improvise a `web_request` workaround.
+
+### `## Installation` content
+
+Provide a copy-pasteable MCP client config snippet for the common harnesses (Claude Code, Codex, Cursor / JSON-config) — and, for remote MCPs that support it, Claude.ai / ChatGPT connectors. For local (`stdio`) MCPs the snippet is the standard `command`/`args`/`env` client entry; show the pinned version and name each required env var (without values). CLIs invoked per call via `npx`/`uvx` need no install step — say so and show the invocation instead.
 
 ---
 
@@ -125,7 +178,7 @@ The `integration` field classifies how the plugin reaches Base MCP. Choose the m
 - **Harness HTTP tool** — when the harness has a direct fetch/curl/shell (Claude Code, Codex, Cursor), use it first for HTTP calls: any method, no allowlist needed.
 - **Base MCP `web_request`** — a server-side fetch for chat-only surfaces (Claude.ai, ChatGPT). Only reaches hosts on the `web_request` allowlist.
 - **Shell / CLI** — runs a `requires.cliPackage` command. Needs `requires.shell` ≠ `none`.
-- **External MCP** — the agent calls tools advertised by a separate MCP server (`requires.externalMcp`), reading their descriptions from the MCP itself.
+- **External MCP** — the agent calls tools advertised by a separate MCP server (`requires.externalMcp`), reading their descriptions from the MCP itself. The server is either remote (hosted `url`) or local (`stdio`, launched on the user's machine); see [MCP Provisioning](#mcp-provisioning).
 - **UI / user-paste fallback** — for chat-only surfaces that can't make the call directly: link the user to the protocol's web UI, or (GET-only) construct a URL and ask the user to paste it back so the agent may fetch it.
 
 The full decision tree (harness HTTP → `web_request` → user-paste), and the GET-only constraint on consumer surfaces, live in [custom-plugins.md](custom-plugins.md). Reference it from `## Surface Routing` rather than restating it.
@@ -167,7 +220,7 @@ Sections appear in this order. **R** = required in every plugin. **C** = conditi
 - **`> [!IMPORTANT]` onboarding callout** — one line telling the agent to run Base MCP onboarding (defined in `SKILL.md`) before any plugin call. Note any session prerequisite here too (e.g. "authenticate once per session — see `## Auth`").
 - **`## Overview`** — one paragraph: what the protocol is, which chain(s) it runs on, and a one-line routing statement (what the plugin reads/builds and which Base MCP tool it lands on). Say whether it returns **unsigned calldata** or executes through a semantic tool.
 - **`## Detection`** *(external-mcp / hybrid-with-MCP)* — how the agent tells whether the required MCP/tooling is present, e.g. "if no `xyz_*` tools are exposed, the MCP isn't installed → see `## Installation`." Don't reach the protocol's HTTP API directly when the MCP is the supported path.
-- **`## Installation`** *(externalMcp or cliPackage set)* — per-harness install steps (Claude Code, Codex, Cursor / JSON-config, Claude.ai, ChatGPT) plus a config snippet for MCPs. CLIs that run via `npx`/`uvx` need no install step — say so and show the invocation.
+- **`## Installation`** *(externalMcp or cliPackage set)* — per-harness install steps (Claude Code, Codex, Cursor / JSON-config, Claude.ai, ChatGPT) plus a config snippet for MCPs. For `externalMcp` follow [MCP Provisioning](#mcp-provisioning): a remote (`http`/`sse`) connector entry, or a local (`stdio`) `command`/`args`/`env` entry with a pinned version. CLIs that run via `npx`/`uvx` need no install step — say so and show the invocation.
 - **`## Auth`** *(auth ≠ none)* — the exact credential or flow: the header name for `api-key`; the ordered step sequence for `siwe-jwt` (get address → start → sign → complete → reuse token), token lifetime, and how to refresh; the connector setup for `oauth-on-install`.
 - **`## Surface Routing`** — a table mapping each capability (typically split read vs write) × surface → execution path, using the [Runtime Routing Primitives](#runtime-routing-primitives). **Always** state what happens on a shell-less / chat-only surface: the fallback, or an explicit "stop." For `cli-only`, state plainly that no-shell surfaces are unsupported and the agent must not improvise a `web_request`/paste workaround.
 - **`## Endpoints` / `## Commands`** — `http-api` → `## Endpoints`: each endpoint with method, URL, parameters, and response shape. `cli-only` / the CLI path of `hybrid` → `## Commands`: each command with flags and output shape. `external-mcp` omits both — the agent reads the MCP's catalog at runtime.
@@ -238,10 +291,10 @@ chains: [base]
 requires:
   shell: none
   allowlist: []
-  externalMcp: null
+  externalMcp: null   # remote: { name, transport: http|sse, url }; local: { name, transport: stdio, command, args, env } — see MCP Provisioning
   cliPackage: null
 auth: none
-risk: []
+risk: []            # add local-exec when externalMcp.transport: stdio
 ---
 
 # <Protocol> Plugin
@@ -287,6 +340,7 @@ Before opening a PR, confirm:
 - [ ] `> [!IMPORTANT]` onboarding callout is first.
 - [ ] `## Overview`, `## Surface Routing`, `## Orchestration`, `## Submission`, `## Example Prompts` all present (the **R** sections).
 - [ ] Conditional sections included where flags demand: `## Detection`/`## Installation` for external MCPs, `## Auth` when `auth != none`, `## Risks & Warnings` when `risk` is non-empty, `## Endpoints` (http-api) or `## Commands` (cli-only / CLI path).
+- [ ] For `externalMcp`: `transport` set, with the matching fields (`url` for `http`/`sse`; `command`/`args`/`env` for `stdio`). Local (`stdio`) MCPs pin an exact version (no `@latest`), list `env` names only, carry the `local-exec` risk tag, and `## Surface Routing` stops on shell-less surfaces.
 - [ ] `## Surface Routing` states the shell-less / chat-only behavior (fallback or stop).
 - [ ] Heading names are canonical — no synonyms (see [Canonical heading names](#canonical-heading-names)).
 - [ ] `## Submission` names a concrete Base MCP tool and shows the mapping into it.

--- a/skills/base-mcp/references/plugin-spec.md
+++ b/skills/base-mcp/references/plugin-spec.md
@@ -64,7 +64,7 @@ Derive every value from the protocol's actual behavior — don't copy another pl
   - `none` — the plugin never needs a shell (pure HTTP API or external MCP).
 - **`requires.allowlist`** — every external host the plugin fetches over HTTP. These must be on the Base MCP `web_request` allowlist for chat-only surfaces to reach them. Leave `[]` for `cli-only` and `external-mcp` plugins that make no direct HTTP calls.
 - **`requires.externalMcp`** — set when the plugin depends on a separate MCP server; otherwise `null`. Pick the `transport` first, then fill the matching fields (full schema and guardrails in [MCP Provisioning](#mcp-provisioning)):
-  - **Remote MCP** (`transport: http` or `sse`) — a hosted server the agent connects to over the network. Provide `url` (e.g. `https://mcp.opensea.io/mcp`). This is the lower-trust case: the server runs on the partner's infra, not the user's machine. `transport` is optional here and **defaults to `http` when `url` is present**, so the legacy `{ name, url }` shape remains valid; set `transport: sse` explicitly when needed.
+  - **Remote MCP** (`transport: http` or `sse`) — a hosted server the agent connects to over the network. Provide `url` (e.g. `https://mcp.<protocol>.example/mcp`). This is the lower-trust case: the server runs on the partner's infra, not the user's machine. `transport` is optional here and **defaults to `http` when `url` is present**, so the legacy `{ name, url }` shape remains valid; set `transport: sse` explicitly when needed.
   - **Local MCP** (`transport: stdio`) — a server **launched on the user's machine** (typically via `npx`/`uvx`). Provide `command`, `args` (with a **pinned** version, never `@latest`), and `env` (required env-var **names only**, never values). A local MCP is **arbitrary code execution on the user's machine**, so it also requires the `local-exec` risk tag and a `## Surface Routing` stop on shell-less surfaces.
 - **`requires.cliPackage`** — the exact invocation string for a CLI the agent **shells out to per call** (e.g. `npx @morpho-org/cli@latest`, or a full `uvx --from <spec> <cmd>` command); otherwise `null`. If the package is an **MCP server** (registered once and then queried as tools, not invoked per call), leave `cliPackage: null` and use `requires.externalMcp` with `transport: stdio` instead.
 - **`auth`**:
@@ -113,7 +113,7 @@ The `integration` field classifies how the plugin reaches Base MCP. Choose the m
 |---|---|---|---|
 | `cli-only` | All calls go through a shell CLI. No HTTP API, no external MCP. | `## Commands`; `shell: required`; `cliPackage` set | Aerodrome |
 | `http-api` | Plugin calls an HTTP API (via `web_request` or harness HTTP tool) to read data or build calldata. | `## Endpoints`; list `allowlist` hosts | Moonwell, Uniswap, Bankr |
-| `external-mcp` | Plugin relies on a separate MCP server — **remote** (hosted, `transport: http\|sse`) or **local** (launched on the user's machine, `transport: stdio`). The agent reads that MCP's own tool catalog — this plugin file does **not** enumerate its tools. | `## Detection` + `## Installation`; `externalMcp` set (+ `local-exec` risk for `stdio`); **omit** `## Endpoints`/`## Commands` | Virtuals (remote), Veil (local stdio) |
+| `external-mcp` | Plugin relies on a separate MCP server — **remote** (hosted, `transport: http\|sse`) or **local** (launched on the user's machine, `transport: stdio`). The agent reads that MCP's own tool catalog — this plugin file does **not** enumerate its tools. | `## Detection` + `## Installation`; `externalMcp` set (+ `local-exec` risk for `stdio`); **omit** `## Endpoints`/`## Commands` | remote (`http`/`sse`), local (`stdio`) |
 | `semantic-base-tool` | Plugin composes Base MCP's higher-level semantic tools (`swap`, `send`) rather than producing raw calldata. | `## Submission` names the semantic tool | *(future)* |
 | `hybrid` | Combines two or more paths with surface-dependent routing. | union of the above; document the routing matrix in `## Surface Routing` | Avantis, Morpho |
 
@@ -130,9 +130,9 @@ A hosted server the agent connects to over the network. The partner runs it on t
 ```yaml
 requires:
   externalMcp:
-    name: opensea
+    name: <protocol>
     transport: http          # or sse
-    url: https://mcp.opensea.io/mcp
+    url: https://mcp.<protocol>.example/mcp
   shell: none
 auth: oauth-on-install       # or api-key / none, as the server requires
 ```
@@ -148,11 +148,11 @@ A server **launched on the user's machine**, typically via `npx`/`uvx`, communic
 ```yaml
 requires:
   externalMcp:
-    name: veil-cash
+    name: <protocol>
     transport: stdio
     command: npx
-    args: ["-y", "@veil-cash/mcp@1.2.3"]   # PIN the version — never @latest
-    env: [VEIL_KEY]                          # required env-var NAMES only — never values
+    args: ["-y", "@<org>/mcp@1.2.3"]        # PIN the version — never @latest
+    env: [PROTOCOL_API_KEY]                  # required env-var NAMES only — never values
   shell: required
 risk: [local-exec]                           # required for any stdio MCP
 ```

--- a/skills/base-mcp/references/plugin-spec.md
+++ b/skills/base-mcp/references/plugin-spec.md
@@ -37,7 +37,7 @@ All optional. Defaults: `shell: none`, `allowlist: []`, `externalMcp: null`, `cl
 |---|---|---|
 | `requires.shell` | `required \| optional \| none` | Whether shell/terminal access is needed. |
 | `requires.allowlist` | string[] | Hosts that must be in the Base MCP `web_request` allowlist. |
-| `requires.externalMcp` | `{ name, transport, … } \| null` | Separate MCP server the plugin depends on. `transport: http \| sse` (remote, hosted) needs `url`; `transport: stdio` (local, launched on the user's machine) needs `command`, `args`, and optional `env`. See [MCP Provisioning](#mcp-provisioning). |
+| `requires.externalMcp` | `{ name, transport: http\|sse, url } \| { name, transport: stdio, command, args, env? } \| null` | Separate MCP server the plugin depends on. `transport: http \| sse` (remote, hosted) needs `url`; `transport: stdio` (local, launched on the user's machine) needs `command`, `args`, and optional `env`. See [MCP Provisioning](#mcp-provisioning). |
 | `requires.cliPackage` | string \| null | npx/uvx invocation for a CLI the agent **shells out to per call** (e.g. `npx @morpho-org/cli@latest`). This is **not** for an MCP server you register once — use `externalMcp` with `transport: stdio` for that. |
 | `auth` | `none \| api-key \| siwe-jwt \| oauth-on-install` | Auth model used by the plugin's external services. |
 | `risk` | string[] | Risk tags that trigger `## Risks & Warnings`. See the tag list below. |


### PR DESCRIPTION
## What

Extends the plugin spec so `external-mcp` plugins can declare an MCP server that runs **locally on the user's machine** (stdio), not just a **remote hosted** server. Today `requires.externalMcp` is `{ name, url }`, which only models a remote URL — there's no clean way to describe an MCP launched via `npx`/`uvx` over stdio (which has a command, not a URL). Authors have had to resort to `url: null`, and `cliPackage` (meant for per-call CLIs) is the wrong fit.

## Changes

- **Transport-tagged `requires.externalMcp`:** `{ name, transport, … }` where `transport` is:
  - `http` / `sse` — remote, hosted; needs `url`.
  - `stdio` — local, launched on the user's machine; needs `command`, `args`, and optional `env`.
- **New `## MCP Provisioning` section** documenting both transports with the install-snippet shape for each.
- **New `local-exec` risk tag**, required whenever `externalMcp.transport: stdio` (running partner code locally is a larger trust surface than a remote MCP or `http-api`).
- **stdio guardrails:** pin the package version (no `@latest`), list `env` var **names only** (never values), and `## Surface Routing` must stop on shell-less / chat-only surfaces.
- **`cliPackage` clarified** as a CLI the agent shells out to *per call*, distinct from a *registered* stdio MCP server.
- Authoring checklist + skeleton template updated; `## Installation` and Runtime Routing Primitives cross-reference the new section.

## Why

Several MCP integrations ship as local stdio servers (npx/uvx packages). Without a first-class way to express that, the frontmatter can't drive correct installation, risk signalling, or surface routing. This makes the local vs remote distinction explicit and adds the guardrails that local execution warrants.

## Notes

Spec/docs only — no plugin behavior changes. Existing remote `external-mcp` plugins map to `transport: http` with their current `url`.
