### PR TITLE
fix(register.sh): handle space after colon in JSON response for builder_code

### DIFF
--- a/skills/build-on-base/scripts/register.sh
+++ b/skills/build-on-base/scripts/register.sh
@@ -18,7 +18,7 @@ RESPONSE=$(curl -sf -X POST "$API_URL" \
   exit 1
 }
 
-BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code":"[^"]*"' | cut -d'"' -f4)
+BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
 
 if [ -z "$BUILDER_CODE" ]; then
   echo "Error: No builder_code in API response" >&2


### PR DESCRIPTION
## Problem

Fixes #54.

The grep pattern on line 21 of `register.sh` requires no space between `:` and `"` in the JSON response:

```bash
# Old — fails on spaced JSON ("builder_code": "bc_...")
BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code":"[^"]*"' | cut -d'"' -f4)
```

However, the reference doc (`references/agents/register.md`) shows the API response with a space after the colon. When the API returns spaced JSON, `BUILDER_CODE` is empty and the script exits 1 — registration silently fails.

## Fix

Use a space-tolerant grep pattern (no new dependencies):

```bash
# New — handles both compact and spaced JSON
BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
```

## Verification

```bash
# Spaced (as shown in reference doc) — now works
echo '{"builder_code": "bc_a1b2c3d4","wallet_address":"0x123"}' | grep -o '"builder_code": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"'
# → bc_a1b2c3d4

# Compact — still works
echo '{"builder_code":"bc_a1b2c3d4","wallet_address":"0x123"}' | grep -o '"builder_code": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"'
# → bc_a1b2c3d4
```