### PR TITLE
Add Brickken Base MCP plugin

### DIFF
--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -65,6 +65,7 @@ Plugins currently maintained alongside this skill (the **native plugins**):
 | Virtuals | [plugins/virtuals.md](plugins/virtuals.md) |
 | Aerodrome (CLI-only) | [plugins/aerodrome.md](plugins/aerodrome.md) |
 | Bankr | [plugins/bankr.md](plugins/bankr.md) |
+| Brickken | [plugins/brickken.md](plugins/brickken.md) |
 
 Load a plugin reference only when the user's request matches it, following the same local-first, web-fallback rule as references (see [Loading referenced files](#loading-referenced-files) above). For a plugin's own external tools, defer to the plugin file first, then to any CLI help, API schema, or MCP tool descriptions it explicitly tells you to use.
 

--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -65,7 +65,6 @@ Plugins currently maintained alongside this skill (the **native plugins**):
 | Virtuals | [plugins/virtuals.md](plugins/virtuals.md) |
 | Aerodrome (CLI-only) | [plugins/aerodrome.md](plugins/aerodrome.md) |
 | Bankr | [plugins/bankr.md](plugins/bankr.md) |
-| Brickken | [plugins/brickken.md](plugins/brickken.md) |
 
 Load a plugin reference only when the user's request matches it, following the same local-first, web-fallback rule as references (see [Loading referenced files](#loading-referenced-files) above). For a plugin's own external tools, defer to the plugin file first, then to any CLI help, API schema, or MCP tool descriptions it explicitly tells you to use.
 

--- a/skills/base-mcp/plugins/brickken.md
+++ b/skills/base-mcp/plugins/brickken.md
@@ -1,6 +1,6 @@
 ---
 title: "Brickken Plugin"
-description: "ERC-8004 agent identity, reputation, and agent-owned ERC-20s on Base — Brickken builds unsigned calldata for send_calls, or self-executes through its x402 CLI/MCP."
+description: "ERC-8004 agent identity, reputation, and agent-owned ERC-20s on Base — Brickken builds unsigned calldata for Base MCP send_calls."
 tags: [ai-agents, agent-commerce, token-launches]
 name: brickken
 version: 0.2.0
@@ -17,36 +17,34 @@ risk: [irreversible, pii]
 # Brickken Plugin
 
 > [!IMPORTANT]
-> Run Base MCP onboarding first (see `SKILL.md`). **Building calldata with Brickken is free** — the x402 USDC fee applies only when **Brickken broadcasts** the transaction (the send step, Path B). A payer holding USDC on the target chain is therefore needed only for Path B (CLI/MCP self-execute); Path A (Base Account via `send_calls`) pays only Base gas. The Base Account address is fetched lazily via `get_wallets` when a call needs it.
+> Run Base MCP onboarding first (see `SKILL.md`). This plugin uses Brickken only to build **unsigned calldata**. Submit every action through Base MCP `send_calls`; never ask for or use a private key, and never use Brickken as the broadcaster. Building calldata with Brickken is free; the user pays only Base gas when their Base Account broadcasts through `send_calls`. The Base Account address is fetched lazily via `get_wallets` when a call needs it.
 
 ## Overview
 
-Brickken puts the **ERC-8004** agent stack onchain: a registry for **agent identity**, a registry for **reputation/feedback**, and an **agent-owned ERC-20** factory for launching and managing agent tokens. This plugin covers those agent methods on Base. Brickken does not execute through one fixed route — it **builds the unsigned calldata** for each action, and you choose how it lands onchain:
+Brickken puts the **ERC-8004** agent stack onchain: a registry for **agent identity**, a registry for **reputation/feedback**, and an **agent-owned ERC-20** factory for launching and managing agent tokens. This plugin covers those agent methods on Base. Brickken builds the unsigned calldata for each action, then Base MCP lands it onchain:
 
-- **Path A — Base Account via `send_calls`.** Brickken builds the calldata for free; the user's Base Account signs and broadcasts it through `send_calls`. No Brickken fee — only Base gas. Submission tool: **`send_calls`**.
-- **Path B — Brickken self-executes (key-based).** The `brickken` CLI (or the Brickken MCP with a `privateKey`) signs with a local EOA key and broadcasts through Brickken's backend, paying the x402 **send** fee. Submission tool: **`none`**.
+- Build calldata with Brickken MCP `prepare_transactions` or a prepare-only Brickken CLI command.
+- Submit the returned `{ to, data, value }` calls through Base MCP `send_calls`, where the user's Base Account signs and broadcasts after approval.
 
-Both are first-class; pick per surface in [Surface Routing](#surface-routing). **Preparing transactions (building calldata) is free**; the x402 USDC fee (EIP-3009 `TransferWithAuthorization`) is charged once, at the **send** step, and only when Brickken broadcasts (Path B). Path A pays no Brickken fee (just Base gas via `send_calls`); Path B pays the send fee plus native gas from the EOA unless Brickken confirms sponsorship. See [Risks & Warnings](#risks--warnings) for per-method costs.
+Submission tool: **`send_calls`**. Brickken self-execution and key-based broadcast are out of scope for this Base MCP plugin.
 
 ## Detection
 
-The Brickken MCP path is available only if the harness exposes Brickken tools (`agent_register`, `agent_create_token`, `prepare_transactions`, …). If no `agent_*` tool is callable, the MCP is not installed — use the CLI (Path B, shell required). Do not assume the MCP is present. For Path A, prefer `prepare_transactions`; `agent_*` tools may auto-execute when the Brickken MCP session has a `privateKey`.
+The Brickken MCP path is available only if the harness exposes Brickken tools (`prepare_transactions`, and possibly `agent_register`, `agent_create_token`, …). Do not assume the MCP is present. Prefer `prepare_transactions` because it returns unsigned calldata. If no Brickken prepare tool is callable and the harness has a shell, use the CLI only in prepare-only mode. If neither is available, this surface cannot reach Brickken.
+
+Do not configure or use Brickken signing credentials. If `get_config` reports that signing credentials are present, do not call `agent_*` tools that may auto-execute; use `prepare_transactions` or a fresh Brickken MCP session without signing credentials.
 
 ## Installation
 
-Two routes reach Brickken; install only what your surface uses.
+Two prepare-only routes reach Brickken; install only what your surface uses.
 
-**Brickken CLI (Path B, needs a shell).** No install step — run via `npx`:
+**Brickken CLI (optional, needs a shell).** No install step — run via `npx`:
 
 ```bash
 npx brickken-cli --help          # or: npm i -g brickken-cli  →  brickken --help
 ```
 
-The CLI is **x402-only**. Provide an EOA key for local transaction signing, the x402 **send** payment, and native gas on the target chain unless Brickken confirms sponsorship:
-
-```bash
-export BRICKKEN_PRIVATE_KEY=0x... # alias: BKN_PRIVATE_KEY
-```
+Use the CLI only to prepare unsigned calldata (`--json`, no execute/broadcast option). Do not provide signing credentials; signing and broadcasting belong to Base MCP `send_calls`.
 
 **Brickken MCP (optional, for the MCP path).** Remote MCP at `https://mcp.brickken.com/mcp`. Add it alongside Base MCP, e.g. in Claude Code:
 
@@ -54,16 +52,16 @@ export BRICKKEN_PRIVATE_KEY=0x... # alias: BKN_PRIVATE_KEY
 claude mcp add --transport http brickken https://mcp.brickken.com/mcp
 ```
 
-For other harnesses use the same URL in the connector/`mcpServers` config. A session that should self-execute (Path B via MCP) must be given a `privateKey` through the MCP's `configure` tool.
+For other harnesses use the same URL in the connector/`mcpServers` config. Do not configure signing credentials.
 
 ## Surface Routing
 
 | Step | Harness with shell (Claude Code, Codex, Cursor) | Shell-less (Claude.ai, ChatGPT) |
 |---|---|---|
-| **Build calldata** (prepare, free) | Brickken MCP `prepare_transactions`, or `brickken` CLI prepare-only (`--json`, no `--execute`) | Brickken MCP `prepare_transactions` |
-| **Execute the action** | Path A `send_calls`, or Path B `brickken … --execute` (pays the send x402) | Path A `send_calls` |
+| **Build calldata** (prepare, free) | Brickken MCP `prepare_transactions`, or `brickken` CLI prepare-only (`--json`, no execute/broadcast option) | Brickken MCP `prepare_transactions` |
+| **Execute the action** | Base MCP `send_calls` | Base MCP `send_calls` |
 
-**Shell-less / chat-only:** Path B's CLI is unavailable without a shell — do not improvise it. Use Path A (`send_calls`) or the Brickken MCP. For Path A through Brickken MCP, call `get_config` first; use `prepare_transactions` or confirm `hasPrivateKey === false` before calling `agent_*`, because `agent_*` tools auto-execute when a `privateKey` is configured. Building calldata is free, so the only x402 payment is the send fee on Path B. If the Brickken MCP isn't installed and there's no shell for the CLI, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell.
+**Shell-less / chat-only:** Use Brickken MCP `prepare_transactions` → Base MCP `send_calls`. If the Brickken MCP isn't installed and there's no shell for prepare-only CLI access, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell. Do not ask the user for a private key or try to self-broadcast through Brickken.
 
 ## Methods
 
@@ -90,11 +88,11 @@ The build-calldata call — Brickken MCP `prepare_transactions` (or `brickken tx
 
 Common args: `signerAddress` (must equal the broadcasting wallet); identity calls take `name/description/image/serviceName/serviceEndpoint/aiModelName/aiModelProvider/x402Support/active` (register/set-uri) or `agentId`/`agentUuid` + `metadataKey/metadataValue/metadataEncoding` (set-metadata); token calls take `tokenAddress`, `to`/`from`/`spenderAddress`, `amount`, `decimals`. `agentRegister` requires `image` (backend validation).
 
-The **send** step (Brickken MCP `send_transactions`, or CLI `--execute`) is used **only by Path B** — it is where Brickken broadcasts and the x402 send fee applies. Path A skips it: `send_calls` broadcasts the prepared calldata instead.
+Brickken broadcast is intentionally out of scope. `send_calls` broadcasts the prepared calldata instead.
 
 ## Commands
 
-Path B. CLI ↔ backend method. Every command is **prepare-only by default** (free); add `--execute` to prepare → sign locally → send → pay the send x402 in one step. Add `--json` for machine-readable output.
+Prepare-only CLI reference. CLI ↔ backend method. Every command must run in prepare-only mode; add `--json` for machine-readable output.
 
 | Command | Method | Purpose |
 |---|---|---|
@@ -111,30 +109,24 @@ Path B. CLI ↔ backend method. Every command is **prepare-only by default** (fr
 | `brickken approve` | `agentApproveToken` | Approve an ERC-20 allowance |
 | `brickken tx prepare --method <name>` | any | Raw method call — any backend method |
 
-Key flags: `--chain 8453`, `--signer-address <wallet>`, `--json`, `--execute`, `--file <json>` (nested payloads), `--env production`. For `create-token --execute`, set `--rpc-url`, `BRICKKEN_RPC_URL`, or `BKN_RPC_URL` when the CLI must recover `tokenAddress` on Base. Output JSON exposes `prepared.transactions[]`, `prepared.txId`, `prepared.info.agentUuid`, `prepared.info.agentURI`, `sent.txHash`, and `tokenAddress` (after `create-token --execute` when receipt lookup succeeds).
+Key flags: `--chain 8453`, `--signer-address <Base Account>`, `--json`, `--file <json>` (nested payloads), `--env production`. Output JSON exposes `prepared.transactions[]`, `prepared.txId`, `prepared.info.agentUuid`, and `prepared.info.agentURI`. Never provide signing credentials or ask Brickken to broadcast.
 
 ## Orchestration
 
-Pick a path from [Surface Routing](#surface-routing). `signerAddress` must equal the wallet that will broadcast — on Path A that's the Base Account, on Path B the EOA behind the key.
+`signerAddress` must equal the wallet that will broadcast: the user's Base Account.
 
-### Path A — Base Account via `send_calls`
+### Base Account via `send_calls`
 
 1. `get_wallets` → the Base Account address (use as `signerAddress`, `chainId: "8453"`).
-2. Build calldata (free): Brickken MCP `prepare_transactions`, **without** executing. Use `agent_*` only after `get_config` confirms `hasPrivateKey === false`.
+2. Build calldata (free): Brickken MCP `prepare_transactions`, or CLI prepare-only with `--json` and no execute/broadcast option.
 3. Map `transactions[]` → `send_calls` (see [Submission](#submission)). For multi-step results (e.g. approve + action), pass them as one batch in order.
 4. User approves the `send_calls` request; poll status (see `../references/approval-mode.md`). Report success only after the status tool confirms it.
-
-### Path B — Brickken self-executes (CLI / MCP)
-
-1. Set `BRICKKEN_PRIVATE_KEY` (alias: `BKN_PRIVATE_KEY`). The EOA must hold USDC for the x402 **send** fee and native gas on the target chain unless Brickken confirms sponsorship.
-2. Run the command with `--execute --json`, e.g. `brickken --env production agent register --chain 8453 --signer-address $WALLET --name … --image … --x402-support true --execute --json`. This builds the calldata (free), signs locally, broadcasts through Brickken's backend, and pays the **send** x402.
-3. Parse `sent.txHash`; for `create-token`, capture `tokenAddress`; for `register`, capture `prepared.info.agentUuid` and reuse it in `set-uri` / `set-metadata`. Don't continue `create-token` → `mint` unless `tokenAddress` is present.
 
 > `agentGiveFeedback` returned a backend **500** during June 2026 sandbox testing — re-test before featuring feedback in a happy path, and surface the error rather than retrying blindly.
 
 ## Submission
 
-**Path A → `send_calls`** (EIP-5792 batched calls; see `../references/batch-calls.md`). Map each prepared transaction into a call:
+Use Base MCP `send_calls` (EIP-5792 batched calls; see `../references/batch-calls.md`). Map each prepared transaction into a call:
 
 ```
 transactions[i].to    → calls[i].to
@@ -142,60 +134,40 @@ transactions[i].data  → calls[i].data
 transactions[i].value → calls[i].value   (default "0x0")
 ```
 
-Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chain string `base`) and the `calls` array in the returned order — any approval precedes the action it unlocks. Drop `gasLimit`/`nonce`/`chainId` from the items; the Base Account fills them. Normalize `value` and `data` to `0x`-prefixed hex (default `value` to `"0x0"`); if Brickken returns `value` as a decimal string or a `{type:"BigNumber",hex}` object, convert to hex wei first. Building the calldata is free, so `send_calls` is the only step on Path A (plus Base gas). Follow the approval/polling flow in `../references/approval-mode.md`.
-
-**Path B → `none`.** The CLI / Brickken MCP submits to Brickken's own backend (which broadcasts after the x402 send payment); nothing routes through a Base MCP write tool.
+Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chain string `base`) and the `calls` array in the returned order — any approval precedes the action it unlocks. Drop `gasLimit`/`nonce`/`chainId` from the items; the Base Account fills them. Normalize `value` and `data` to `0x`-prefixed hex (default `value` to `"0x0"`); if Brickken returns `value` as a decimal string or a `{type:"BigNumber",hex}` object, convert to hex wei first. Building the calldata is free, so `send_calls` is the only submission step (plus Base gas). Follow the approval/polling flow in `../references/approval-mode.md`.
 
 ## Example Prompts
 
-**"Register my agent on Base."** (Path A)
+**"Register my agent on Base."**
 1. `get_wallets` → Base Account address.
 2. Brickken MCP `prepare_transactions` `{ method: "agentRegister", chainId: "8453", signerAddress: <address>, name, description, image, x402Support: true, active: true }` (free).
 3. Map `transactions[]` → `send_calls(chain: "base", calls)`.
 4. User approves → poll status → report the agent identity (`info.agentUuid`, `info.agentURI`).
 
-**"Launch an agent token called RAGT and mint 1000 to me."** (Path B / CLI — agent-token deploy is the priciest call; confirm cost first)
-1. Confirm with the user: `agentCreateToken` ≈ **$9.98 USDC** (send fee) + deploy gas on mainnet (see [Risks & Warnings](#risks--warnings)).
-2. `brickken --env production create-token --chain 8453 --signer-address $WALLET --name "Research Agent Token" --symbol RAGT --agent-wallet $WALLET --premint 1000 --decimals 18 --rpc-url $BASE_RPC_URL --execute --json` → capture `tokenAddress` + `sent.txHash`.
-3. `brickken --env production mint --chain 8453 --signer-address $WALLET --token-address $TOKEN --to $WALLET --amount 1000 --decimals 18 --execute --json`.
+**"Launch an agent token called RAGT and mint 1000 to me."**
+1. Confirm with the user that token deployment spends Base gas on mainnet.
+2. `get_wallets` → Base Account address.
+3. Prepare `agentCreateToken` with `signerAddress: <Base Account>`, token metadata, `agentWallet: <Base Account>`, and any supported premint fields.
+4. Map `transactions[]` → `send_calls(chain: "base", calls)` → approve → poll.
+5. Capture `tokenAddress` from the prepare response or confirmed transaction receipt before any later mint/transfer. If a separate mint is still needed, prepare `agentMintToken` and submit it through `send_calls`.
 
-**"Transfer 10 RAGT to 0xabc…."** (Path A)
+**"Transfer 10 RAGT to 0xabc…."**
 1. Prepare (free) `{ method: "agentTransferToken", chainId: "8453", signerAddress: <Base Account>, tokenAddress, to: "0xabc…", amount: "10", decimals: "18" }`.
 2. `send_calls(chain: "base", calls)` → approve → poll.
 
-**Chat-only fallback.** On Claude.ai / ChatGPT with no shell: use the Brickken MCP (`prepare_transactions` → `send_calls`). If the Brickken MCP isn't installed, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell (e.g. Claude Code). Do not fall back to user-paste.
+**Chat-only fallback.** On Claude.ai / ChatGPT with no shell: use the Brickken MCP (`prepare_transactions` → `send_calls`). If the Brickken MCP isn't installed, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell that can prepare unsigned calldata. Do not fall back to user-paste.
 
 ## Risks & Warnings
 
 - **`irreversible`** — every action here is an onchain write (identity registration, wallet rotation, token deploy/mint/burn/transfer). They cannot be undone once broadcast. Confirm the target chain is `base` (8453) and the `signerAddress` matches the broadcasting wallet before submitting; never auto-rotate the agent wallet (`agentSetWallet`) without explicit user intent.
 - **`pii`** — identity and feedback calls accept emails (`ownerEmail`, feedback `email`) and free-text profile fields that get written onchain / pinned to IPFS. Don't send personal data the user didn't authorize; warn that anything submitted is public and permanent.
-- **Cost (x402, mainnet).** Building calldata (prepare) is **always free**. The x402 fee applies only when Brickken broadcasts: **Path A pays no Brickken fee** (the Base Account broadcasts via `send_calls` — only Base gas), while **Path B pays the x402 send fee** plus native gas from the EOA unless Brickken confirms sponsorship. The send fee is **non-refundable**. Always state the USDC cost and get confirmation before executing on Path B — especially `agentCreateToken` (**≈ $9.98** + deploy gas). Never auto-spend. Per-method send fees are in [Notes](#notes).
-- **Base availability.** These contracts/prices are validated against Brickken's sandbox (Ethereum Sepolia). Confirm the ERC-8004 registries, token factory, and x402 facilitator are live on Base mainnet (8453) before promising execution there.
+- **Cost (mainnet gas).** Building calldata (prepare) is **always free**. This plugin does not use Brickken's paid broadcast path, so there is no Brickken broadcast fee. The user still pays Base gas through `send_calls`; token deployment can be relatively expensive. Preview the transaction and get confirmation before submitting. Never auto-spend.
+- **Base availability.** These contracts are validated against Brickken's sandbox (Ethereum Sepolia). Confirm the ERC-8004 registries and token factory are live on Base mainnet (8453) before promising execution there.
 
 ## Notes
 
-**Mainnet x402 pricing (USDC/action).** Building calldata (prepare) is **free**. The fee below is the **send** fee, charged once and only when Brickken broadcasts (Path B). On Path A the same actions cost no Brickken fee — only Base gas.
-
-| Method | Send fee | Extra |
-|---|---|---|
-| `agentRegister` | 0.98 | |
-| `agentSetURI` | 0.48 | + IPFS |
-| `agentSetMetadata` | 0.48 | |
-| `agentSetWallet` | 0.98 | |
-| `agentGiveFeedback` | 0.24 | |
-| `agentRevokeFeedback` | 0.24 | |
-| `agentAppendFeedbackResponse` | 0.48 | + IPFS |
-| `agentCreateToken` | 9.98 | + deploy gas (high) |
-| `agentMintToken` | 0.10 | + ERC-20 gas |
-| `agentBurnToken` | 0.04 | + ERC-20 gas |
-| `agentTransferToken` | 0.04 | + ERC-20 gas |
-| `agentTransferFromToken` | 0.04 | + ERC-20 gas |
-| `agentApproveToken` | 0.02 | + ERC-20 gas |
-
-Sandbox / Sepolia is a flat ~$0.01 ref price per send — do not quote it for mainnet.
-
-- **x402 mechanics.** Only the **send** step is paid. Its 402 carries a `PAYMENT-REQUIRED` header; payment is a base64 `X-Payment` header wrapping an EIP-3009 `TransferWithAuthorization` USDC signature over `{from, to, value, validAfter, validBefore, nonce}`, signed by the EOA key on Path B. Path A never hits a paid step — building calldata is free and the Base Account broadcasts it directly via `send_calls`.
-- **Path A vs B economics.** Path A = no Brickken fee + Base gas (the Base Account broadcasts). Path B = the x402 **send** fee + native gas from the EOA unless Brickken confirms sponsorship (Brickken's backend broadcasts the locally signed transaction). The IPFS upload for `register`/`set-uri`/`append-response` happens at **prepare** (free), so a Path-A broadcast is functionally complete with no Brickken charge.
+- **Signing belongs to Base Account.** Never ask for or use a private key or other signing credential. If a Brickken surface offers broadcast, do not use it for this Base MCP plugin.
+- **Prepare economics.** Preparing calldata is free. The IPFS upload for `register`/`set-uri`/`append-response` happens at prepare time, so a Base MCP `send_calls` broadcast is functionally complete with no Brickken send charge.
 - **Chains.** Brickken maps decimal `8453` → internal hex `2105`; pass `8453` (or `0x2105`). Brickken's testnet is **Ethereum Sepolia (11155111)**, which is *not* Base's `base-sepolia` (84532) — there is no shared testnet, so this plugin targets `chains: [base]` (mainnet) only.
 - **Reference addresses (Sepolia, for orientation only):** identity registry `0x8004A818BFB912233c491871b3d84c89A494BD9e`, reputation registry `0x8004B663056A597Dffe9eCcC1965A193B7388713`, agent-token factory `0xB082876148de3a8372d5fa333a9364f9eD16354B`. Get Base addresses from the `prepare` response `info`, not these.
-- **CLI is x402-only.** Only the **send** step is priced — preparing calldata is free — so a prepare-only command (no `--execute`) costs nothing, and an executed command costs the send fee above.
+- **CLI usage.** The CLI is allowed only for prepare-only calldata generation. Prepare-only commands cost nothing and must still be submitted through Base MCP `send_calls`.

--- a/skills/base-mcp/plugins/brickken.md
+++ b/skills/base-mcp/plugins/brickken.md
@@ -1,14 +1,15 @@
 ---
 title: "Brickken Plugin"
-description: "ERC-8004 agent identity, reputation, and agent-owned ERC-20s on Base — Brickken builds unsigned calldata for Base MCP send_calls."
+description: "ERC-8004 identity, reputation, and agent-token operations through Brickken with Base MCP x402 approval."
 tags: [ai-agents, agent-commerce, token-launches]
 name: brickken
 version: 0.2.0
 integration: hybrid
-chains: [base]
+chains: [base, base-sepolia]
 requires:
   shell: optional
-  externalMcp: { name: brickken, url: https://mcp.brickken.com/mcp }
+  allowlist: []
+  externalMcp: { name: brickken, url: "https://mcp.brickken.com/mcp" }
   cliPackage: npx brickken-cli
 auth: none
 risk: [irreversible, pii]
@@ -17,157 +18,133 @@ risk: [irreversible, pii]
 # Brickken Plugin
 
 > [!IMPORTANT]
-> Run Base MCP onboarding first (see `SKILL.md`). This plugin uses Brickken only to build **unsigned calldata**. Submit every action through Base MCP `send_calls`; never ask for or use a private key, and never use Brickken as the broadcaster. Building calldata with Brickken is free; the user pays only Base gas when their Base Account broadcasts through `send_calls`. The Base Account address is fetched lazily via `get_wallets` when a call needs it.
+> Run Base MCP onboarding first (see `SKILL.md`). Brickken MCP or CLI prepares the operation; Base MCP collects the x402 approval. Brickken's relayer signs, pays native gas, and broadcasts.
 
 ## Overview
 
-Brickken puts the **ERC-8004** agent stack onchain: a registry for **agent identity**, a registry for **reputation/feedback**, and an **agent-owned ERC-20** factory for launching and managing agent tokens. This plugin covers those agent methods on Base. Brickken builds the unsigned calldata for each action, then Base MCP lands it onchain:
+Brickken provides ERC-8004 identity, reputation, and agent-token operations on Base mainnet, with Base Sepolia available for tests. Prepare is free through Brickken MCP `prepare_transactions` or the Brickken CLI. Paid execution goes through Base MCP `initiate_x402_request` and `complete_x402_request`.
 
-- Build calldata with Brickken MCP `prepare_transactions` or a prepare-only Brickken CLI command.
-- Submit the returned `{ to, data, value }` calls through Base MCP `send_calls`, where the user's Base Account signs and broadcasts after approval.
-
-Submission tool: **`send_calls`**. Brickken self-execution and key-based broadcast are out of scope for this Base MCP plugin.
+Brickken is initially the onchain operator in `brickken-relayed` mode. `agentSetWallet` changes the ERC-8004 operational wallet but does not transfer the ERC-721 identity. Transfer custody explicitly with `agentTransferOwnership` only when the user requests it.
 
 ## Detection
 
-The Brickken MCP path is available only if the harness exposes Brickken tools (`prepare_transactions`, and possibly `agent_register`, `agent_create_token`, …). Do not assume the MCP is present. Prefer `prepare_transactions` because it returns unsigned calldata. If no Brickken prepare tool is callable and the harness has a shell, use the CLI only in prepare-only mode. If neither is available, this surface cannot reach Brickken.
+Prefer Brickken MCP when `prepare_transactions` and `get_transaction_status` are callable. With a shell, use the Brickken CLI as the alternative. If neither Brickken MCP nor a shell is available, stop: no fallback is available on that surface.
 
-Do not configure or use Brickken signing credentials. If `get_config` reports that signing credentials are present, do not call `agent_*` tools that may auto-execute; use `prepare_transactions` or a fresh Brickken MCP session without signing credentials.
+Regardless of the prepare surface, use Base MCP for x402 approval.
 
 ## Installation
 
-Two prepare-only routes reach Brickken; install only what your surface uses.
-
-**Brickken CLI (optional, needs a shell).** No install step — run via `npx`:
-
-```bash
-npx brickken-cli --help          # or: npm i -g brickken-cli  →  brickken --help
-```
-
-Use the CLI only to prepare unsigned calldata (`--json`, no execute/broadcast option). Do not provide signing credentials; signing and broadcasting belong to Base MCP `send_calls`.
-
-**Brickken MCP (optional, for the MCP path).** Remote MCP at `https://mcp.brickken.com/mcp`. Add it alongside Base MCP, e.g. in Claude Code:
+Brickken MCP:
 
 ```bash
 claude mcp add --transport http brickken https://mcp.brickken.com/mcp
 ```
 
-For other harnesses use the same URL in the connector/`mcpServers` config. Do not configure signing credentials.
+Brickken CLI for shell-capable harnesses:
+
+```bash
+npx brickken-cli --help
+```
+
+Use the CLI in prepare/status mode only. Base MCP remains responsible for x402 approval and completion.
 
 ## Surface Routing
 
-| Step | Harness with shell (Claude Code, Codex, Cursor) | Shell-less (Claude.ai, ChatGPT) |
+| Step | Shell-capable harness | Shell-less / chat-only |
 |---|---|---|
-| **Build calldata** (prepare, free) | Brickken MCP `prepare_transactions`, or `brickken` CLI prepare-only (`--json`, no execute/broadcast option) | Brickken MCP `prepare_transactions` |
-| **Execute the action** | Base MCP `send_calls` | Base MCP `send_calls` |
-
-**Shell-less / chat-only:** Use Brickken MCP `prepare_transactions` → Base MCP `send_calls`. If the Brickken MCP isn't installed and there's no shell for prepare-only CLI access, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell. Do not ask the user for a private key or try to self-broadcast through Brickken.
-
-## Methods
-
-The build-calldata call — Brickken MCP `prepare_transactions` (or `brickken tx prepare`) — takes a `method` plus its args and returns the unsigned transactions (free, no payment):
-
-```json
-{
-  "transactions": [
-    { "to": "0x…", "data": "0x…", "value": "0x0", "gasLimit": "0x…", "chainId": 8453, "nonce": 49 }
-  ],
-  "txId": "0x…",
-  "info": {
-    "agentUuid": "54399c6e-…",
-    "standard": "ERC-8004",
-    "registryAddress": "0x8004A818…",
-    "reputationRegistryAddress": "0x8004B663…",
-    "agentURI": "ipfs://Qm…",
-    "chainId": "eip155:8453"
-  }
-}
-```
-
-`method` values (this plugin's scope): `agentRegister`, `agentSetURI`, `agentSetMetadata`, `agentSetWallet`, `agentGiveFeedback`, `agentRevokeFeedback`, `agentAppendFeedbackResponse`, `agentCreateToken`, `agentMintToken`, `agentBurnToken`, `agentTransferToken`, `agentTransferFromToken`, `agentApproveToken`.
-
-Common args: `signerAddress` (must equal the broadcasting wallet); identity calls take `name/description/image/serviceName/serviceEndpoint/aiModelName/aiModelProvider/x402Support/active` (register/set-uri) or `agentId`/`agentUuid` + `metadataKey/metadataValue/metadataEncoding` (set-metadata); token calls take `tokenAddress`, `to`/`from`/`spenderAddress`, `amount`, `decimals`. `agentRegister` requires `image` (backend validation).
-
-Brickken broadcast is intentionally out of scope. `send_calls` broadcasts the prepared calldata instead.
+| Prepare, free | Brickken MCP or CLI | Brickken MCP |
+| Approve x402 | Base MCP `initiate_x402_request` | Base MCP `initiate_x402_request` |
+| Execute | Base MCP `complete_x402_request` | Base MCP `complete_x402_request` |
+| Poll pending operation | Brickken MCP or CLI | Brickken MCP |
 
 ## Commands
 
-Prepare-only CLI reference. CLI ↔ backend method. Every command must run in prepare-only mode; add `--json` for machine-readable output.
+Use Brickken MCP `prepare_transactions` or `brickken tx prepare --method <method> --file <json> --json` with `executionMode: "brickken-relayed"`. Use `chainId: "8453"` for Base mainnet and `chainId: "84532"` for Base Sepolia tests. Omit `signerAddress` in relayed mode. For `agentCreateToken`, omit `agentWallet`.
 
-| Command | Method | Purpose |
-|---|---|---|
-| `brickken agent register` | `agentRegister` | Register an ERC-8004 agent identity |
-| `brickken agent set-uri` | `agentSetURI` | Update the agent profile/metadata URI (IPFS) |
-| `brickken agent set-metadata` | `agentSetMetadata` | Set one onchain key/value |
-| `brickken agent set-wallet` | `agentSetWallet` | Rotate the agent's operational wallet |
-| `brickken agent feedback give` | `agentGiveFeedback` | Submit reputation feedback |
-| `brickken agent feedback respond` | `agentAppendFeedbackResponse` | Respond to received feedback |
-| `brickken agent feedback revoke` | `agentRevokeFeedback` | Revoke a feedback entry |
-| `brickken create-token` | `agentCreateToken` | Deploy an agent-owned ERC-20 |
-| `brickken mint` / `burn` | `agentMintToken` / `agentBurnToken` | Mint / burn agent tokens |
-| `brickken transfer` / `transfer-from` | `agentTransferToken` / `agentTransferFromToken` | Transfer agent tokens |
-| `brickken approve` | `agentApproveToken` | Approve an ERC-20 allowance |
-| `brickken tx prepare --method <name>` | any | Raw method call — any backend method |
+`agentRegister` requires `name`, `description`, `image`, and a non-empty `services` array. `image` must be a publicly reachable HTTPS URL for the agent logo; do not use a local path or omit it. Ask for the user's logo, or use an explicitly authorized test fixture.
 
-Key flags: `--chain 8453`, `--signer-address <Base Account>`, `--json`, `--file <json>` (nested payloads), `--env production`. Output JSON exposes `prepared.transactions[]`, `prepared.txId`, `prepared.info.agentUuid`, and `prepared.info.agentURI`. Never provide signing credentials or ask Brickken to broadcast.
+Supported methods:
+
+- Identity: `agentRegister`, `agentSetURI`, `agentSetMetadata`, `agentSetWallet`, `agentTransferOwnership`.
+- Reputation: `agentGiveFeedback`, `agentRevokeFeedback`, `agentAppendFeedbackResponse`.
+- Agent tokens: `agentCreateToken`, `agentMintToken`, `agentBurnToken`, `agentTransferToken`, `agentTransferFromToken`, `agentApproveToken`.
+
+Prepare returns one `txId`, one unsigned transaction, and `x402Requirements`. If MCP or CLI wraps these fields under `prepared`, unwrap that object before submission.
+
+For pending operations, use Brickken MCP `get_transaction_status` with the returned operation hash, or:
+
+```bash
+brickken tx status --hash <operation-hash> --json
+```
+
+### Ownership transfer
+
+Prepare `agentTransferOwnership` with `agentUuid` or `agentId` and `newOwner`. This creates an ERC-721 `safeTransferFrom` from Brickken custody to the requested wallet.
+
+Ownership transfer is separate from `agentSetWallet`. After transfer, Brickken's relayer can no longer perform owner-only operations unless ownership is returned.
+
+### Base Sepolia testing
+
+- Use operation and payment network `eip155:84532` (`base-sepolia` in Base MCP).
+- The Brickken x402 test USDC is `0x8E17c614F99EbEFC73B57fA64a374A6Ef5F4C126` with 6 decimals.
+- Do not substitute Circle's canonical Base Sepolia USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`; the x402 challenge requires the exact quoted asset.
+- Expected ERC-8004 test registries are identity `0x8004A818BFB912233c491871b3d84c89A494BD9e` and reputation `0x8004B663056A597Dffe9eCcC1965A193B7388713`.
+- Before initiating x402, verify the payer holds the asset returned by `x402Requirements`. Testnet balances may not appear in portfolio indexing; use a Base Sepolia `balanceOf` RPC read when necessary.
+- If prepare reports that the registry is not configured, stop. No valid `txId` exists and no payment should be initiated.
 
 ## Orchestration
 
-`signerAddress` must equal the wallet that will broadcast: the user's Base Account.
-
-### Base Account via `send_calls`
-
-1. `get_wallets` → the Base Account address (use as `signerAddress`, `chainId: "8453"`).
-2. Build calldata (free): Brickken MCP `prepare_transactions`, or CLI prepare-only with `--json` and no execute/broadcast option.
-3. Map `transactions[]` → `send_calls` (see [Submission](#submission)). For multi-step results (e.g. approve + action), pass them as one batch in order.
-4. User approves the `send_calls` request; poll status (see `../references/approval-mode.md`). Report success only after the status tool confirms it.
-
-> `agentGiveFeedback` returned a backend **500** during June 2026 sandbox testing — re-test before featuring feedback in a happy path, and surface the error rather than retrying blindly.
+1. Confirm the target (`base` or `base-sepolia`), the irreversible action, custody, and any public or PII fields.
+2. Prepare through Brickken MCP or CLI with `chainId: "8453"` for mainnet or `"84532"` for tests and `executionMode: "brickken-relayed"`.
+3. Require a scalar `txId` and exactly one transaction. Preserve `to`, `data`, and `value` exactly.
+4. Validate that the quote network matches the operation network and that the payer holds the exact quoted asset. On Base Sepolia require USDC `0x8E17c614F99EbEFC73B57fA64a374A6Ef5F4C126`. Parse the exact decimal from `extra.displayPrice` as `maxPayment`.
+5. Call Base MCP `initiate_x402_request` with method `POST`, the active Brickken environment's `/send-transactions` resource, the prepared body, and `maxPayment`. Do not switch environments between prepare and send.
+6. Show the approval URL. Poll Base MCP `get_request_status` only after the user acts, then call `complete_x402_request(requestId)`.
+7. Report confirmed only when Brickken returns `status: "confirmed"` and a transaction hash.
+8. On `status: "pending"`, use Brickken MCP `get_transaction_status` or `brickken tx status`. Do not resubmit or pay the same `txId` again. Brickken's reconciliation settles after confirmation or releases on revert/authorization expiry.
+9. To transfer an identity to the Base Account, call Base MCP `get_wallets`, prepare `agentTransferOwnership` with that address as `newOwner`, and run a separate x402 approval.
 
 ## Submission
 
-Use Base MCP `send_calls` (EIP-5792 batched calls; see `../references/batch-calls.md`). Map each prepared transaction into a call:
+Use Base MCP `initiate_x402_request`, `get_request_status`, and `complete_x402_request`. Brickken MCP/CLI produces the prepare result; Base MCP authorizes the quoted payment and completes the paid send resource.
 
-```
-transactions[i].to    → calls[i].to
-transactions[i].data  → calls[i].data
-transactions[i].value → calls[i].value   (default "0x0")
+Request body:
+
+```json
+{
+  "txId": "0x...",
+  "transactions": [
+    { "to": "0x...", "data": "0x...", "value": "0x0" }
+  ]
+}
 ```
 
-Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chain string `base`) and the `calls` array in the returned order — any approval precedes the action it unlocks. Drop `gasLimit`/`nonce`/`chainId` from the items; the Base Account fills them. Normalize `value` and `data` to `0x`-prefixed hex (default `value` to `"0x0"`); if Brickken returns `value` as a decimal string or a `{type:"BigNumber",hex}` object, convert to hex wei first. Building the calldata is free, so `send_calls` is the only submission step (plus Base gas). Follow the approval/polling flow in `../references/approval-mode.md`.
+Mapping:
+
+```text
+x402Requirements[].extra.displayPrice numeric amount -> initiate_x402_request.maxPayment
+txId                                                   -> body.txId
+transactions[0].{to,data,value}                        -> body.transactions[0]
+```
+
+The Base Account is the x402 payer, while Brickken's relayer is the onchain sender.
 
 ## Example Prompts
 
-**"Register my agent on Base."**
-1. `get_wallets` → Base Account address.
-2. Brickken MCP `prepare_transactions` `{ method: "agentRegister", chainId: "8453", signerAddress: <address>, name, description, image, x402Support: true, active: true }` (free).
-3. Map `transactions[]` → `send_calls(chain: "base", calls)`.
-4. User approves → poll status → report the agent identity (`info.agentUuid`, `info.agentURI`).
+**"Register my agent on Base."** Prepare `agentRegister` through Brickken MCP/CLI, disclose Brickken custody, complete the Base MCP x402 approval, and return `agentUuid`, `txId`, and the operation hash.
 
-**"Launch an agent token called RAGT and mint 1000 to me."**
-1. Confirm with the user that token deployment spends Base gas on mainnet.
-2. `get_wallets` → Base Account address.
-3. Prepare `agentCreateToken` with `signerAddress: <Base Account>`, token metadata, `agentWallet: <Base Account>`, and any supported premint fields.
-4. Map `transactions[]` → `send_calls(chain: "base", calls)` → approve → poll.
-5. Capture `tokenAddress` from the prepare response or confirmed transaction receipt before any later mint/transfer. If a separate mint is still needed, prepare `agentMintToken` and submit it through `send_calls`.
+**"Set my Base wallet as the agent wallet."** Use `agentSetWallet` with the required wallet authorization signature. Explain that this changes the operational wallet only.
 
-**"Transfer 10 RAGT to 0xabc…."**
-1. Prepare (free) `{ method: "agentTransferToken", chainId: "8453", signerAddress: <Base Account>, tokenAddress, to: "0xabc…", amount: "10", decimals: "18" }`.
-2. `send_calls(chain: "base", calls)` → approve → poll.
-
-**Chat-only fallback.** On Claude.ai / ChatGPT with no shell: use the Brickken MCP (`prepare_transactions` → `send_calls`). If the Brickken MCP isn't installed, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell that can prepare unsigned calldata. Do not fall back to user-paste.
+**"Send the agent NFT to my Base wallet."** Call Base MCP `get_wallets`, explicitly confirm loss of Brickken custody, then prepare and execute `agentTransferOwnership` with the Base Account as `newOwner`.
 
 ## Risks & Warnings
 
-- **`irreversible`** — every action here is an onchain write (identity registration, wallet rotation, token deploy/mint/burn/transfer). They cannot be undone once broadcast. Confirm the target chain is `base` (8453) and the `signerAddress` matches the broadcasting wallet before submitting; never auto-rotate the agent wallet (`agentSetWallet`) without explicit user intent.
-- **`pii`** — identity and feedback calls accept emails (`ownerEmail`, feedback `email`) and free-text profile fields that get written onchain / pinned to IPFS. Don't send personal data the user didn't authorize; warn that anything submitted is public and permanent.
-- **Cost (mainnet gas).** Building calldata (prepare) is **always free**. This plugin does not use Brickken's paid broadcast path, so there is no Brickken broadcast fee. The user still pays Base gas through `send_calls`; token deployment can be relatively expensive. Preview the transaction and get confirmation before submitting. Never auto-spend.
-- **Base availability.** These contracts are validated against Brickken's sandbox (Ethereum Sepolia). Confirm the ERC-8004 registries and token factory are live on Base mainnet (8453) before promising execution there.
+- **Custody.** Brickken initially owns the ERC-721 identity and controls agent tokens created by its relayer.
+- **Ownership transfer.** `agentTransferOwnership` is irreversible and disables later Brickken owner-only relayed actions for that identity.
+- **PII.** Agent profiles and feedback may publish free text or contact data to IPFS/onchain storage.
+- **Payment.** Prepare is free. Send charges the exact quoted USDC amount through Base MCP x402 approval.
+- **Retries.** Never replay a `txId` after an operation hash exists. Poll status instead.
 
 ## Notes
 
-- **Signing belongs to Base Account.** Never ask for or use a private key or other signing credential. If a Brickken surface offers broadcast, do not use it for this Base MCP plugin.
-- **Prepare economics.** Preparing calldata is free. The IPFS upload for `register`/`set-uri`/`append-response` happens at prepare time, so a Base MCP `send_calls` broadcast is functionally complete with no Brickken send charge.
-- **Chains.** Brickken maps decimal `8453` → internal hex `2105`; pass `8453` (or `0x2105`). Brickken's testnet is **Ethereum Sepolia (11155111)**, which is *not* Base's `base-sepolia` (84532) — there is no shared testnet, so this plugin targets `chains: [base]` (mainnet) only.
-- **Reference addresses (Sepolia, for orientation only):** identity registry `0x8004A818BFB912233c491871b3d84c89A494BD9e`, reputation registry `0x8004B663056A597Dffe9eCcC1965A193B7388713`, agent-token factory `0xB082876148de3a8372d5fa333a9364f9eD16354B`. Get Base addresses from the `prepare` response `info`, not these.
-- **CLI usage.** The CLI is allowed only for prepare-only calldata generation. Prepare-only commands cost nothing and must still be submitted through Base MCP `send_calls`.
+This workflow targets Base mainnet and Base Sepolia tests. A timeout leaves both operation and payment pending; Brickken's background reconciliation settles only after a successful receipt and releases the authorization on revert or expiry.

--- a/skills/base-mcp/plugins/brickken.md
+++ b/skills/base-mcp/plugins/brickken.md
@@ -8,8 +8,8 @@ integration: hybrid
 chains: [base, base-sepolia]
 requires:
   shell: optional
-  allowlist: []
-  externalMcp: { name: brickken, url: "https://mcp.brickken.com/mcp" }
+  allowlist: [mcp.brickken.com]
+  externalMcp: null
   cliPackage: npx brickken-cli
 auth: none
 risk: [irreversible, pii]
@@ -18,23 +18,29 @@ risk: [irreversible, pii]
 # Brickken Plugin
 
 > [!IMPORTANT]
-> Run Base MCP onboarding first (see `SKILL.md`). Brickken MCP or CLI prepares the operation; Base MCP collects the x402 approval. Brickken's relayer signs, pays native gas, and broadcasts.
+> Run Base MCP onboarding first (see `SKILL.md`). Exposed Brickken MCP tools, hosted Brickken MCP HTTP API, or CLI prepare the operation; Base MCP collects the x402 approval. Brickken's relayer signs, pays native gas, and broadcasts.
 
 ## Overview
 
-Brickken provides ERC-8004 identity, reputation, and agent-token operations on Base mainnet, with Base Sepolia available for tests. Prepare is free through Brickken MCP `prepare_transactions` or the Brickken CLI. Paid execution goes through Base MCP `initiate_x402_request` and `complete_x402_request`.
+Brickken provides ERC-8004 identity, reputation, and agent-token operations on Base mainnet, with Base Sepolia available for tests. Prepare is free through exposed Brickken MCP tools, the hosted Brickken MCP HTTP API (`https://mcp.brickken.com/mcp`), or the Brickken CLI. Paid execution goes through Base MCP `initiate_x402_request` and `complete_x402_request`.
 
 Brickken is initially the onchain operator in `brickken-relayed` mode. `agentSetWallet` changes the ERC-8004 operational wallet but does not transfer the ERC-721 identity. Transfer custody explicitly with `agentTransferOwnership` only when the user requests it.
 
 ## Detection
 
-Prefer Brickken MCP when `prepare_transactions` and `get_transaction_status` are callable. With a shell, use the Brickken CLI as the alternative. If neither Brickken MCP nor a shell is available, stop: no fallback is available on that surface.
+Use this routing order:
+
+1. If Brickken MCP tools are already exposed (`prepare_transactions`, `get_transaction_status`), call them directly.
+2. Otherwise, if the harness has an HTTP tool and `mcp.brickken.com` is reachable via allowlist, call the hosted Brickken MCP API over HTTP.
+3. With shell access, Brickken CLI is an alternative for prepare/status workflows.
+
+Do not stop on shell-less surfaces when HTTP is available: the hosted Brickken MCP API is a valid fallback.
 
 Regardless of the prepare surface, use Base MCP for x402 approval.
 
 ## Installation
 
-Brickken MCP:
+Optional Brickken MCP connector install (convenience path):
 
 ```bash
 claude mcp add --transport http brickken https://mcp.brickken.com/mcp
@@ -48,18 +54,60 @@ npx brickken-cli --help
 
 Use the CLI in prepare/status mode only. Base MCP remains responsible for x402 approval and completion.
 
+## Endpoints
+
+Hosted Brickken MCP endpoint:
+
+- `POST https://mcp.brickken.com/mcp`
+- `Content-Type: application/json`
+- `Accept: application/json, text/event-stream`
+
+JSON-RPC shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "prepare-1",
+  "method": "tools/call",
+  "params": {
+    "name": "prepare_transactions",
+    "arguments": {
+      "method": "agentRegister",
+      "chainId": "84532",
+      "executionMode": "brickken-relayed",
+      "name": "My Agent",
+      "description": "Example",
+      "image": "https://example.com/logo.png",
+      "services": [
+        {
+          "name": "demo",
+          "description": "demo service",
+          "endpoint": "https://example.com"
+        }
+      ]
+    }
+  }
+}
+```
+
+Response handling:
+
+- Some harnesses return plain JSON-RPC `result`.
+- Some stream SSE chunks; parse the final JSON object.
+- MCP wrappers may place payload in `result.content[0].text` as a JSON string; parse and unwrap before mapping to `txId`, `transactions`, and `x402Requirements`.
+
 ## Surface Routing
 
 | Step | Shell-capable harness | Shell-less / chat-only |
 |---|---|---|
-| Prepare, free | Brickken MCP or CLI | Brickken MCP |
+| Prepare, free | Brickken MCP tools, hosted HTTP API, or CLI | Brickken MCP tools or hosted HTTP API |
 | Approve x402 | Base MCP `initiate_x402_request` | Base MCP `initiate_x402_request` |
 | Execute | Base MCP `complete_x402_request` | Base MCP `complete_x402_request` |
-| Poll pending operation | Brickken MCP or CLI | Brickken MCP |
+| Poll pending operation | Brickken MCP tools, hosted HTTP API, or CLI | Brickken MCP tools or hosted HTTP API |
 
 ## Commands
 
-Use Brickken MCP `prepare_transactions` or `brickken tx prepare --method <method> --file <json> --json` with `executionMode: "brickken-relayed"`. Use `chainId: "8453"` for Base mainnet and `chainId: "84532"` for Base Sepolia tests. Omit `signerAddress` in relayed mode. For `agentCreateToken`, omit `agentWallet`.
+Use Brickken `prepare_transactions` through exposed MCP tools, hosted HTTP API (`tools/call`), or `brickken tx prepare --method <method> --file <json> --json` with `executionMode: "brickken-relayed"`. Use `chainId: "8453"` for Base mainnet and `chainId: "84532"` for Base Sepolia tests. Omit `signerAddress` in relayed mode. For `agentCreateToken`, omit `agentWallet`.
 
 `agentRegister` requires `name`, `description`, `image`, and a non-empty `services` array. `image` must be a publicly reachable HTTPS URL for the agent logo; do not use a local path or omit it. Ask for the user's logo, or use an explicitly authorized test fixture.
 
@@ -71,7 +119,7 @@ Supported methods:
 
 Prepare returns one `txId`, one unsigned transaction, and `x402Requirements`. If MCP or CLI wraps these fields under `prepared`, unwrap that object before submission.
 
-For pending operations, use Brickken MCP `get_transaction_status` with the returned operation hash, or:
+For pending operations, use Brickken `get_transaction_status` through exposed MCP tools or hosted HTTP API, or:
 
 ```bash
 brickken tx status --hash <operation-hash> --json
@@ -95,18 +143,18 @@ Ownership transfer is separate from `agentSetWallet`. After transfer, Brickken's
 ## Orchestration
 
 1. Confirm the target (`base` or `base-sepolia`), the irreversible action, custody, and any public or PII fields.
-2. Prepare through Brickken MCP or CLI with `chainId: "8453"` for mainnet or `"84532"` for tests and `executionMode: "brickken-relayed"`.
+2. Prepare through exposed Brickken MCP tools, hosted HTTP API, or CLI with `chainId: "8453"` for mainnet or `"84532"` for tests and `executionMode: "brickken-relayed"`.
 3. Require a scalar `txId` and exactly one transaction. Preserve `to`, `data`, and `value` exactly.
 4. Validate that the quote network matches the operation network and that the payer holds the exact quoted asset. On Base Sepolia require USDC `0x8E17c614F99EbEFC73B57fA64a374A6Ef5F4C126`. Parse the exact decimal from `extra.displayPrice` as `maxPayment`.
 5. Call Base MCP `initiate_x402_request` with method `POST`, the active Brickken environment's `/send-transactions` resource, the prepared body, and `maxPayment`. Do not switch environments between prepare and send.
 6. Show the approval URL. Poll Base MCP `get_request_status` only after the user acts, then call `complete_x402_request(requestId)`.
 7. Report confirmed only when Brickken returns `status: "confirmed"` and a transaction hash.
-8. On `status: "pending"`, use Brickken MCP `get_transaction_status` or `brickken tx status`. Do not resubmit or pay the same `txId` again. Brickken's reconciliation settles after confirmation or releases on revert/authorization expiry.
+8. On `status: "pending"`, use Brickken `get_transaction_status` through exposed MCP tools or hosted HTTP API, or `brickken tx status`. Do not resubmit or pay the same `txId` again. Brickken's reconciliation settles after confirmation or releases on revert/authorization expiry.
 9. To transfer an identity to the Base Account, call Base MCP `get_wallets`, prepare `agentTransferOwnership` with that address as `newOwner`, and run a separate x402 approval.
 
 ## Submission
 
-Use Base MCP `initiate_x402_request`, `get_request_status`, and `complete_x402_request`. Brickken MCP/CLI produces the prepare result; Base MCP authorizes the quoted payment and completes the paid send resource.
+Use Base MCP `initiate_x402_request`, `get_request_status`, and `complete_x402_request`. Exposed Brickken MCP tools, hosted HTTP API, or CLI produce the prepare result; Base MCP authorizes the quoted payment and completes the paid send resource.
 
 Request body:
 
@@ -131,7 +179,7 @@ The Base Account is the x402 payer, while Brickken's relayer is the onchain send
 
 ## Example Prompts
 
-**"Register my agent on Base."** Prepare `agentRegister` through Brickken MCP/CLI, disclose Brickken custody, complete the Base MCP x402 approval, and return `agentUuid`, `txId`, and the operation hash.
+**"Register my agent on Base."** Prepare `agentRegister` through exposed Brickken MCP tools, hosted HTTP API, or CLI, disclose Brickken custody, complete the Base MCP x402 approval, and return `agentUuid`, `txId`, and the operation hash.
 
 **"Set my Base wallet as the agent wallet."** Use `agentSetWallet` with the required wallet authorization signature. Explain that this changes the operational wallet only.
 

--- a/skills/base-mcp/plugins/brickken.md
+++ b/skills/base-mcp/plugins/brickken.md
@@ -134,8 +134,8 @@ Ownership transfer is separate from `agentSetWallet`. After transfer, Brickken's
 ### Base Sepolia testing
 
 - Use operation and payment network `eip155:84532` (`base-sepolia` in Base MCP).
-- The Brickken x402 test USDC is `0x8E17c614F99EbEFC73B57fA64a374A6Ef5F4C126` with 6 decimals.
-- Do not substitute Circle's canonical Base Sepolia USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`; the x402 challenge requires the exact quoted asset.
+- The Brickken x402 test USDC is Circle USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e` with 6 decimals, settled via EIP-3009 (EIP-712 name `USDC`, version `2`, authorization window 300s).
+- Always fund and pay with the exact asset quoted in `x402Requirements`; do not substitute another token.
 - Expected ERC-8004 test registries are identity `0x8004A818BFB912233c491871b3d84c89A494BD9e` and reputation `0x8004B663056A597Dffe9eCcC1965A193B7388713`.
 - Before initiating x402, verify the payer holds the asset returned by `x402Requirements`. Testnet balances may not appear in portfolio indexing; use a Base Sepolia `balanceOf` RPC read when necessary.
 - If prepare reports that the registry is not configured, stop. No valid `txId` exists and no payment should be initiated.
@@ -145,7 +145,7 @@ Ownership transfer is separate from `agentSetWallet`. After transfer, Brickken's
 1. Confirm the target (`base` or `base-sepolia`), the irreversible action, custody, and any public or PII fields.
 2. Prepare through exposed Brickken MCP tools, hosted HTTP API, or CLI with `chainId: "8453"` for mainnet or `"84532"` for tests and `executionMode: "brickken-relayed"`.
 3. Require a scalar `txId` and exactly one transaction. Preserve `to`, `data`, and `value` exactly.
-4. Validate that the quote network matches the operation network and that the payer holds the exact quoted asset. On Base Sepolia require USDC `0x8E17c614F99EbEFC73B57fA64a374A6Ef5F4C126`. Parse the exact decimal from `extra.displayPrice` as `maxPayment`.
+4. Validate that the quote network matches the operation network and that the payer holds the exact quoted asset. On Base Sepolia require Circle USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`. Parse the exact decimal from `extra.displayPrice` as `maxPayment`.
 5. Call Base MCP `initiate_x402_request` with method `POST`, the active Brickken environment's `/send-transactions` resource, the prepared body, and `maxPayment`. Do not switch environments between prepare and send.
 6. Show the approval URL. Poll Base MCP `get_request_status` only after the user acts, then call `complete_x402_request(requestId)`.
 7. Report confirmed only when Brickken returns `status: "confirmed"` and a transaction hash.

--- a/skills/base-mcp/plugins/brickken.md
+++ b/skills/base-mcp/plugins/brickken.md
@@ -8,7 +8,6 @@ integration: hybrid
 chains: [base]
 requires:
   shell: optional
-  allowlist: [api.brickken.com, api.sandbox.brickken.com]
   externalMcp: { name: brickken, url: https://mcp.brickken.com/mcp }
   cliPackage: npx brickken-cli
 auth: none
@@ -18,26 +17,24 @@ risk: [irreversible, pii]
 # Brickken Plugin
 
 > [!IMPORTANT]
-> Run Base MCP onboarding first (see `SKILL.md`). Brickken's agent API is **x402-paid**: every call costs USDC, so the payer (the Base Account on Path A when settlement is supported, or a funded EOA key on Path B) must hold USDC on the target chain before you start. The Base Account address is fetched lazily via `get_wallets` when a call needs it.
+> Run Base MCP onboarding first (see `SKILL.md`). **Building calldata with Brickken is free** — the x402 USDC fee applies only when **Brickken broadcasts** the transaction (the send step, Path B). A payer holding USDC on the target chain is therefore needed only for Path B (CLI/MCP self-execute); Path A (Base Account via `send_calls`) pays only Base gas. The Base Account address is fetched lazily via `get_wallets` when a call needs it.
 
 ## Overview
 
 Brickken puts the **ERC-8004** agent stack onchain: a registry for **agent identity**, a registry for **reputation/feedback**, and an **agent-owned ERC-20** factory for launching and managing agent tokens. This plugin covers those agent methods on Base. Brickken does not execute through one fixed route — it **builds the unsigned calldata** for each action, and you choose how it lands onchain:
 
-- **Path A — Base Account via `send_calls` (x402-gated).** Brickken builds the calldata; when Base MCP can settle Brickken's x402 prepare invoice from the Base Account, the user's Base Account signs and broadcasts it through `send_calls`. Submission tool: **`send_calls`**.
-- **Path B — Brickken self-executes (key-based).** The `brickken` CLI (or the Brickken MCP with a `privateKey`) signs with a local EOA key, pays x402, and broadcasts — no Base Account. Submission tool: **`none`**.
+- **Path A — Base Account via `send_calls`.** Brickken builds the calldata for free; the user's Base Account signs and broadcasts it through `send_calls`. No Brickken fee — only Base gas. Submission tool: **`send_calls`**.
+- **Path B — Brickken self-executes (key-based).** The `brickken` CLI (or the Brickken MCP with a `privateKey`) signs with a local EOA key and broadcasts through Brickken's backend, paying the x402 **send** fee. Submission tool: **`none`**.
 
-Both are first-class; pick per surface in [Surface Routing](#surface-routing). The agent API is x402-native: `prepare-transactions` and `send-transactions` are **each** priced in USDC (EIP-3009 `TransferWithAuthorization`). Path A pays only the prepare fee (then Base gas via `send_calls`); Path B pays the full USDC total plus native gas from the EOA unless Brickken confirms sponsorship for the target chain. See [Risks & Warnings](#risks--warnings) for per-method costs.
+Both are first-class; pick per surface in [Surface Routing](#surface-routing). **Preparing transactions (building calldata) is free**; the x402 USDC fee (EIP-3009 `TransferWithAuthorization`) is charged once, at the **send** step, and only when Brickken broadcasts (Path B). Path A pays no Brickken fee (just Base gas via `send_calls`); Path B pays the send fee plus native gas from the EOA unless Brickken confirms sponsorship. See [Risks & Warnings](#risks--warnings) for per-method costs.
 
 ## Detection
 
-The Brickken MCP path is available only if the harness exposes Brickken tools (`agent_register`, `agent_create_token`, `prepare_transactions`, …). If no `agent_*` tool is callable, the MCP is not installed — use the CLI (Path B, shell required) or call the HTTP API directly (see [Installation](#installation)). Do not assume the MCP is present. For Path A, prefer `prepare_transactions`; `agent_*` tools may auto-execute when the Brickken MCP session has a `privateKey`.
+The Brickken MCP path is available only if the harness exposes Brickken tools (`agent_register`, `agent_create_token`, `prepare_transactions`, …). If no `agent_*` tool is callable, the MCP is not installed — use the CLI (Path B, shell required). Do not assume the MCP is present. For Path A, prefer `prepare_transactions`; `agent_*` tools may auto-execute when the Brickken MCP session has a `privateKey`.
 
 ## Installation
 
-Three routes reach Brickken; install only what your surface uses.
-
-**HTTP API (no install).** Build calldata by POSTing to the Brickken API — host `api.brickken.com` (production) or `api.sandbox.brickken.com` (sandbox) must be on the Base MCP `web_request` allowlist for chat-only surfaces. On harnesses with a direct HTTP tool, no allowlist is needed.
+Two routes reach Brickken; install only what your surface uses.
 
 **Brickken CLI (Path B, needs a shell).** No install step — run via `npx`:
 
@@ -45,7 +42,7 @@ Three routes reach Brickken; install only what your surface uses.
 npx brickken-cli --help          # or: npm i -g brickken-cli  →  brickken --help
 ```
 
-The CLI is **x402-only** — it ignores API keys. Provide an EOA key for local transaction signing, x402 payment, and native gas on the target chain unless Brickken confirms sponsorship:
+The CLI is **x402-only**. Provide an EOA key for local transaction signing, the x402 **send** payment, and native gas on the target chain unless Brickken confirms sponsorship:
 
 ```bash
 export BRICKKEN_PRIVATE_KEY=0x... # alias: BKN_PRIVATE_KEY
@@ -61,19 +58,16 @@ For other harnesses use the same URL in the connector/`mcpServers` config. A ses
 
 ## Surface Routing
 
-| Step | Harness with shell (Claude Code, Codex, Cursor) | Harness with HTTP tool, no shell | Chat-only (Claude.ai, ChatGPT) |
-|---|---|---|---|
-| **Build calldata** (prepare) | Harness HTTP `POST /prepare-transactions`, Brickken MCP `prepare_transactions`, or `brickken` CLI prepare-only (`--json`, no `--execute`) | harness HTTP `POST /prepare-transactions` | Brickken MCP `prepare_transactions`, or `web_request` POST to the allowlisted Brickken host |
-| **Pay the prepare x402** | Base MCP x402 if settlement succeeds (Path A), or the CLI/EOA key (Path B) | Base MCP x402 if settlement succeeds (Path A) | Base MCP x402 if settlement succeeds (Path A) |
-| **Execute the action** | Path A `send_calls`, or Path B `brickken … --execute` | Path A `send_calls` | Path A `send_calls` |
+| Step | Harness with shell (Claude Code, Codex, Cursor) | Shell-less (Claude.ai, ChatGPT) |
+|---|---|---|
+| **Build calldata** (prepare, free) | Brickken MCP `prepare_transactions`, or `brickken` CLI prepare-only (`--json`, no `--execute`) | Brickken MCP `prepare_transactions` |
+| **Execute the action** | Path A `send_calls`, or Path B `brickken … --execute` (pays the send x402) | Path A `send_calls` |
 
-**Shell-less / chat-only:** Path B's CLI is unavailable without a shell — do not improvise it. Use Path A (`send_calls`) or the Brickken MCP. For Path A through Brickken MCP, call `get_config` first; use `prepare_transactions` or confirm `hasPrivateKey === false` before calling `agent_*`, because `agent_*` tools auto-execute when a `privateKey` is configured. Paying the prepare fee on Path A depends on Base MCP settling Brickken's x402 invoice from the Base Account (see [Notes](#notes) — verify on your surface). If neither a Base MCP x402 capability nor a funded EOA key is available to pay the prepare fee, stop and tell the user the call requires a USDC payment they can't currently make.
+**Shell-less / chat-only:** Path B's CLI is unavailable without a shell — do not improvise it. Use Path A (`send_calls`) or the Brickken MCP. For Path A through Brickken MCP, call `get_config` first; use `prepare_transactions` or confirm `hasPrivateKey === false` before calling `agent_*`, because `agent_*` tools auto-execute when a `privateKey` is configured. Building calldata is free, so the only x402 payment is the send fee on Path B. If the Brickken MCP isn't installed and there's no shell for the CLI, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell.
 
-## Endpoints
+## Methods
 
-HTTP path (Path A build-calldata, and Path B under the hood). API root: `https://api.brickken.com` (production) or `https://api.sandbox.brickken.com` (sandbox).
-
-**`POST /prepare-transactions`** — body `{ "method": <name>, "chainId": "8453", "signerAddress": <Base Account>, …method args }`. Returns **402** the first time → pay the x402 invoice → retry → **200**:
+The build-calldata call — Brickken MCP `prepare_transactions` (or `brickken tx prepare`) — takes a `method` plus its args and returns the unsigned transactions (free, no payment):
 
 ```json
 {
@@ -96,13 +90,11 @@ HTTP path (Path A build-calldata, and Path B under the hood). API root: `https:/
 
 Common args: `signerAddress` (must equal the broadcasting wallet); identity calls take `name/description/image/serviceName/serviceEndpoint/aiModelName/aiModelProvider/x402Support/active` (register/set-uri) or `agentId`/`agentUuid` + `metadataKey/metadataValue/metadataEncoding` (set-metadata); token calls take `tokenAddress`, `to`/`from`/`spenderAddress`, `amount`, `decimals`. `agentRegister` requires `image` (backend validation).
 
-**`POST /send-transactions`** — `{ txId, signedTransactions }`. Used **only by Path B** (Brickken broadcasts). Path A skips it — `send_calls` broadcasts instead.
-
-> API-key alternative (not this plugin's default): the same host accepts an `x-api-key` header instead of paying x402. Use it only if you have a Brickken API key; with no key, the host falls back to the x402 invoice this plugin assumes.
+The **send** step (Brickken MCP `send_transactions`, or CLI `--execute`) is used **only by Path B** — it is where Brickken broadcasts and the x402 send fee applies. Path A skips it: `send_calls` broadcasts the prepared calldata instead.
 
 ## Commands
 
-Path B. CLI ↔ backend method. Every command is **prepare-only by default**; add `--execute` to prepare → sign locally → send → pay x402 in one step. Add `--json` for machine-readable output.
+Path B. CLI ↔ backend method. Every command is **prepare-only by default** (free); add `--execute` to prepare → sign locally → send → pay the send x402 in one step. Add `--json` for machine-readable output.
 
 | Command | Method | Purpose |
 |---|---|---|
@@ -119,7 +111,7 @@ Path B. CLI ↔ backend method. Every command is **prepare-only by default**; ad
 | `brickken approve` | `agentApproveToken` | Approve an ERC-20 allowance |
 | `brickken tx prepare --method <name>` | any | Raw method call — any backend method |
 
-Key flags: `--chain 8453`, `--signer-address <wallet>`, `--json`, `--execute`, `--file <json>` (nested payloads), `--env production` (or `--base-url <api root>`). For `create-token --execute`, set `--rpc-url`, `BRICKKEN_RPC_URL`, or `BKN_RPC_URL` when the CLI must recover `tokenAddress` on Base. Output JSON exposes `prepared.transactions[]`, `prepared.txId`, `prepared.info.agentUuid`, `prepared.info.agentURI`, `sent.txHash`, and `tokenAddress` (after `create-token --execute` when receipt lookup succeeds).
+Key flags: `--chain 8453`, `--signer-address <wallet>`, `--json`, `--execute`, `--file <json>` (nested payloads), `--env production`. For `create-token --execute`, set `--rpc-url`, `BRICKKEN_RPC_URL`, or `BKN_RPC_URL` when the CLI must recover `tokenAddress` on Base. Output JSON exposes `prepared.transactions[]`, `prepared.txId`, `prepared.info.agentUuid`, `prepared.info.agentURI`, `sent.txHash`, and `tokenAddress` (after `create-token --execute` when receipt lookup succeeds).
 
 ## Orchestration
 
@@ -128,15 +120,14 @@ Pick a path from [Surface Routing](#surface-routing). `signerAddress` must equal
 ### Path A — Base Account via `send_calls`
 
 1. `get_wallets` → the Base Account address (use as `signerAddress`, `chainId: "8453"`).
-2. Build calldata: `POST /prepare-transactions` (harness HTTP / `web_request`) or Brickken MCP `prepare_transactions`, **without** executing. Use `agent_*` only after `get_config` confirms `hasPrivateKey === false`.
-3. Pay the **prepare** x402 invoice with Base MCP's x402 capability if it can settle Brickken's EIP-3009 invoice from the Base Account. If settlement fails, stop and report that Path A is unavailable on the current surface.
-4. Map `transactions[]` → `send_calls` (see [Submission](#submission)). For multi-step results (e.g. approve + action), pass them as one batch in order.
-5. User approves the `send_calls` request; poll status (see `../references/approval-mode.md`). Report success only after the status tool confirms it.
+2. Build calldata (free): Brickken MCP `prepare_transactions`, **without** executing. Use `agent_*` only after `get_config` confirms `hasPrivateKey === false`.
+3. Map `transactions[]` → `send_calls` (see [Submission](#submission)). For multi-step results (e.g. approve + action), pass them as one batch in order.
+4. User approves the `send_calls` request; poll status (see `../references/approval-mode.md`). Report success only after the status tool confirms it.
 
 ### Path B — Brickken self-executes (CLI / MCP)
 
-1. Set `BRICKKEN_PRIVATE_KEY` (alias: `BKN_PRIVATE_KEY`). The EOA must hold USDC for x402 and native gas on the target chain unless Brickken confirms sponsorship.
-2. Run the command with `--execute --json`, e.g. `brickken --env production agent register --chain 8453 --signer-address $WALLET --name … --image … --x402-support true --execute --json`. This pays **prepare + send** x402, signs locally, and broadcasts through Brickken's backend.
+1. Set `BRICKKEN_PRIVATE_KEY` (alias: `BKN_PRIVATE_KEY`). The EOA must hold USDC for the x402 **send** fee and native gas on the target chain unless Brickken confirms sponsorship.
+2. Run the command with `--execute --json`, e.g. `brickken --env production agent register --chain 8453 --signer-address $WALLET --name … --image … --x402-support true --execute --json`. This builds the calldata (free), signs locally, broadcasts through Brickken's backend, and pays the **send** x402.
 3. Parse `sent.txHash`; for `create-token`, capture `tokenAddress`; for `register`, capture `prepared.info.agentUuid` and reuse it in `set-uri` / `set-metadata`. Don't continue `create-token` → `mint` unless `tokenAddress` is present.
 
 > `agentGiveFeedback` returned a backend **500** during June 2026 sandbox testing — re-test before featuring feedback in a happy path, and surface the error rather than retrying blindly.
@@ -151,7 +142,7 @@ transactions[i].data  → calls[i].data
 transactions[i].value → calls[i].value   (default "0x0")
 ```
 
-Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chain string `base`) and the `calls` array in the returned order — any approval precedes the action it unlocks. Drop `gasLimit`/`nonce`/`chainId` from the items; the Base Account fills them. Normalize `value` and `data` to `0x`-prefixed hex (default `value` to `"0x0"`); if Brickken returns `value` as a decimal string or a `{type:"BigNumber",hex}` object, convert to hex wei first. The prepare-fee x402 payment is a **separate step before** `send_calls`, not part of it. Follow the approval/polling flow in `../references/approval-mode.md`.
+Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chain string `base`) and the `calls` array in the returned order — any approval precedes the action it unlocks. Drop `gasLimit`/`nonce`/`chainId` from the items; the Base Account fills them. Normalize `value` and `data` to `0x`-prefixed hex (default `value` to `"0x0"`); if Brickken returns `value` as a decimal string or a `{type:"BigNumber",hex}` object, convert to hex wei first. Building the calldata is free, so `send_calls` is the only step on Path A (plus Base gas). Follow the approval/polling flow in `../references/approval-mode.md`.
 
 **Path B → `none`.** The CLI / Brickken MCP submits to Brickken's own backend (which broadcasts after the x402 send payment); nothing routes through a Base MCP write tool.
 
@@ -159,52 +150,52 @@ Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chai
 
 **"Register my agent on Base."** (Path A)
 1. `get_wallets` → Base Account address.
-2. `POST /prepare-transactions` `{ method: "agentRegister", chainId: "8453", signerAddress: <address>, name, description, image, x402Support: true, active: true }`; pay the prepare x402.
+2. Brickken MCP `prepare_transactions` `{ method: "agentRegister", chainId: "8453", signerAddress: <address>, name, description, image, x402Support: true, active: true }` (free).
 3. Map `transactions[]` → `send_calls(chain: "base", calls)`.
 4. User approves → poll status → report the agent identity (`info.agentUuid`, `info.agentURI`).
 
 **"Launch an agent token called RAGT and mint 1000 to me."** (Path B / CLI — agent-token deploy is the priciest call; confirm cost first)
-1. Confirm with the user: `agentCreateToken` ≈ **$9.99 USDC** + deploy gas on mainnet (see [Risks & Warnings](#risks--warnings)).
+1. Confirm with the user: `agentCreateToken` ≈ **$9.98 USDC** (send fee) + deploy gas on mainnet (see [Risks & Warnings](#risks--warnings)).
 2. `brickken --env production create-token --chain 8453 --signer-address $WALLET --name "Research Agent Token" --symbol RAGT --agent-wallet $WALLET --premint 1000 --decimals 18 --rpc-url $BASE_RPC_URL --execute --json` → capture `tokenAddress` + `sent.txHash`.
 3. `brickken --env production mint --chain 8453 --signer-address $WALLET --token-address $TOKEN --to $WALLET --amount 1000 --decimals 18 --execute --json`.
 
 **"Transfer 10 RAGT to 0xabc…."** (Path A)
-1. Prepare `{ method: "agentTransferToken", chainId: "8453", signerAddress: <Base Account>, tokenAddress, to: "0xabc…", amount: "10", decimals: "18" }`; pay prepare x402.
+1. Prepare (free) `{ method: "agentTransferToken", chainId: "8453", signerAddress: <Base Account>, tokenAddress, to: "0xabc…", amount: "10", decimals: "18" }`.
 2. `send_calls(chain: "base", calls)` → approve → poll.
 
-**Chat-only fallback.** On Claude.ai / ChatGPT with no harness HTTP tool: use the Brickken MCP if installed; otherwise the Brickken host must be allowlisted for `web_request` to POST `prepare-transactions`. If it isn't, tell the user this surface can't reach Brickken and point them to a harness with HTTP tools (e.g. Claude Code). Do not fall back to user-paste — the prepare call is a POST.
+**Chat-only fallback.** On Claude.ai / ChatGPT with no shell: use the Brickken MCP (`prepare_transactions` → `send_calls`). If the Brickken MCP isn't installed, this surface can't reach Brickken — point the user to a harness with the Brickken MCP or a shell (e.g. Claude Code). Do not fall back to user-paste.
 
 ## Risks & Warnings
 
 - **`irreversible`** — every action here is an onchain write (identity registration, wallet rotation, token deploy/mint/burn/transfer). They cannot be undone once broadcast. Confirm the target chain is `base` (8453) and the `signerAddress` matches the broadcasting wallet before submitting; never auto-rotate the agent wallet (`agentSetWallet`) without explicit user intent.
 - **`pii`** — identity and feedback calls accept emails (`ownerEmail`, feedback `email`) and free-text profile fields that get written onchain / pinned to IPFS. Don't send personal data the user didn't authorize; warn that anything submitted is public and permanent.
-- **Cost (x402, mainnet).** Each action is paid in USDC and is **non-refundable**. Path A pays the prepare column, then Base gas through `send_calls`; Path B pays prepare + send USDC plus native gas from the EOA unless Brickken confirms sponsorship. Always state the USDC cost and get confirmation before executing — especially `agentCreateToken` (**≈ $9.99** + deploy gas). Never auto-spend. Per-method totals are in [Notes](#notes).
+- **Cost (x402, mainnet).** Building calldata (prepare) is **always free**. The x402 fee applies only when Brickken broadcasts: **Path A pays no Brickken fee** (the Base Account broadcasts via `send_calls` — only Base gas), while **Path B pays the x402 send fee** plus native gas from the EOA unless Brickken confirms sponsorship. The send fee is **non-refundable**. Always state the USDC cost and get confirmation before executing on Path B — especially `agentCreateToken` (**≈ $9.98** + deploy gas). Never auto-spend. Per-method send fees are in [Notes](#notes).
 - **Base availability.** These contracts/prices are validated against Brickken's sandbox (Ethereum Sepolia). Confirm the ERC-8004 registries, token factory, and x402 facilitator are live on Base mainnet (8453) before promising execution there.
 
 ## Notes
 
-**Mainnet x402 pricing (USDC/call, 2 calls per action).** Path A = Prepare only + Base gas; Path B = Total + native gas where required.
+**Mainnet x402 pricing (USDC/action).** Building calldata (prepare) is **free**. The fee below is the **send** fee, charged once and only when Brickken broadcasts (Path B). On Path A the same actions cost no Brickken fee — only Base gas.
 
-| Method | Prepare | Send | Total | Extra |
-|---|---|---|---|---|
-| `agentRegister` | 0.50 | 0.49 | 0.99 | |
-| `agentSetURI` | 0.25 | 0.24 | 0.49 | + IPFS |
-| `agentSetMetadata` | 0.25 | 0.24 | 0.49 | |
-| `agentSetWallet` | 0.50 | 0.49 | 0.99 | |
-| `agentGiveFeedback` | 0.13 | 0.12 | 0.25 | |
-| `agentRevokeFeedback` | 0.13 | 0.12 | 0.25 | |
-| `agentAppendFeedbackResponse` | 0.25 | 0.24 | 0.49 | + IPFS |
-| `agentCreateToken` | 5.00 | 4.99 | 9.99 | + deploy gas (high) |
-| `agentMintToken` | 0.05 | 0.05 | 0.10 | + ERC-20 gas |
-| `agentBurnToken` | 0.03 | 0.02 | 0.05 | + ERC-20 gas |
-| `agentTransferToken` | 0.03 | 0.02 | 0.05 | + ERC-20 gas |
-| `agentTransferFromToken` | 0.03 | 0.02 | 0.05 | + ERC-20 gas |
-| `agentApproveToken` | 0.02 | 0.01 | 0.03 | + ERC-20 gas |
+| Method | Send fee | Extra |
+|---|---|---|
+| `agentRegister` | 0.98 | |
+| `agentSetURI` | 0.48 | + IPFS |
+| `agentSetMetadata` | 0.48 | |
+| `agentSetWallet` | 0.98 | |
+| `agentGiveFeedback` | 0.24 | |
+| `agentRevokeFeedback` | 0.24 | |
+| `agentAppendFeedbackResponse` | 0.48 | + IPFS |
+| `agentCreateToken` | 9.98 | + deploy gas (high) |
+| `agentMintToken` | 0.10 | + ERC-20 gas |
+| `agentBurnToken` | 0.04 | + ERC-20 gas |
+| `agentTransferToken` | 0.04 | + ERC-20 gas |
+| `agentTransferFromToken` | 0.04 | + ERC-20 gas |
+| `agentApproveToken` | 0.02 | + ERC-20 gas |
 
-Sandbox / Sepolia is a flat ~$0.01 ref price per call — do not quote it for mainnet.
+Sandbox / Sepolia is a flat ~$0.01 ref price per send — do not quote it for mainnet.
 
-- **x402 mechanics.** The 402 carries a `PAYMENT-REQUIRED` header; payment is a base64 `X-Payment` header wrapping an EIP-3009 `TransferWithAuthorization` USDC signature over `{from, to, value, validAfter, validBefore, nonce}`. Path B signs this with the EOA key. Path A relies on Base MCP's x402 capability to sign it from the Base Account — **a smart-contract wallet signs via ERC-1271, not EOA ECDSA**, so confirm Base MCP + Brickken's facilitator settle this on your surface before treating Path A as keyless.
-- **Path A vs B economics.** Path A = prepare USDC + Base gas (Base Account broadcasts). Path B = full USDC total + native gas from the EOA unless Brickken confirms sponsorship (Brickken's backend broadcasts the locally signed transaction after the send-side x402 payment). Path A skips Brickken's `send-transactions` fee; the IPFS upload for `register`/`set-uri`/`append-response` happens at **prepare**, so a Path-A broadcast is functionally complete.
+- **x402 mechanics.** Only the **send** step is paid. Its 402 carries a `PAYMENT-REQUIRED` header; payment is a base64 `X-Payment` header wrapping an EIP-3009 `TransferWithAuthorization` USDC signature over `{from, to, value, validAfter, validBefore, nonce}`, signed by the EOA key on Path B. Path A never hits a paid step — building calldata is free and the Base Account broadcasts it directly via `send_calls`.
+- **Path A vs B economics.** Path A = no Brickken fee + Base gas (the Base Account broadcasts). Path B = the x402 **send** fee + native gas from the EOA unless Brickken confirms sponsorship (Brickken's backend broadcasts the locally signed transaction). The IPFS upload for `register`/`set-uri`/`append-response` happens at **prepare** (free), so a Path-A broadcast is functionally complete with no Brickken charge.
 - **Chains.** Brickken maps decimal `8453` → internal hex `2105`; pass `8453` (or `0x2105`). Brickken's testnet is **Ethereum Sepolia (11155111)**, which is *not* Base's `base-sepolia` (84532) — there is no shared testnet, so this plugin targets `chains: [base]` (mainnet) only.
 - **Reference addresses (Sepolia, for orientation only):** identity registry `0x8004A818BFB912233c491871b3d84c89A494BD9e`, reputation registry `0x8004B663056A597Dffe9eCcC1965A193B7388713`, agent-token factory `0xB082876148de3a8372d5fa333a9364f9eD16354B`. Get Base addresses from the `prepare` response `info`, not these.
-- **CLI is x402-only** — it ignores `BRICKKEN_API_KEY`/`BKN_API_KEY`. Both `prepare` and `send` are x402-priced, so an executed command costs the Total above.
+- **CLI is x402-only.** Only the **send** step is priced — preparing calldata is free — so a prepare-only command (no `--execute`) costs nothing, and an executed command costs the send fee above.

--- a/skills/base-mcp/plugins/brickken.md
+++ b/skills/base-mcp/plugins/brickken.md
@@ -1,0 +1,210 @@
+---
+title: "Brickken Plugin"
+description: "ERC-8004 agent identity, reputation, and agent-owned ERC-20s on Base — Brickken builds unsigned calldata for send_calls, or self-executes through its x402 CLI/MCP."
+tags: [ai-agents, agent-commerce, token-launches]
+name: brickken
+version: 0.2.0
+integration: hybrid
+chains: [base]
+requires:
+  shell: optional
+  allowlist: [api.brickken.com, api.sandbox.brickken.com]
+  externalMcp: { name: brickken, url: https://mcp.brickken.com/mcp }
+  cliPackage: npx brickken-cli
+auth: none
+risk: [irreversible, pii]
+---
+
+# Brickken Plugin
+
+> [!IMPORTANT]
+> Run Base MCP onboarding first (see `SKILL.md`). Brickken's agent API is **x402-paid**: every call costs USDC, so the payer (the Base Account on Path A when settlement is supported, or a funded EOA key on Path B) must hold USDC on the target chain before you start. The Base Account address is fetched lazily via `get_wallets` when a call needs it.
+
+## Overview
+
+Brickken puts the **ERC-8004** agent stack onchain: a registry for **agent identity**, a registry for **reputation/feedback**, and an **agent-owned ERC-20** factory for launching and managing agent tokens. This plugin covers those agent methods on Base. Brickken does not execute through one fixed route — it **builds the unsigned calldata** for each action, and you choose how it lands onchain:
+
+- **Path A — Base Account via `send_calls` (x402-gated).** Brickken builds the calldata; when Base MCP can settle Brickken's x402 prepare invoice from the Base Account, the user's Base Account signs and broadcasts it through `send_calls`. Submission tool: **`send_calls`**.
+- **Path B — Brickken self-executes (key-based).** The `brickken` CLI (or the Brickken MCP with a `privateKey`) signs with a local EOA key, pays x402, and broadcasts — no Base Account. Submission tool: **`none`**.
+
+Both are first-class; pick per surface in [Surface Routing](#surface-routing). The agent API is x402-native: `prepare-transactions` and `send-transactions` are **each** priced in USDC (EIP-3009 `TransferWithAuthorization`). Path A pays only the prepare fee (then Base gas via `send_calls`); Path B pays the full USDC total plus native gas from the EOA unless Brickken confirms sponsorship for the target chain. See [Risks & Warnings](#risks--warnings) for per-method costs.
+
+## Detection
+
+The Brickken MCP path is available only if the harness exposes Brickken tools (`agent_register`, `agent_create_token`, `prepare_transactions`, …). If no `agent_*` tool is callable, the MCP is not installed — use the CLI (Path B, shell required) or call the HTTP API directly (see [Installation](#installation)). Do not assume the MCP is present. For Path A, prefer `prepare_transactions`; `agent_*` tools may auto-execute when the Brickken MCP session has a `privateKey`.
+
+## Installation
+
+Three routes reach Brickken; install only what your surface uses.
+
+**HTTP API (no install).** Build calldata by POSTing to the Brickken API — host `api.brickken.com` (production) or `api.sandbox.brickken.com` (sandbox) must be on the Base MCP `web_request` allowlist for chat-only surfaces. On harnesses with a direct HTTP tool, no allowlist is needed.
+
+**Brickken CLI (Path B, needs a shell).** No install step — run via `npx`:
+
+```bash
+npx brickken-cli --help          # or: npm i -g brickken-cli  →  brickken --help
+```
+
+The CLI is **x402-only** — it ignores API keys. Provide an EOA key for local transaction signing, x402 payment, and native gas on the target chain unless Brickken confirms sponsorship:
+
+```bash
+export BRICKKEN_PRIVATE_KEY=0x... # alias: BKN_PRIVATE_KEY
+```
+
+**Brickken MCP (optional, for the MCP path).** Remote MCP at `https://mcp.brickken.com/mcp`. Add it alongside Base MCP, e.g. in Claude Code:
+
+```bash
+claude mcp add --transport http brickken https://mcp.brickken.com/mcp
+```
+
+For other harnesses use the same URL in the connector/`mcpServers` config. A session that should self-execute (Path B via MCP) must be given a `privateKey` through the MCP's `configure` tool.
+
+## Surface Routing
+
+| Step | Harness with shell (Claude Code, Codex, Cursor) | Harness with HTTP tool, no shell | Chat-only (Claude.ai, ChatGPT) |
+|---|---|---|---|
+| **Build calldata** (prepare) | Harness HTTP `POST /prepare-transactions`, Brickken MCP `prepare_transactions`, or `brickken` CLI prepare-only (`--json`, no `--execute`) | harness HTTP `POST /prepare-transactions` | Brickken MCP `prepare_transactions`, or `web_request` POST to the allowlisted Brickken host |
+| **Pay the prepare x402** | Base MCP x402 if settlement succeeds (Path A), or the CLI/EOA key (Path B) | Base MCP x402 if settlement succeeds (Path A) | Base MCP x402 if settlement succeeds (Path A) |
+| **Execute the action** | Path A `send_calls`, or Path B `brickken … --execute` | Path A `send_calls` | Path A `send_calls` |
+
+**Shell-less / chat-only:** Path B's CLI is unavailable without a shell — do not improvise it. Use Path A (`send_calls`) or the Brickken MCP. For Path A through Brickken MCP, call `get_config` first; use `prepare_transactions` or confirm `hasPrivateKey === false` before calling `agent_*`, because `agent_*` tools auto-execute when a `privateKey` is configured. Paying the prepare fee on Path A depends on Base MCP settling Brickken's x402 invoice from the Base Account (see [Notes](#notes) — verify on your surface). If neither a Base MCP x402 capability nor a funded EOA key is available to pay the prepare fee, stop and tell the user the call requires a USDC payment they can't currently make.
+
+## Endpoints
+
+HTTP path (Path A build-calldata, and Path B under the hood). API root: `https://api.brickken.com` (production) or `https://api.sandbox.brickken.com` (sandbox).
+
+**`POST /prepare-transactions`** — body `{ "method": <name>, "chainId": "8453", "signerAddress": <Base Account>, …method args }`. Returns **402** the first time → pay the x402 invoice → retry → **200**:
+
+```json
+{
+  "transactions": [
+    { "to": "0x…", "data": "0x…", "value": "0x0", "gasLimit": "0x…", "chainId": 8453, "nonce": 49 }
+  ],
+  "txId": "0x…",
+  "info": {
+    "agentUuid": "54399c6e-…",
+    "standard": "ERC-8004",
+    "registryAddress": "0x8004A818…",
+    "reputationRegistryAddress": "0x8004B663…",
+    "agentURI": "ipfs://Qm…",
+    "chainId": "eip155:8453"
+  }
+}
+```
+
+`method` values (this plugin's scope): `agentRegister`, `agentSetURI`, `agentSetMetadata`, `agentSetWallet`, `agentGiveFeedback`, `agentRevokeFeedback`, `agentAppendFeedbackResponse`, `agentCreateToken`, `agentMintToken`, `agentBurnToken`, `agentTransferToken`, `agentTransferFromToken`, `agentApproveToken`.
+
+Common args: `signerAddress` (must equal the broadcasting wallet); identity calls take `name/description/image/serviceName/serviceEndpoint/aiModelName/aiModelProvider/x402Support/active` (register/set-uri) or `agentId`/`agentUuid` + `metadataKey/metadataValue/metadataEncoding` (set-metadata); token calls take `tokenAddress`, `to`/`from`/`spenderAddress`, `amount`, `decimals`. `agentRegister` requires `image` (backend validation).
+
+**`POST /send-transactions`** — `{ txId, signedTransactions }`. Used **only by Path B** (Brickken broadcasts). Path A skips it — `send_calls` broadcasts instead.
+
+> API-key alternative (not this plugin's default): the same host accepts an `x-api-key` header instead of paying x402. Use it only if you have a Brickken API key; with no key, the host falls back to the x402 invoice this plugin assumes.
+
+## Commands
+
+Path B. CLI ↔ backend method. Every command is **prepare-only by default**; add `--execute` to prepare → sign locally → send → pay x402 in one step. Add `--json` for machine-readable output.
+
+| Command | Method | Purpose |
+|---|---|---|
+| `brickken agent register` | `agentRegister` | Register an ERC-8004 agent identity |
+| `brickken agent set-uri` | `agentSetURI` | Update the agent profile/metadata URI (IPFS) |
+| `brickken agent set-metadata` | `agentSetMetadata` | Set one onchain key/value |
+| `brickken agent set-wallet` | `agentSetWallet` | Rotate the agent's operational wallet |
+| `brickken agent feedback give` | `agentGiveFeedback` | Submit reputation feedback |
+| `brickken agent feedback respond` | `agentAppendFeedbackResponse` | Respond to received feedback |
+| `brickken agent feedback revoke` | `agentRevokeFeedback` | Revoke a feedback entry |
+| `brickken create-token` | `agentCreateToken` | Deploy an agent-owned ERC-20 |
+| `brickken mint` / `burn` | `agentMintToken` / `agentBurnToken` | Mint / burn agent tokens |
+| `brickken transfer` / `transfer-from` | `agentTransferToken` / `agentTransferFromToken` | Transfer agent tokens |
+| `brickken approve` | `agentApproveToken` | Approve an ERC-20 allowance |
+| `brickken tx prepare --method <name>` | any | Raw method call — any backend method |
+
+Key flags: `--chain 8453`, `--signer-address <wallet>`, `--json`, `--execute`, `--file <json>` (nested payloads), `--env production` (or `--base-url <api root>`). For `create-token --execute`, set `--rpc-url`, `BRICKKEN_RPC_URL`, or `BKN_RPC_URL` when the CLI must recover `tokenAddress` on Base. Output JSON exposes `prepared.transactions[]`, `prepared.txId`, `prepared.info.agentUuid`, `prepared.info.agentURI`, `sent.txHash`, and `tokenAddress` (after `create-token --execute` when receipt lookup succeeds).
+
+## Orchestration
+
+Pick a path from [Surface Routing](#surface-routing). `signerAddress` must equal the wallet that will broadcast — on Path A that's the Base Account, on Path B the EOA behind the key.
+
+### Path A — Base Account via `send_calls`
+
+1. `get_wallets` → the Base Account address (use as `signerAddress`, `chainId: "8453"`).
+2. Build calldata: `POST /prepare-transactions` (harness HTTP / `web_request`) or Brickken MCP `prepare_transactions`, **without** executing. Use `agent_*` only after `get_config` confirms `hasPrivateKey === false`.
+3. Pay the **prepare** x402 invoice with Base MCP's x402 capability if it can settle Brickken's EIP-3009 invoice from the Base Account. If settlement fails, stop and report that Path A is unavailable on the current surface.
+4. Map `transactions[]` → `send_calls` (see [Submission](#submission)). For multi-step results (e.g. approve + action), pass them as one batch in order.
+5. User approves the `send_calls` request; poll status (see `../references/approval-mode.md`). Report success only after the status tool confirms it.
+
+### Path B — Brickken self-executes (CLI / MCP)
+
+1. Set `BRICKKEN_PRIVATE_KEY` (alias: `BKN_PRIVATE_KEY`). The EOA must hold USDC for x402 and native gas on the target chain unless Brickken confirms sponsorship.
+2. Run the command with `--execute --json`, e.g. `brickken --env production agent register --chain 8453 --signer-address $WALLET --name … --image … --x402-support true --execute --json`. This pays **prepare + send** x402, signs locally, and broadcasts through Brickken's backend.
+3. Parse `sent.txHash`; for `create-token`, capture `tokenAddress`; for `register`, capture `prepared.info.agentUuid` and reuse it in `set-uri` / `set-metadata`. Don't continue `create-token` → `mint` unless `tokenAddress` is present.
+
+> `agentGiveFeedback` returned a backend **500** during June 2026 sandbox testing — re-test before featuring feedback in a happy path, and surface the error rather than retrying blindly.
+
+## Submission
+
+**Path A → `send_calls`** (EIP-5792 batched calls; see `../references/batch-calls.md`). Map each prepared transaction into a call:
+
+```
+transactions[i].to    → calls[i].to
+transactions[i].data  → calls[i].data
+transactions[i].value → calls[i].value   (default "0x0")
+```
+
+Call `send_calls` with `chain: "base"` (map `chainId 8453` → the Base MCP chain string `base`) and the `calls` array in the returned order — any approval precedes the action it unlocks. Drop `gasLimit`/`nonce`/`chainId` from the items; the Base Account fills them. Normalize `value` and `data` to `0x`-prefixed hex (default `value` to `"0x0"`); if Brickken returns `value` as a decimal string or a `{type:"BigNumber",hex}` object, convert to hex wei first. The prepare-fee x402 payment is a **separate step before** `send_calls`, not part of it. Follow the approval/polling flow in `../references/approval-mode.md`.
+
+**Path B → `none`.** The CLI / Brickken MCP submits to Brickken's own backend (which broadcasts after the x402 send payment); nothing routes through a Base MCP write tool.
+
+## Example Prompts
+
+**"Register my agent on Base."** (Path A)
+1. `get_wallets` → Base Account address.
+2. `POST /prepare-transactions` `{ method: "agentRegister", chainId: "8453", signerAddress: <address>, name, description, image, x402Support: true, active: true }`; pay the prepare x402.
+3. Map `transactions[]` → `send_calls(chain: "base", calls)`.
+4. User approves → poll status → report the agent identity (`info.agentUuid`, `info.agentURI`).
+
+**"Launch an agent token called RAGT and mint 1000 to me."** (Path B / CLI — agent-token deploy is the priciest call; confirm cost first)
+1. Confirm with the user: `agentCreateToken` ≈ **$9.99 USDC** + deploy gas on mainnet (see [Risks & Warnings](#risks--warnings)).
+2. `brickken --env production create-token --chain 8453 --signer-address $WALLET --name "Research Agent Token" --symbol RAGT --agent-wallet $WALLET --premint 1000 --decimals 18 --rpc-url $BASE_RPC_URL --execute --json` → capture `tokenAddress` + `sent.txHash`.
+3. `brickken --env production mint --chain 8453 --signer-address $WALLET --token-address $TOKEN --to $WALLET --amount 1000 --decimals 18 --execute --json`.
+
+**"Transfer 10 RAGT to 0xabc…."** (Path A)
+1. Prepare `{ method: "agentTransferToken", chainId: "8453", signerAddress: <Base Account>, tokenAddress, to: "0xabc…", amount: "10", decimals: "18" }`; pay prepare x402.
+2. `send_calls(chain: "base", calls)` → approve → poll.
+
+**Chat-only fallback.** On Claude.ai / ChatGPT with no harness HTTP tool: use the Brickken MCP if installed; otherwise the Brickken host must be allowlisted for `web_request` to POST `prepare-transactions`. If it isn't, tell the user this surface can't reach Brickken and point them to a harness with HTTP tools (e.g. Claude Code). Do not fall back to user-paste — the prepare call is a POST.
+
+## Risks & Warnings
+
+- **`irreversible`** — every action here is an onchain write (identity registration, wallet rotation, token deploy/mint/burn/transfer). They cannot be undone once broadcast. Confirm the target chain is `base` (8453) and the `signerAddress` matches the broadcasting wallet before submitting; never auto-rotate the agent wallet (`agentSetWallet`) without explicit user intent.
+- **`pii`** — identity and feedback calls accept emails (`ownerEmail`, feedback `email`) and free-text profile fields that get written onchain / pinned to IPFS. Don't send personal data the user didn't authorize; warn that anything submitted is public and permanent.
+- **Cost (x402, mainnet).** Each action is paid in USDC and is **non-refundable**. Path A pays the prepare column, then Base gas through `send_calls`; Path B pays prepare + send USDC plus native gas from the EOA unless Brickken confirms sponsorship. Always state the USDC cost and get confirmation before executing — especially `agentCreateToken` (**≈ $9.99** + deploy gas). Never auto-spend. Per-method totals are in [Notes](#notes).
+- **Base availability.** These contracts/prices are validated against Brickken's sandbox (Ethereum Sepolia). Confirm the ERC-8004 registries, token factory, and x402 facilitator are live on Base mainnet (8453) before promising execution there.
+
+## Notes
+
+**Mainnet x402 pricing (USDC/call, 2 calls per action).** Path A = Prepare only + Base gas; Path B = Total + native gas where required.
+
+| Method | Prepare | Send | Total | Extra |
+|---|---|---|---|---|
+| `agentRegister` | 0.50 | 0.49 | 0.99 | |
+| `agentSetURI` | 0.25 | 0.24 | 0.49 | + IPFS |
+| `agentSetMetadata` | 0.25 | 0.24 | 0.49 | |
+| `agentSetWallet` | 0.50 | 0.49 | 0.99 | |
+| `agentGiveFeedback` | 0.13 | 0.12 | 0.25 | |
+| `agentRevokeFeedback` | 0.13 | 0.12 | 0.25 | |
+| `agentAppendFeedbackResponse` | 0.25 | 0.24 | 0.49 | + IPFS |
+| `agentCreateToken` | 5.00 | 4.99 | 9.99 | + deploy gas (high) |
+| `agentMintToken` | 0.05 | 0.05 | 0.10 | + ERC-20 gas |
+| `agentBurnToken` | 0.03 | 0.02 | 0.05 | + ERC-20 gas |
+| `agentTransferToken` | 0.03 | 0.02 | 0.05 | + ERC-20 gas |
+| `agentTransferFromToken` | 0.03 | 0.02 | 0.05 | + ERC-20 gas |
+| `agentApproveToken` | 0.02 | 0.01 | 0.03 | + ERC-20 gas |
+
+Sandbox / Sepolia is a flat ~$0.01 ref price per call — do not quote it for mainnet.
+
+- **x402 mechanics.** The 402 carries a `PAYMENT-REQUIRED` header; payment is a base64 `X-Payment` header wrapping an EIP-3009 `TransferWithAuthorization` USDC signature over `{from, to, value, validAfter, validBefore, nonce}`. Path B signs this with the EOA key. Path A relies on Base MCP's x402 capability to sign it from the Base Account — **a smart-contract wallet signs via ERC-1271, not EOA ECDSA**, so confirm Base MCP + Brickken's facilitator settle this on your surface before treating Path A as keyless.
+- **Path A vs B economics.** Path A = prepare USDC + Base gas (Base Account broadcasts). Path B = full USDC total + native gas from the EOA unless Brickken confirms sponsorship (Brickken's backend broadcasts the locally signed transaction after the send-side x402 payment). Path A skips Brickken's `send-transactions` fee; the IPFS upload for `register`/`set-uri`/`append-response` happens at **prepare**, so a Path-A broadcast is functionally complete.
+- **Chains.** Brickken maps decimal `8453` → internal hex `2105`; pass `8453` (or `0x2105`). Brickken's testnet is **Ethereum Sepolia (11155111)**, which is *not* Base's `base-sepolia` (84532) — there is no shared testnet, so this plugin targets `chains: [base]` (mainnet) only.
+- **Reference addresses (Sepolia, for orientation only):** identity registry `0x8004A818BFB912233c491871b3d84c89A494BD9e`, reputation registry `0x8004B663056A597Dffe9eCcC1965A193B7388713`, agent-token factory `0xB082876148de3a8372d5fa333a9364f9eD16354B`. Get Base addresses from the `prepare` response `info`, not these.
+- **CLI is x402-only** — it ignores `BRICKKEN_API_KEY`/`BKN_API_KEY`. Both `prepare` and `send` are x402-priced, so an executed command costs the Total above.


### PR DESCRIPTION
Adds a native Base MCP plugin for Brickken ERC-8004 agent identity, reputation, and agent-owned ERC-20 operations.

The plugin supports:
- Path A: Brickken prepares unsigned calldata, Base MCP submits via send_calls when x402 settlement from the Base Account succeeds.
- Path B: Brickken CLI/MCP self-submits when configured with an EOA key.
- Mainnet x402 cost disclosure, native gas requirements, and sandbox caveats.

Also registers Brickken in the Base MCP native plugins table.

Validation:
- Checked against skills/base-mcp/references/plugin-spec.md required frontmatter and canonical headings.
- Ran git diff --check.