### PR TITLE
Reframe Morpho no-shell path as HTTP API instead of MCP install

### DIFF
--- a/skills/base-mcp/plugins/morpho.md
+++ b/skills/base-mcp/plugins/morpho.md
@@ -3,13 +3,13 @@ title: "Morpho Plugin"
 description: "Lend, borrow, and manage vault or market positions on Morpho."
 tags: [lending, borrowing, vaults, yield]
 name: morpho
-version: 0.2.0
+version: 0.3.0
 integration: hybrid
 chains: [base]
 requires:
   shell: optional
-  allowlist: []
-  externalMcp: { name: morpho, transport: http, url: "https://mcp.morpho.org/" }
+  allowlist: [mcp.morpho.org]
+  externalMcp: null
   cliPackage: "npx @morpho-org/cli@latest"
 auth: none
 risk: [liquidation]
@@ -18,56 +18,35 @@ risk: [liquidation]
 # Morpho Plugin
 
 > [!IMPORTANT]
-> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any Morpho command or tool. Fetch the user's wallet address only when a flow actually needs it, such as position reads or write preparation.
+> Complete the short Base MCP onboarding flow defined in `SKILL.md` before calling any Morpho command or endpoint. Fetch the user's wallet address only when a flow actually needs it, such as position reads or write preparation.
 
 ## Overview
 
-Morpho is a lending protocol. This plugin has two supported execution paths:
+Morpho is a two-layer lending protocol: isolated markets (Morpho Blue) and vault aggregation (MetaMorpho). This plugin has two execution paths that both produce **unsigned calldata** submitted through Base MCP `send_calls`:
 
-1. **CLI-capable harnesses:** use Morpho CLI (`npx @morpho-org/cli@latest`) to query protocol state and prepare simulated unsigned transactions.
-2. **Chat-only or no-shell harnesses:** use Morpho MCP (`https://mcp.morpho.org/`) for vault discovery, position queries, and prepare-style tools.
+1. **Shell/terminal harnesses:** use the Morpho CLI (`npx @morpho-org/cli@latest`) to query protocol state and prepare simulated unsigned transactions.
+2. **Chat-only or no-shell harnesses:** call the hosted Morpho HTTP API at `https://mcp.morpho.org/` (JSON-RPC 2.0 over HTTP) for the same reads and prepare-style operations.
 
-Prefer Morpho CLI whenever the harness has shell/terminal access. If no shell is available, do not stop; detect whether Morpho MCP tools are already exposed, and if not, help the user install the Morpho MCP for their current surface. Both paths prepare unsigned calls that are submitted through Base MCP's `send_calls`.
-
-## Detection
-
-Use this routing order:
-
-1. **Shell/terminal available** (Codex, Claude Code, Cursor terminal, or similar): use the [Morpho CLI](#commands).
-2. **No shell, but Morpho MCP tools are exposed**: use the [MCP path](#orchestration).
-3. **No shell and no Morpho MCP tools**: help the user install Morpho MCP (see [Installation](#installation)), then ask them to reconnect or restart the session so the tools register.
-
-## Installation
-
-The Morpho CLI needs no install step — it runs via `npx @morpho-org/cli@latest` on any shell-capable harness.
-
-Install Morpho MCP when the MCP path is needed and its tools are not already exposed:
-
-- **Claude Code:** `claude mcp add morpho --transport http https://mcp.morpho.org/`
-- **Codex:** `codex mcp add morpho --url https://mcp.morpho.org/` (or add `[mcp_servers.morpho] url = "https://mcp.morpho.org/"` to `codex.toml`)
-- **Claude.ai web / Claude Desktop / iOS / Android:** Customize → Connectors → Add custom connector, name `morpho`, URL `https://mcp.morpho.org/`.
-- **ChatGPT:** Settings → Connectors → Create, name `morpho`, MCP Server URL `https://mcp.morpho.org/`, Authentication `OAuth` (enable Developer Mode if prompted).
-- **Cursor / JSON-config harnesses without shell:** add the JSON snippet below to the harness's MCP config and restart.
-- **Other / unknown no-shell harness:** show the JSON snippet below and ask the user where their MCP config lives.
-
-```json
-{
-  "mcpServers": {
-    "base-mcp": { "url": "https://mcp.base.org" },
-    "morpho": { "transport": "http", "url": "https://mcp.morpho.org/" }
-  }
-}
-```
+Prefer the CLI whenever the harness has shell/terminal access; otherwise use the HTTP API. Neither path requires installing a separate server — the HTTP API is a hosted endpoint.
 
 ## Surface Routing
 
-| Surface | Path |
-|---------|------|
-| Shell/terminal available | Morpho CLI (`npx @morpho-org/cli@latest`) → `send_calls`. |
-| No shell, Morpho MCP tools exposed | Morpho MCP prepare/read tools → `send_calls`. |
-| No shell, no Morpho MCP tools | Install Morpho MCP (see [Installation](#installation)), then use the MCP path. |
+Both paths read protocol state and return prepared unsigned calls; only the transport differs. HTTP routing follows the standard order in [../references/custom-plugins.md](../references/custom-plugins.md).
 
-Both paths submit through Base MCP `send_calls`; only the preparation differs. For `--chain base`, submit with `chain: "base"`.
+| Capability | Path |
+|-----------|------|
+| Read vaults / markets / positions / health (shell) | Morpho CLI query commands. |
+| Prepare deposit/withdraw/supply/borrow/repay/collateral (shell) | Morpho CLI `prepare-*` (simulates by default) → `send_calls`. |
+| Read or prepare (no shell) | Morpho HTTP API (JSON-RPC POST) at `mcp.morpho.org` — harness HTTP tool if available, else the chat-only HTTP path in [../references/custom-plugins.md](../references/custom-plugins.md) → `send_calls`. |
+
+The HTTP API is **POST/JSON-RPC**, so the GET-only user-paste fallback does not apply. On a chat-only surface with no POST-capable HTTP path, tell the user the operation needs a harness with HTTP tools (e.g. Claude Code) and stop — do not improvise.
+
+## Installation
+
+Neither path needs an install step:
+
+- **Morpho CLI** runs on demand via `npx @morpho-org/cli@latest` on any shell-capable harness — no global install.
+- **Morpho HTTP API** is a hosted endpoint at `https://mcp.morpho.org/` — nothing to install or register. Reaching it from a chat-only surface follows the HTTP routing in [../references/custom-plugins.md](../references/custom-plugins.md).
 
 ## Commands
 
@@ -106,6 +85,66 @@ Use the CLI's built-in flags (`--fields`, `--sort-by`, `--limit`, etc.) to shape
 
 For Base Account flows, use `--chain base` and submit prepared transactions through Base MCP with `chain: "base"`. The upstream CLI also supports other chain names; only submit through Base MCP when the chain is supported by Base MCP's `send_calls`.
 
+## Endpoints
+
+Use this path when no shell/terminal is available. The Morpho HTTP API exposes the same reads and prepare operations as the CLI.
+
+### Transport
+
+```
+POST https://mcp.morpho.org/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+```
+
+The endpoint speaks **JSON-RPC 2.0**. Call a method with `method: "tools/call"`, the method name in `params.name`, and its arguments in `params.arguments`. The response is returned as a Server-Sent Events frame — a single `data:` line wrapping the JSON-RPC envelope. Unwrap `result.content[0].text`, which is itself a JSON string holding the payload (vault list, `PreparedOperation`, etc.).
+
+Request example (top USDC vaults on Base):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "morpho_query_vaults",
+    "arguments": { "chain": "base", "assetSymbol": "USDC", "sort": "apy_desc", "limit": 5 }
+  }
+}
+```
+
+Every method requires `chain` (one of: `ethereum`, `base`, `arbitrum`, `optimism`, `polygon`, `unichain`, `worldchain`, `katana`, `hyperevm`, `monad`, `stable`). For Base Account flows use `chain: "base"` and submit through Base MCP with `chain: "base"`. Send `method: "tools/list"` to enumerate the live method set and exact parameters — the catalog below mirrors the CLI but may evolve.
+
+### Read methods
+
+| Method | Purpose / key args |
+|--------|--------------------|
+| `morpho_query_vaults` | Discover vaults. `chain`, `assetSymbol?`, `assetAddress?`, `sort?` (apy/tvl), `limit?`, `fields?`. |
+| `morpho_get_vault` | One vault. `chain`, `address`. |
+| `morpho_query_markets` | Discover Blue markets. `chain`, `loanAsset?`, `collateralAsset?`, `sortBy?`, `sortDirection?`, `limit?`. |
+| `morpho_get_market` | One market. `chain`, `id`. |
+| `morpho_get_positions` | All user positions (vault + market), zero balances filtered. `chain`, `userAddress`. |
+| `morpho_get_token_balance` | Balance + whether an approval is needed. `chain`, `userAddress`, `tokenAddress`. |
+| `morpho_query_docs` | Search Morpho protocol docs. `question`. |
+| `morpho_health_check`, `morpho_get_supported_chains` | Service and supported-chain metadata. |
+
+### Prepare methods
+
+Each returns a `PreparedOperation` with `transactions`, `requirements`, `outcome` (preview-derived post-state estimate), and `warnings`.
+
+| Method | Purpose / key args |
+|--------|--------------------|
+| `morpho_prepare_deposit` | Vault deposit. `chain`, `vaultAddress`, `userAddress`, `amount` (`"max"` allowed). |
+| `morpho_prepare_withdraw` | Vault withdraw. `chain`, `vaultAddress`, `userAddress`, `amount`. |
+| `morpho_prepare_supply` | Market supply. `chain`, `marketId`, `userAddress`, `amount`. |
+| `morpho_prepare_borrow` | Market borrow (includes health-factor check). `chain`, `marketId`, `userAddress`, `borrowAmount`. |
+| `morpho_prepare_repay` | Market repay. `chain`, `marketId`, `userAddress`, `amount`. |
+| `morpho_prepare_supply_collateral` | Add collateral without borrowing. `chain`, `marketId`, `userAddress`, `amount`. |
+| `morpho_prepare_withdraw_collateral` | Remove collateral (health-factor check when borrows exist). `chain`, `marketId`, `userAddress`, `amount`. |
+| `morpho_prepare_claim_rewards` | Claim Merkl rewards. `chain`, `userAddress`. |
+
+Amounts are human-readable units, not raw base units. Any required approval transactions are already included in the returned `transactions` array (USDT reset-to-zero and DAI non-standard approval are handled automatically).
+
 ## Orchestration
 
 ### CLI path
@@ -122,27 +161,25 @@ get_request_status(request ID) -> confirmed
 
 `prepare-*` commands simulate by default. Check `simulationOk` before presenting an approval link. If `simulationOk` is `false`, inspect and report the revert reason instead of submitting the batch.
 
-### MCP path
-
-Use this path only when no shell/terminal is available, or when the user explicitly asks to use the already connected Morpho MCP. Morpho MCP URL: `https://mcp.morpho.org/`.
-
-The exact list of Morpho tools, their parameters, and supported chains are exposed by the Morpho MCP itself. Read its tool descriptions rather than relying on a fixed catalog in this file. Tools may be added, renamed, or removed over time.
+### HTTP API path
 
 ```
-Morpho MCP read tool -> choose vault or market
-Morpho MCP prepare tool -> { calls: [...], chainId }
-send_calls(chain, calls) -> approval URL + request ID
+get_wallets -> user address
+POST mcp.morpho.org tools/call: morpho_query_* -> choose vault or market
+POST mcp.morpho.org tools/call: morpho_prepare_* -> PreparedOperation
+unwrap result.content[0].text -> review summary, outcome, warnings, transactions
+send_calls(chain="base", calls from transactions[]) -> approval URL + request ID
 user approves
 get_request_status(request ID) -> confirmed
 ```
 
-For MCP-generated calls, review any simulation output or warnings returned by the Morpho tool before submitting the batch. If the MCP exposes a simulation tool, use it for novel, large, borrow, or collateral-withdrawal operations.
+Respect warning severity in the `PreparedOperation`: `error` = HALT (do not present transactions for signing — explain the risk); `warning` = present but prominently flag it and require user acknowledgment; `info` = include in the summary for transparency. For borrow and collateral-withdrawal operations, read positions/health (`morpho_get_positions`, the prepare method's health check) and verify the health factor before and after.
 
 ## Submission
 
 Target tool: **`send_calls`** (both paths).
 
-A prepared operation includes a root `transactions` array (CLI) or a `{ calls, chainId }` object (MCP). For each transaction, pass only the unsigned call fields Base MCP needs:
+A prepared operation includes a `transactions` array. For each transaction, pass only the unsigned call fields Base MCP needs:
 
 ```json
 {
@@ -157,31 +194,31 @@ A prepared operation includes a root `transactions` array (CLI) or a `{ calls, c
 }
 ```
 
-Map the MCP-returned `chainId` to Base MCP's `chain` string. Then walk the approval flow and poll `get_request_status` — see [../references/batch-calls.md](../references/batch-calls.md) and [../references/approval-mode.md](../references/approval-mode.md).
+Preserve transaction order — approvals precede the protocol action. Map the chain to Base MCP's `chain` string, then walk the approval flow and poll `get_request_status` — see [../references/batch-calls.md](../references/batch-calls.md) and [../references/approval-mode.md](../references/approval-mode.md).
 
 ## Example Prompts
 
 ```
 Find the best USDC vault on Base by APY and deposit 100 USDC
 ```
-1. If shell exists, run `query-vaults --chain base --asset-symbol USDC --sort apy_desc --limit 5`; otherwise call the Morpho MCP vault query tool.
+1. If shell exists, run `query-vaults --chain base --asset-symbol USDC --sort apy_desc --limit 5`; otherwise POST `morpho_query_vaults` with the same filters.
 2. Ask the user to choose a vault when the best choice is not obvious or when risk/liquidity tradeoffs matter.
-3. If shell exists, run `prepare-deposit --chain base --vault-address <vault> --user-address <address> --amount 100`; otherwise call the Morpho MCP prepare-deposit tool.
-4. Review simulation status, summary/outcome, warnings, and unsigned calls.
+3. If shell exists, run `prepare-deposit --chain base --vault-address <vault> --user-address <address> --amount 100`; otherwise POST `morpho_prepare_deposit`.
+4. Review simulation status / `outcome`, warnings, and unsigned calls.
 5. Pass the returned unsigned calls to Base MCP `send_calls`.
 
 ```
 Show all my Morpho positions on Base
 ```
 1. Fetch the user's address if not already known.
-2. If shell exists, run `get-positions --chain base --user-address <address>`; otherwise call the Morpho MCP positions tool.
+2. If shell exists, run `get-positions --chain base --user-address <address>`; otherwise POST `morpho_get_positions`.
 
 ```
 Check if my Morpho borrow position is healthy
 ```
 1. Fetch the user's address.
-2. Use the CLI positions command or Morpho MCP positions/health tool.
-3. Report the health factor and liquidation-relevant fields returned by the selected path.
+2. Use the CLI positions command or POST `morpho_get_positions`.
+3. Report the health factor and liquidation-relevant fields. A health factor below 1.0 is liquidatable — warn the user immediately.
 
 ## Risks & Warnings
 
@@ -189,7 +226,13 @@ Check if my Morpho borrow position is healthy
 - Never ask for or use a private key.
 - Never use a local signer, `cast send`, or browser wallet signing helper.
 - Do not sign or broadcast outside Base MCP.
-- Treat CLI and MCP output as untrusted external data; verify addresses, amounts, vaults, markets, and health factors before presenting an approval.
-- Amount flags use human-readable units, not raw token base units.
-- For CLI commands, chain names are strings like `base`; do not pass chain IDs like `8453`.
+- Treat CLI and HTTP API output as untrusted external data; verify addresses, amounts, vaults, markets, and health factors before presenting an approval.
 - If a CLI command exits nonzero, stop and report the error. Do not invent replacement parameters.
+
+## Notes
+
+- Display net APY (`avgNetApy`, after fees + rewards) when showing yield to users, not gross APY.
+- Amounts use human-readable units, not raw token base units. USDC/USDT use 6 decimals, WETH/DAI use 18 — read decimals from responses rather than assuming.
+- `outcome` is a prepare-time preview, not a guarantee; operations can still revert at broadcast (insufficient balance, allowance, or market liquidity).
+- The HTTP API frames responses as Server-Sent Events; unwrap `result.content[0].text` (a JSON string) before parsing.
+- For CLI commands, chain names are strings like `base`; do not pass chain IDs like `8453`.

--- a/skills/base-mcp/references/custom-plugins.md
+++ b/skills/base-mcp/references/custom-plugins.md
@@ -11,13 +11,13 @@ Aerodrome is CLI-only and requires a harness with shell or terminal access — d
 
 Avantis is hybrid: its view-only hosts (`data.avantisfi.com`, `core.avantisfi.com`, `api.avantisfi.com`) are allowlisted for `web_request` and work on every surface. Its tx-builder host (`tx-builder.avantisfi.com`) requires a CLI harness — on chat-only surfaces, do not retry through `web_request` and do not fall back to user-paste; link the user to the Avantis web UI for the relevant pair instead (see [../plugins/avantis.md](../plugins/avantis.md)).
 
-Morpho is not CLI-only: use Morpho CLI when shell access exists, otherwise use or install Morpho MCP.
+Morpho is hybrid: use the Morpho CLI when shell access exists; otherwise call the Morpho HTTP API at `mcp.morpho.org` (POST/JSON-RPC) — its host is allowlisted for `web_request`. See [../plugins/morpho.md](../plugins/morpho.md).
 
 Custom or user-supplied plugins are almost certainly **not** in the allowlist and will be rejected by `web_request`.
 
 ## Priority order for HTTP calls
 
-Use this order **for every HTTP-based plugin call — native or not**. CLI-only plugins follow their plugin file and require shell access. Morpho follows its hybrid CLI/MCP routing in [../plugins/morpho.md](../plugins/morpho.md).
+Use this order **for every HTTP-based plugin call — native or not**. CLI-only plugins follow their plugin file and require shell access. Morpho follows its hybrid CLI/HTTP routing in [../plugins/morpho.md](../plugins/morpho.md).
 
 ### 1. Harness HTTP tool (preferred whenever available)
 
@@ -54,6 +54,6 @@ So for non-native plugins on Claude / ChatGPT consumer surfaces:
 | Aerodrome, no shell/terminal tool | Tell the user the plugin requires CLI access and stop. |
 | Avantis view-only reads (pairs, positions, history), no shell | Use `web_request` — the `data`, `core`, and `history` hosts are allowlisted. |
 | Avantis tx-builder calls, no shell | Do not retry through `web_request`. Link the user to the Avantis web UI (`https://www.avantisfi.com/trade?asset=<SYMBOL>-USD`) for the relevant pair. |
-| Morpho, no shell/terminal tool | Use already exposed Morpho MCP tools, or help the user install `https://mcp.morpho.org/` for their current surface. |
+| Morpho, no shell/terminal tool | Call the Morpho HTTP API at `mcp.morpho.org` (POST/JSON-RPC) via `web_request` — its host is allowlisted. See [../plugins/morpho.md](../plugins/morpho.md). |
 | Native HTTP plugin, no harness HTTP tool | Use `web_request` if the host is allowlisted. |
 | Non-native plugin, no harness HTTP tool (Claude / ChatGPT consumer apps) | GET only. Construct the URL, ask the user to paste it into the chat so you're allowed to fetch it, then parse the response. If the API needs POST, tell the user this surface can't support it. |


### PR DESCRIPTION
## What

Morpho's endpoint at `https://mcp.morpho.org/` is a hosted **JSON-RPC 2.0 over HTTP** server. A plain `POST` works end-to-end — I verified `initialize`, `tools/list`, and a live `tools/call` (`morpho_query_vaults` returned real Base vault data) **with no install and no session**. Per the [plugin spec](../blob/master/skills/base-mcp/references/plugin-spec.md), that's the `http-api` integration pattern.

So this reframes the plugin's no-shell path from *"install the Morpho MCP and reconnect"* to *"call the HTTP API directly."* It stays `hybrid` — CLI when a shell exists, HTTP API otherwise.

## Changes

**`plugins/morpho.md`** (`v0.2.0` → `v0.3.0`)
- Frontmatter: `allowlist: []` → `[mcp.morpho.org]`; `externalMcp: {…}` → `null` (cliPackage unchanged).
- Removed `## Detection` and the multi-harness MCP-install content in `## Installation`.
- Added `## Endpoints`: JSON-RPC transport (POST, required headers, SSE-unwrap of `result.content[0].text`) + a method catalog mirroring the CLI. Kept `## Commands` for the CLI path.
- `## Orchestration`: replaced the MCP sub-flow with an HTTP API sub-flow.
- Refreshed `## Surface Routing`, `## Example Prompts`, `## Submission`, `## Notes`.

**`references/custom-plugins.md`**
- Updated the three Morpho routing references so they no longer say "install Morpho MCP" and point at the HTTP API instead (kept `web_request` here — this file *is* the web_request-allowlist reference).

## Note for reviewers

`morpho.md` deliberately contains **no mention of `web_request`** — chat-only mechanics are deferred to `custom-plugins.md` via reference, and the host requirement lives in the `allowlist` frontmatter field. Landing this assumes `mcp.morpho.org` gets added to the Base MCP `web_request` allowlist so chat-only surfaces can reach it.