### PR TITLE
security: remove hardcoded Uniswap API key from public plugin doc

### DIFF
--- a/skills/base-mcp/plugins/uniswap.md
+++ b/skills/base-mcp/plugins/uniswap.md
@@ -28,12 +28,14 @@ Uniswap on Base: token swaps using the proxy-approval flow (no Permit2 signing) 
 
 ## Auth
 
+Obtain a Uniswap Trade API key from https://hub.uniswap.org/ — never commit your key to version control.
+
 Use these headers for all requests:
 
 ```json
 {
   "Content-Type": "application/json",
-  "x-api-key": "NeoYO3V50_koJAipDEalYWbMO1XMaFPAQmpOm6_Npo0"
+  "x-api-key": "<YOUR_UNISWAP_API_KEY>"
 }
 ```
 


### PR DESCRIPTION
## Summary

`skills/base-mcp/plugins/uniswap.md` line 28 contains a live `x-api-key` value committed to the public repository:
"x-api-key": "NeoYO3V50_koJAipDEalYWbMO1XMaFPAQmpOm6_Npo0"
This is a real credential anyone who clones the repo can extract.

## Why this matters

**Immediate risk**: the key can be abused by anyone, which leads to rate-limiting or revocation. Once that happens, every user copying this plugin example as a starting point sees auth failures with no indication that the cause is a shared-and-burned credential.

**Long-term risk**: this file is positioned as a reference plugin. Anyone authoring a new Base MCP plugin uses it as a template. Shipping a hardcoded secret in the reference teaches plugin authors that embedding raw credentials in skill files is the expected pattern.

## The fix

```diff
- "x-api-key": "NeoYO3V50_koJAipDEalYWbMO1XMaFPAQmpOm6_Npo0"
+ "x-api-key": "<YOUR_UNISWAP_API_KEY>"
```

The placeholder format `<YOUR_*>` matches the existing convention used elsewhere in the same file (e.g., `<address>`, `<base units>`).

Also added a one-line note under the `## Auth Headers` section:

> Obtain a Uniswap Trade API key from https://hub.uniswap.org/ — never commit your key to version control.

## Follow-up recommendation

The leaked key should be rotated out of band by whoever originally issued it, independent of this PR. Removing it from the source tree alone doesn't invalidate the key; only the issuer can do that.

## Verification

- ✅ One file modified: `skills/base-mcp/plugins/uniswap.md`
- ✅ Placeholder uses existing `<*>` convention in the file
- ✅ Auth note points to the official Uniswap developer portal
- ✅ No other content touched