### PR TITLE
Remove dead NOTIFICATIONS.md links in minikit-to-farcaster mapping

### DIFF
--- a/skills/build-on-base/references/migrations/minikit-to-farcaster/mapping.md
+++ b/skills/build-on-base/references/migrations/minikit-to-farcaster/mapping.md
@@ -409,7 +409,7 @@ function AuthButton() {
 
 ## useNotification
 
-Notifications require server-side implementation. See [NOTIFICATIONS.md](NOTIFICATIONS.md) for details.
+Notifications require server-side implementation.
 
 ### Before (MiniKit)
 ```typescript
@@ -448,5 +448,3 @@ function NotifyButton() {
   return <button onClick={handleNotify}>Send Test</button>;
 }
 ```
-
-See [NOTIFICATIONS.md](NOTIFICATIONS.md) for server-side implementation.


### PR DESCRIPTION
The useNotification section in the minikit-to-farcaster mapping links to NOTIFICATIONS.md twice but that file does not exist in the repo and is not listed in the migration overview. Both links are dead. Removed the two references. The section still explains notifications go through a server webhook and keeps the before and after code examples.

Type of change: documentation. Affected skill: build-on-base.