### PR TITLE
fix: register.sh fails to parse builder_code when JSON has whitespace around the colon

### DIFF
--- a/skills/build-on-base/scripts/register.sh
+++ b/skills/build-on-base/scripts/register.sh
@@ -18,7 +18,7 @@ RESPONSE=$(curl -sf -X POST "$API_URL" \
   exit 1
 }
 
-BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code":"[^"]*"' | cut -d'"' -f4)
+BUILDER_CODE=$(echo "$RESPONSE" | grep -oE '"builder_code"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | cut -d'"' -f4)
 
 if [ -z "$BUILDER_CODE" ]; then
   echo "Error: No builder_code in API response" >&2


### PR DESCRIPTION
## Summary

`skills/build-on-base/scripts/register.sh` cannot extract `builder_code` from the registration API response when the JSON is pretty-printed, so registration exits 1 even on a call the API fulfilled.

Fixes #54.

## Root cause

Line 21 uses `grep -o '"builder_code":"[^"]*"'`, which requires the value to sit immediately after the colon. JSON permits whitespace there, and the real response - along with this repo's own reference in `references/agents/register.md` - is pretty-printed as `"builder_code": "..."`. The pattern matches nothing, the empty-value guard fires under `set -euo pipefail`, and the script exits 1.

## Fix

```sh
BUILDER_CODE=$(echo "$RESPONSE" | grep -oE '"builder_code"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | cut -d'"' -f4)
```

`[[:space:]]*` sits on both sides of the colon, so spaces and tabs are tolerated before it as well as after. `head -n 1` keeps the assignment a single line if the key ever appears more than once in a response.

`cut -d'"' -f4` still lands on the value: whatever whitespace the pattern absorbs stays inside the third quote-delimited field.

## Testing

Five response shapes, run against both patterns:

| Response shape | on `master` | with this PR |
| --- | --- | --- |
| `{"builder_code":"abc"}` | `abc` | `abc` |
| `{"builder_code": "abc"}` | empty | `abc` |
| `{"builder_code"  :   "abc"}` | empty | `abc` |
| `{"builder_code"\t:\t"abc"}` | empty | `abc` |
| multi-line pretty-printed | empty | `abc` |

`bash -n` clean.

## Not changed

Left as `grep` rather than a JSON parser on purpose: the script has no `jq` dependency today, and adding one for a single field would be a heavier change than this bug warrants.

Script-only, one line changed.
