### PR TITLE
docs: add verify-contracts reference covering Etherscan V2 API migration

### DIFF
--- a/skills/build-on-base/references/verify-contracts.md
+++ b/skills/build-on-base/references/verify-contracts.md
@@ -1,0 +1,120 @@
+# Verifying Contracts on Base
+
+## Critical: Basescan V1 API is Deactivated
+
+The V1 endpoint (`api.basescan.org/api`, `api-sepolia.basescan.org/api`) was **permanently deactivated on August 15, 2025**. Using it returns:
+
+    You are using a deprecated V1 endpoint, switch to Etherscan API V2
+    using https://docs.etherscan.io/v2-migration
+
+Use the **Etherscan V2 unified endpoint** instead:
+
+| | V1 (deprecated) | V2 (correct) |
+|---|---|---|
+| Mainnet | `https://api.basescan.org/api` | `https://api.etherscan.io/v2/api?chainid=8453` |
+| Sepolia | `https://api-sepolia.basescan.org/api` | `https://api.etherscan.io/v2/api?chainid=84532` |
+| API Key | Per-chain Basescan key | Single Etherscan key |
+
+## Prerequisites
+
+- Deployed contract address
+- Contract source code (must match deployed bytecode exactly)
+- Etherscan API key (free account at etherscan.io/apidashboard)
+
+## Foundry
+
+### Basic verification
+
+    # Mainnet
+    forge verify-contract <contract-address> src/MyContract.sol:MyContract \
+      --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+      --etherscan-api-key $ETHERSCAN_API_KEY \
+      --watch
+
+    # Sepolia
+    forge verify-contract <contract-address> src/MyContract.sol:MyContract \
+      --verifier-url "https://api.etherscan.io/v2/api?chainid=84532" \
+      --etherscan-api-key $ETHERSCAN_API_KEY \
+      --watch
+
+### With constructor arguments
+
+    forge verify-contract <contract-address> src/MyContract.sol:MyContract \
+      --verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+      --etherscan-api-key $ETHERSCAN_API_KEY \
+      --constructor-args $(cast abi-encode "constructor(address,uint256)" 0xabc... 100) \
+      --watch
+
+### foundry.toml V2 config
+
+    [etherscan]
+    base = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=8453" }
+    base-sepolia = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=84532" }
+
+### Already verified
+
+If the contract is already verified, forge exits cleanly with `Contract source code already verified`. This is not an error.
+
+## Hardhat
+
+### hardhat.config.ts
+
+    import { HardhatUserConfig } from "hardhat/config";
+    import "@nomicfoundation/hardhat-verify";
+
+    const config: HardhatUserConfig = {
+      etherscan: {
+        apiKey: process.env.ETHERSCAN_API_KEY as string,
+        customChains: [
+          {
+            network: "base",
+            chainId: 8453,
+            urls: {
+              apiURL: "https://api.etherscan.io/v2/api?chainid=8453",
+              browserURL: "https://basescan.org",
+            },
+          },
+          {
+            network: "base-sepolia",
+            chainId: 84532,
+            urls: {
+              apiURL: "https://api.etherscan.io/v2/api?chainid=84532",
+              browserURL: "https://sepolia.basescan.org",
+            },
+          },
+        ],
+      },
+    };
+
+    export default config;
+
+### Verify command
+
+    npx hardhat verify --network base <contract-address>
+    npx hardhat verify --network base-sepolia <contract-address> <constructor-arg>
+
+## Sourcify — no API key required
+
+    # Mainnet
+    forge verify-contract <contract-address> src/MyContract.sol:MyContract \
+      --verifier sourcify --chain 8453 --watch
+
+    # Sepolia
+    forge verify-contract <contract-address> src/MyContract.sol:MyContract \
+      --verifier sourcify --chain 84532 --watch
+
+Check status at sourcify.dev/#/lookup
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `deprecated V1 endpoint` | Using api.basescan.org | Switch to api.etherscan.io/v2/api?chainid=8453 |
+| `Invalid API key` | Using Basescan key with V2 | Create Etherscan key at etherscan.io |
+| `Bytecode does not match` | Source or compiler mismatch | Match foundry.toml optimizer settings exactly |
+| `Already verified` | Already on BaseScan | Not an error |
+| `Missing constructor args` | Constructor takes arguments | Add --constructor-args flag |
+
+## Cross-reference
+
+For deployment before verification, see deploy-contracts.md.


### PR DESCRIPTION
Closes #35.

## Problem

The Basescan V1 API (`api.basescan.org/api`) was permanently deactivated on August 15, 2025. Stale docs, LLM training data, and blog posts keep surfacing the old endpoint. Developers and AI agents hitting this get a cryptic error with no clear fix.

## What this adds

A new reference file `verify-contracts.md` covering:

- V1 → V2 migration table with the exact error message and correct endpoint
- Foundry `forge verify-contract` (Mainnet/Sepolia, constructor args, linked libraries, `--watch`)
- `foundry.toml` V2 config replacing deprecated per-chain Basescan URLs
- Hardhat `@nomicfoundation/hardhat-verify` with `apiKey` as single string + `customChains` pointing to V2
- Sourcify as a decentralized alternative (no API key)
- Common errors table with causes and fixes
- Cross-reference to `deploy-contracts.md`

## Verified

The V2 endpoint and Sourcify flows were tested on Base Sepolia before opening this PR (see #35 for reproduction details).