### PR TITLE
feat: add plugin-review skill

### DIFF
--- a/.claude/skills/plugin-review/SKILL.md
+++ b/.claude/skills/plugin-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: plugin-review
+description: Validate and review Base MCP plugin files against the Plugin Specification. Use when writing a new plugin, preparing a plugin PR for submission, self-checking a plugin before opening a PR, or reviewing someone else's plugin PR. Triggers on requests like "check my plugin against the spec", "validate this plugin file", "review my plugin PR", "does this plugin conform to the spec", "prepare my plugin for submission", "write a plugin for X protocol".
+license: Complete terms in LICENSE.txt
+---
+
+# Plugin Review
+
+Validate Base MCP plugin files against the current Plugin Specification. Produces a conformance report with actionable findings.
+
+Works for both **authors** (self-check before submitting a PR) and **reviewers** (evaluate an incoming PR).
+
+## Workflow
+
+1. **Fetch the current spec** (it changes — never rely on a stale copy):
+   ```bash
+   curl -s https://raw.githubusercontent.com/base/skills/master/skills/base-mcp/references/plugin-spec.md
+   ```
+   Related docs worth reading: `references/custom-plugins.md`, `references/approval-mode.md`, `references/batch-calls.md`, and `SKILL.md` (the root skill). Existing native plugins under `skills/base-mcp/plugins/` are the precedent for conventions.
+
+2. **Read the plugin file** in full. If reviewing a PR:
+   ```bash
+   gh pr view <n> --repo base/skills --json title,body,number,headRefName,files,additions,deletions
+   gh pr diff <n> --repo base/skills
+   # raw plugin file (diff may be truncated):
+   gh api "repos/base/skills/pulls/<n>/files" --jq '.[] | select(.filename|endswith(".md")) | .raw_url'
+   ```
+
+3. **Static conformance evaluation** — assess against every dimension in `references/evaluation-criteria.md`. Write the report using `references/report-template.md`.
+
+4. **(Optional) Live API / SDK verification** — exercise the documented endpoints/SDK/contracts with read-only calls. See `references/live-testing.md`. Append a `## Live API / SDK Verification` section to the report. This routinely overturns doc claims (fabricated/locked endpoints, broken hosts, wrong response shapes).
+
+5. **Save the report.** If reviewing a PR and asked to comment, draft a PR comment from the report using `references/comment-guidelines.md` and post with: `gh pr comment <n> --repo base/skills --body-file <comment-file>`.
+
+## Multiple PRs
+
+Evaluate PRs in parallel by spinning up one sub-agent per PR (each writes its own report + returns a short verdict summary). Hand each sub-agent: the spec (or its raw URL), the PR number, the evaluation criteria, the report template, and the comment guidelines.
+
+## Critical gotchas
+
+These recur and are easy to get wrong — full detail in `references/evaluation-criteria.md`:
+
+- **Smart-account signatures break naive signing.** The default Base MCP wallet is a smart contract; `sign` returns a variable-length ERC-1271/6492 signature (>200 bytes), not a 65-byte EOA sig. Any plugin that splices a signature into a fixed-width calldata slot, or bakes an off-chain EIP-712 signature into calldata (e.g. Permit2 `buildCallWithPermit2`), is **broken** for that wallet. Correct pattern: onchain allowance grants.
+- **`irreversible` risk is NOT for every onchain write.** The spec says "flag when worth emphasizing." Pure swaps use `slippage` (precedent: Uniswap, Aerodrome carry `[slippage]`, not `irreversible`). Reserve `irreversible` for asymmetric/severe cases (perps/liquidation, token launches/rug). Do not demand it on swaps.
+- **Don't self-register.** A plugin PR must NOT edit the `SKILL.md` plugins table, the Integration Types "Examples" cell, or the "Existing Plugin Conformance" table — those are maintainer-managed (codified in plugin-spec.md "Contribution Scope"). The only sanctioned shared-file edit is appending a genuinely net-new tag to the vocabulary list. Limit the diff to `plugins/<slug>.md` (+ that tag line).
+- **`version` is the plugin-doc version** — not the npm/package version and not a global spec version. The spec mandates no specific starting number.
+- **Verify claims, don't trust them.** Auth models, allowlist completeness, response shapes, and contract addresses are frequently wrong in the doc. Probe them (live testing).
+- **Reference links** from a plugin file must use `../references/...` (plugin files live in `plugins/`, refs in `references/`).

--- a/.claude/skills/plugin-review/SKILL.md
+++ b/.claude/skills/plugin-review/SKILL.md
@@ -26,9 +26,9 @@ Works for both **authors** (self-check before submitting a PR) and **reviewers**
    gh api "repos/base/skills/pulls/<n>/files" --jq '.[] | select(.filename|endswith(".md")) | .raw_url'
    ```
 
-3. **Static conformance evaluation** — assess against every dimension in `references/evaluation-criteria.md`. Write the report using `references/report-template.md`.
+3. **Static conformance evaluation** — assess against every dimension in `references/evaluation-criteria.md` (includes compliance/language checks and high-risk category gates). Write the report using `references/report-template.md`.
 
-4. **(Optional) Live API / SDK verification** — exercise the documented endpoints/SDK/contracts with read-only calls. See `references/live-testing.md`. Append a `## Live API / SDK Verification` section to the report. This routinely overturns doc claims (fabricated/locked endpoints, broken hosts, wrong response shapes).
+4. **(Optional) Live API / SDK verification** — exercise the documented endpoints/SDK/contracts with read-only calls. See `references/live-testing.md`. For perps/prediction-market/gambling plugins, also run the **geoblock verification** (compare frontend vs API access restrictions). Append a `## Live API / SDK Verification` section to the report. This routinely overturns doc claims (fabricated/locked endpoints, broken hosts, wrong response shapes).
 
 5. **Save the report.** If reviewing a PR and asked to comment, draft a PR comment from the report using `references/comment-guidelines.md` and post with: `gh pr comment <n> --repo base/skills --body-file <comment-file>`.
 
@@ -46,3 +46,6 @@ These recur and are easy to get wrong — full detail in `references/evaluation-
 - **`version` is the plugin-doc version** — not the npm/package version and not a global spec version. The spec mandates no specific starting number.
 - **Verify claims, don't trust them.** Auth models, allowlist completeness, response shapes, and contract addresses are frequently wrong in the doc. Probe them (live testing).
 - **Reference links** from a plugin file must use `../references/...` (plugin files live in `plugins/`, refs in `references/`).
+- **Neutral language is mandatory.** No yield/rate/performance claims, no "you should buy X", no "always deposit here", no defaulting to specific tokens. Steering language is a blocker.
+- **Perps, prediction markets, and privacy plugins need legal review** before inclusion as native plugins. Flag this as a pre-merge process gate in the report.
+- **API geoblock parity.** If the protocol's frontend geoblocks US IPs (or others), the API must enforce equivalent restrictions. If it doesn't, Base MCP risks being a circumvention tool — flag as a blocker.

--- a/.claude/skills/plugin-review/references/comment-guidelines.md
+++ b/.claude/skills/plugin-review/references/comment-guidelines.md
@@ -1,0 +1,42 @@
+# PR Comment Guidelines
+
+When reviewing a plugin PR, draft the comment to a file first. **Only post when explicitly instructed.**
+
+## Style rules
+- **Professional and concise.** Skimmable. Actionable.
+- **No emojis.**
+- **No compliments / no praise.** Don't tell authors their work is good. Omit "Strengths." Don't include non-actionable "this part is correct" notes (the only exception: a brief "leave X as-is" guard if there's real risk of them breaking a working piece while changing other things — and frame it as guidance, not praise).
+- **No testing-context asides.** Never mention how the finding was produced (no "we ran read-only", "no funds moved", etc.). State findings as **facts about the plugin / API / contracts**, e.g. "`POST /x` returns HTTP 500 on all endpoints," "the API requires an object, not a string," "Seaport calldata isn't returned as hex."
+- **Cite specifics**: field names, endpoints, file paths, section names, contract behavior. Link shared files (e.g. the tag vocabulary in `references/plugin-spec.md`) when asking for an edit there.
+
+## Structure
+Open with one neutral framing sentence (what's needed before merge, no praise). Then group findings:
+
+```markdown
+<one-line framing — e.g. "A few changes before merge:" or "There are structural and functional issues to resolve before this can be reviewed for merge.">
+
+**Required**
+- <blocking/major items — what's wrong + the concrete fix>
+
+**Minor**
+- <minor/nit items>
+```
+
+- Use **Required** for blockers/majors, **Minor** for the rest. Call out "blocking" explicitly when an item makes the plugin unusable for the default wallet or unroutable.
+- If there are no required items, omit the **Required** section (don't pad).
+- Sub-bullet multi-part items (e.g. several request-schema mismatches under one bullet).
+
+## Always include when applicable
+
+- **Contribution scope (Required) — if the PR edits shared/registry files.** Tell them to revert the `SKILL.md` plugins-table row and any `references/plugin-spec.md` edits to the Integration Types "Examples" cell, the "Existing Plugin Conformance" table, or the plugin count — maintainers register plugins when the program is ready. Preserve only a genuinely net-new tag-vocabulary addition. Limit the diff to `plugins/<slug>.md` (+ that tag line). Tailor: list exactly which files/edits to revert for this PR.
+
+## Calibration (don't over-ask)
+- Don't recommend `irreversible` on swap plugins (see evaluation-criteria gotcha #2).
+- Don't mandate a specific `version` number; at most flag package-mirroring "in case unintended."
+- Don't ask for things the MCP client handles (e.g. transport headers like `Mcp-Session-Id` are handled by the client, not the plugin).
+- Don't flag a correct chat-only "stop" as a defect.
+
+## Posting (only when instructed)
+```bash
+gh pr comment <n> --repo base/skills --body-file <comment-file>
+```

--- a/.claude/skills/plugin-review/references/comment-guidelines.md
+++ b/.claude/skills/plugin-review/references/comment-guidelines.md
@@ -29,6 +29,9 @@ Open with one neutral framing sentence (what's needed before merge, no praise). 
 ## Always include when applicable
 
 - **Contribution scope (Required) — if the PR edits shared/registry files.** Tell them to revert the `SKILL.md` plugins-table row and any `references/plugin-spec.md` edits to the Integration Types "Examples" cell, the "Existing Plugin Conformance" table, or the plugin count — maintainers register plugins when the program is ready. Preserve only a genuinely net-new tag-vocabulary addition. Limit the diff to `plugins/<slug>.md` (+ that tag line). Tailor: list exactly which files/edits to revert for this PR.
+- **Promotional / steering language (Required).** If the plugin copy contains yield/rate/performance claims, directional recommendations ("you should buy X", "always deposit here"), default parameters steering toward specific tokens, or actions routing outside Base without clear user intent — request removal. State the specific text that needs to change.
+- **API geoblock gap (Required) — for perps/prediction-market/gambling plugins.** If the protocol's frontend geoblocks US IPs but the API serves them, flag this as a blocker and ask the submitter to confirm whether API-level restrictions are planned or already enforced.
+- **High-risk category note — for perps, prediction markets, privacy plugins.** Note that plugins in these categories require additional review before inclusion as a native plugin. This is informational to the submitter, not a change request on the plugin itself.
 
 ## Calibration (don't over-ask)
 - Don't recommend `irreversible` on swap plugins (see evaluation-criteria gotcha #2).

--- a/.claude/skills/plugin-review/references/evaluation-criteria.md
+++ b/.claude/skills/plugin-review/references/evaluation-criteria.md
@@ -1,0 +1,81 @@
+# Evaluation Criteria
+
+Assess each plugin against these dimensions. The spec (`skills/base-mcp/references/plugin-spec.md`) is the source of truth — fetch the current version; it changes. Cite evidence (line/section) for every finding.
+
+## Table of contents
+- File location & naming
+- Frontmatter
+- Integration type
+- Required body sections
+- Submission
+- Surface Routing
+- Allowlist
+- Security
+- Content quality
+- Cross-cutting gotchas (read these)
+- Severity rubric
+
+## File location & naming
+- Plugin file is at `skills/base-mcp/plugins/<slug>.md`.
+- `<slug>` matches frontmatter `name`.
+
+## Frontmatter
+Required fields present: `title`, `description`, `tags`, `name`, `version`, `integration`, `chains`.
+- **Enums valid**: `integration` ∈ {cli-only, http-api, external-mcp, semantic-base-tool, hybrid}; `requires.shell` ∈ {required, optional, none}; `auth` ∈ {none, api-key, siwe-jwt, oauth-on-install}; `risk` tags ∈ {liquidation, slippage, low-liquidity, pii, irreversible}.
+- **`chains` ⊆ supported set**: arbitrum, avalanche, base, base-sepolia, bsc, ethereum, optimism, polygon. `[]` is valid if no onchain tx routes through Base MCP. (Re-check the live `chain` param on Base MCP tools — the set can change.)
+- **`tags`**: 3–5 lowercase, hyphenated capability/category keywords (not the protocol name). Reuse existing vocabulary; flag net-new tags (and confirm they're appended to the vocabulary list — the one sanctioned shared-file edit).
+- **Capability flags** (`requires.shell/allowlist/externalMcp/cliPackage`, `auth`, `risk`) accurate and derived from real behavior, not copied from another plugin.
+- **`version`** is the plugin-doc version (semver). NOT the package/npm version, NOT a spec version. No mandated starting value.
+
+## Integration type
+Most specific value per the spec's ordered questions (first match wins): cli-only → http-api → external-mcp → semantic-base-tool → hybrid. If wrong, state the correct value and why.
+
+## Required body sections
+R = always required; C = conditional on flags.
+- R: `> [!IMPORTANT]` onboarding callout (first), `## Overview`, `## Surface Routing`, `## Orchestration`, `## Submission`, `## Example Prompts`.
+- C: `## Detection` + `## Installation` (external-mcp, or hybrid with MCP path, or `cliPackage` set); `## Auth` (auth ≠ none); `## Endpoints` (http-api) or `## Commands` (cli-only / CLI path of hybrid); `## Risks & Warnings` (risk non-empty). external-mcp omits Endpoints/Commands.
+- **Canonical heading names** — no synonyms (e.g. "Safety Notes"/"Execution Warnings" → `## Risks & Warnings`; "API" → `## Endpoints`; inline send_calls blocks → `## Submission`).
+- **Canonical order** as listed above; no broken internal `#anchor` links after renames.
+
+## Submission
+Names a concrete Base MCP tool — `send_calls`, `swap`, `sign`, or `none` — and shows the **exact mapping** from the endpoint/command/MCP output into that tool's input (`{to, value, data}` normalization, chain-string mapping, approvals-before-action batch order). For `none`, state why.
+
+## Surface Routing
+A capability × surface table (read vs write × harness vs chat-only) mapping to an execution path (harness HTTP tool / `web_request` / CLI / external MCP / UI-paste fallback). **Must state the shell-less / chat-only behavior** — an explicit fallback or an explicit "stop." (A correct chat-only "stop when the host isn't on the `web_request` allowlist" is good, not a defect.)
+
+## Allowlist
+`requires.allowlist` lists **every** external host the plugin fetches over HTTP, and no extras. This is the SSRF / `web_request` boundary. `[]` is only correct for cli-only / external-mcp plugins making no direct HTTP calls. Cross-check against the hosts actually referenced in the body (and, in live testing, actually contacted).
+
+## Security
+- Untrusted partner output: external APIs can return malicious calldata. Is `to`/target validated before submit? Are amounts/min-outs checked?
+- SSRF: does it take user-supplied URLs to fetch server-side?
+- Auth/API-key handling: keys never logged/echoed; secret mechanisms preferred over chat paste.
+- PII / irreversible: are the risk tags honest and complete (without over-tagging — see gotchas)?
+
+## Content quality
+Orchestration is realistic and actionable; example prompts are concrete (a read, a primary write, an edge/fallback); no copy-paste leftovers from another plugin; response shapes match reality.
+
+## Cross-cutting gotchas (the high-value, easy-to-miss ones)
+
+1. **Smart-account signatures (ERC-1271/6492) are variable-length (>200 bytes), not 65-byte EOA sigs.** The default Base MCP account is a smart contract wallet. Any plugin that:
+   - string-replaces a fixed 65-byte signature placeholder inside calldata, or
+   - bakes an off-chain EIP-712 signature into calldata (e.g. Permit2 `buildCallWithPermit2`)
+   is **broken** for the default wallet (works only for EOAs). Correct pattern: grant the allowance onchain in the `send_calls` batch (e.g. ERC20 `approve` → Permit2 `approve` → router call). Treat this as a blocker, not a nit.
+
+2. **`irreversible` risk is "flag when worth emphasizing," not every write.** Spec precedent: pure swap/DEX plugins (Uniswap, Aerodrome) carry `[slippage]` only. `irreversible` belongs on asymmetric/severe cases — perps/liquidation (Avantis), token launches/rug (Bankr). A swap is economically recoverable (swap back); its salient risk is `slippage`. Do NOT recommend adding `irreversible` to a swap plugin.
+
+3. **Contribution scope / self-registration.** Partners must NOT edit: the `SKILL.md` plugins table (registry), the Integration Types "Examples" cell, or the "Existing Plugin Conformance" table/count. These are maintainer-managed and bumping them causes merge conflicts between concurrent PRs and self-asserts "native" status. The ONLY sanctioned shared-file edit is appending a genuinely net-new tag to the vocabulary list in plugin-spec.md. (Codified in plugin-spec.md "Contribution Scope".) Self-registration edits must be reverted before merge.
+
+4. **`version` semantics.** Plugin-doc version, independent of upstream package version. Mirroring the package version is acceptable but worth flagging in case unintended. The spec mandates no specific starting number — do not assert "must be 0.2.0."
+
+5. **Allowlist provisioning is operator-controlled.** A plugin declaring `requires.allowlist` does not mean those hosts are live-allowlisted; that's a maintainer step (ideally bound to plugin acceptance). The plugin must fail safe on chat-only surfaces when not allowlisted (stop, don't improvise). Don't fault the plugin for this stop.
+
+6. **Reference links** use `../references/...` from plugin files (plugins live in `plugins/`, refs in `references/`). Bare `references/...` resolves to a non-existent `plugins/references/` path.
+
+7. **REST "build" endpoints may return decoded structs, not hex calldata.** If so, the curl→`send_calls` path needs an ABI-encode step the plugin must document (or restrict to a CLI path that encodes internally).
+
+## Severity rubric
+- **blocker** — breaks the documented flow, security hole, or makes the plugin unroutable (missing required frontmatter, broken submission for the default wallet, dead/locked API, false auth claim).
+- **major** — wrong integration type, missing required section, inaccurate allowlist, mis-declared auth.
+- **minor** — doc/response-shape drift, non-canonical headings, missing optional risk nuance.
+- **nit** — wording, formatting, version cosmetics.

--- a/.claude/skills/plugin-review/references/evaluation-criteria.md
+++ b/.claude/skills/plugin-review/references/evaluation-criteria.md
@@ -12,6 +12,10 @@ Assess each plugin against these dimensions. The spec (`skills/base-mcp/referenc
 - Allowlist
 - Security
 - Content quality
+- Compliance & language
+- Geoblocking (high-risk categories)
+- Disclaimers
+- High-risk category gate
 - Cross-cutting gotchas (read these)
 - Severity rubric
 
@@ -55,6 +59,24 @@ A capability × surface table (read vs write × harness vs chat-only) mapping to
 ## Content quality
 Orchestration is realistic and actionable; example prompts are concrete (a read, a primary write, an edge/fallback); no copy-paste leftovers from another plugin; response shapes match reality.
 
+## Compliance & language
+Plugin copy must use **neutral, non-promotional language**. Flag as a **blocker** if the plugin text contains any of:
+- Yield, rate, or performance claims ("earn 12% APY", "best returns")
+- Directional recommendations ("you should buy X", "always deposit here", "recommended strategy")
+- Default trade parameters that steer toward specific tokens or positions
+- Actions that route outside of Base without clear user intent (e.g. a plugin silently bridging to another chain or defaulting to a non-Base chain)
+
+The plugin must describe what the protocol *does*, not advocate for using it. Orchestration should present options neutrally, not prescribe a preferred action.
+
+## Geoblocking (high-risk categories)
+Applies to plugins in **perps, prediction markets, and gambling** categories. If the protocol's frontend geoblocks US IPs (or other jurisdictions), the underlying API must enforce equivalent restrictions. Check this during live testing (see `references/live-testing.md`). If the API serves US IPs while the frontend blocks them, Base MCP risks being deemed a circumvention tool — flag as a **blocker**.
+
+## Disclaimers
+The plugin's `> [!IMPORTANT]` onboarding callout (first element in the body) should include appropriate disclaimers about the plugin's third-party nature and any relevant risk context. For high-risk categories (perps, prediction markets, privacy), disclaimers should be more prominent. The plugin's `## Installation` section (if present) should also reference these disclaimers.
+
+## High-risk category gate
+Plugins in the following categories require **explicit legal review** before inclusion as a native plugin: **perps/perpetual futures, prediction markets, and privacy-focused protocols**. Flag this in the report if the plugin falls into one of these categories — it is not a defect in the plugin itself, but a pre-merge process gate.
+
 ## Cross-cutting gotchas (the high-value, easy-to-miss ones)
 
 1. **Smart-account signatures (ERC-1271/6492) are variable-length (>200 bytes), not 65-byte EOA sigs.** The default Base MCP account is a smart contract wallet. Any plugin that:
@@ -74,8 +96,12 @@ Orchestration is realistic and actionable; example prompts are concrete (a read,
 
 7. **REST "build" endpoints may return decoded structs, not hex calldata.** If so, the curl→`send_calls` path needs an ABI-encode step the plugin must document (or restrict to a CLI path that encodes internally).
 
+8. **Delist readiness.** Native plugins can be disabled quickly if the underlying API goes rogue, turns malicious, or starts returning harmful calldata. Although users review every transaction via approval mode, inclusion as a native plugin creates an expectation that things work as intended. The plugin itself doesn't need to implement a kill-switch, but reviewers should note if the plugin's architecture makes fast delisting difficult (e.g. hardcoded into core routing with no clean boundary).
+
+9. **Review scope is bounded.** Base review is limited to spec conformance, basic QA, and live testing as documented in this skill. The review does not constitute co-authorship or curation of the plugin's underlying protocol. This boundary is intentional — it allows the plugin program to scale without accumulating unbounded liability.
+
 ## Severity rubric
-- **blocker** — breaks the documented flow, security hole, or makes the plugin unroutable (missing required frontmatter, broken submission for the default wallet, dead/locked API, false auth claim).
-- **major** — wrong integration type, missing required section, inaccurate allowlist, mis-declared auth.
+- **blocker** — breaks the documented flow, security hole, makes the plugin unroutable (missing required frontmatter, broken submission for the default wallet, dead/locked API, false auth claim), promotional/steering language, or API circumvents frontend geoblocking in a regulated category.
+- **major** — wrong integration type, missing required section, inaccurate allowlist, mis-declared auth, missing disclaimers for high-risk category.
 - **minor** — doc/response-shape drift, non-canonical headings, missing optional risk nuance.
 - **nit** — wording, formatting, version cosmetics.

--- a/.claude/skills/plugin-review/references/live-testing.md
+++ b/.claude/skills/plugin-review/references/live-testing.md
@@ -27,5 +27,23 @@ Append findings as `## Live API / SDK Verification` in the report. Update the ve
 - Optimism: `https://mainnet.optimism.io`
 - Polygon: `https://polygon-rpc.com`
 
+## Geoblock verification (perps, prediction markets, gambling)
+
+For plugins in regulated categories where the protocol's frontend geoblocks certain jurisdictions (typically US), verify that the API enforces equivalent restrictions. If the API serves requests that the frontend would block, Base MCP risks being deemed a circumvention tool.
+
+Test from a US IP (or the relevant restricted jurisdiction):
+```bash
+# Compare frontend vs API behavior:
+# 1. Check if the protocol's website blocks US IPs (look for 403, redirects, or "not available in your region" pages)
+curl -s -o /dev/null -w "%{http_code}" https://<protocol-frontend>/
+
+# 2. Hit the same protocol's API endpoints the plugin documents
+curl -s -o /dev/null -w "%{http_code}" https://<protocol-api>/v1/quote?...
+
+# If the frontend returns 403/redirect but the API returns 200, flag as a blocker.
+```
+
+If you're behind a VPN, test from both a US and non-US exit to confirm the difference. Note: some APIs geoblock at the account/auth level rather than the IP level — probe both authenticated and unauthenticated paths.
+
 ### Safety recap
 Read-only/build only. Don't approve, don't broadcast, don't spend. Throwaway eval API keys end up in plaintext in the session — let them lapse after the review.

--- a/.claude/skills/plugin-review/references/live-testing.md
+++ b/.claude/skills/plugin-review/references/live-testing.md
@@ -1,0 +1,31 @@
+# Live Testing Playbook
+
+Optional phase that materially improves a review by checking reality instead of the doc's claims. **Strictly read-only / non-destructive**: never submit an onchain tx, spend funds, launch a token, buy, or sign-and-broadcast.
+
+## API / SDK verification
+
+Goal: confirm the documented endpoints/SDK/contracts actually exist and behave as claimed.
+
+Tools: `curl`, `node`, `npm`/`npx`, `cast` (foundry), Etherscan API, public RPCs.
+
+For each documented endpoint/command/SDK entrypoint:
+1. **Call it.** GET/quote/build endpoints are fine to call (they only return data) — do NOT submit returned calldata. Do NOT call endpoints that create/launch/buy even if they return data; probe those with HEAD/OPTIONS or a deliberately-invalid body to observe the error shape.
+2. **Record** exact request, HTTP status, and whether the response shape matches the doc.
+3. **Verify auth claims.** Probe unauthenticated — a `401` proves the endpoint is real and gated; a `402` proves an x402/paid path. This frequently contradicts the doc (e.g. "no auth" claims that actually 401; auth endpoints that turn out to be public; preview hosts that 500 on valid input).
+4. **SDK**: `npm view <pkg> version repository` to confirm it exists; optionally install in a temp dir and run a minimal read-only call. CLIs via npx: `npx -y <pkg> --help`.
+5. **Contracts**: confirm documented addresses exist onchain (`cast code <addr> --rpc-url <rpc-url>` or Etherscan) on the claimed chain.
+6. **Allowlist**: list hosts the plugin actually contacts; confirm `requires.allowlist` ⊇ that set with no extras.
+
+Append findings as `## Live API / SDK Verification` in the report. Update the verdict if reality changes it.
+
+### Useful public RPCs
+
+- Base: `https://mainnet.base.org`
+- Base Sepolia: `https://sepolia.base.org`
+- Ethereum: `https://eth.llamarpc.com`
+- Arbitrum: `https://arb1.arbitrum.io/rpc`
+- Optimism: `https://mainnet.optimism.io`
+- Polygon: `https://polygon-rpc.com`
+
+### Safety recap
+Read-only/build only. Don't approve, don't broadcast, don't spend. Throwaway eval API keys end up in plaintext in the session — let them lapse after the review.

--- a/.claude/skills/plugin-review/references/report-template.md
+++ b/.claude/skills/plugin-review/references/report-template.md
@@ -29,6 +29,10 @@ Write to a file like `PR-<n>-<slug>.md` (for PR reviews) or `<slug>-review.md` (
 | Canonical headings | | |
 | Canonical order / anchors intact | | |
 | allowlist accuracy | | |
+| Neutral language (no yield claims, no steering) | | |
+| Geoblock parity (if perps/prediction/gambling) | | frontend vs API |
+| Disclaimers in onboarding callout | | |
+| High-risk category gate (perps/prediction/privacy) | | legal review needed? |
 | Contribution scope (no self-registration) | | SKILL.md / Examples / Conformance table |
 
 ## Detailed Findings

--- a/.claude/skills/plugin-review/references/report-template.md
+++ b/.claude/skills/plugin-review/references/report-template.md
@@ -1,0 +1,49 @@
+# Evaluation Report Template
+
+Write to a file like `PR-<n>-<slug>.md` (for PR reviews) or `<slug>-review.md` (for self-checks). This is the thorough, evidence-based artifact. Be precise; quote the plugin where it matters.
+
+```markdown
+# <slug> — Plugin Spec Evaluation
+
+**Plugin:** `<slug>.md` · **Evaluated against:** current Base MCP Plugin Specification · **Date:** <YYYY-MM-DD>
+
+## Verdict
+<One of: ✅ Conforms / 🟡 Approve with minor changes / 🔴 Request changes.> <1–2 sentence rationale reflecting both static and (if run) live findings.>
+
+## Conformance Checklist
+| Requirement | Status | Notes |
+|---|---|---|
+| File location `plugins/<slug>.md` | ✅/🔴 | |
+| Frontmatter required fields | | title/description/tags/name/version/integration/chains |
+| Enum validity | | integration/shell/auth/risk |
+| chains ⊆ supported set | | |
+| tags (vocabulary, net-new flagged) | | |
+| integration most-specific | | |
+| `> [!IMPORTANT]` callout first | | |
+| `## Overview` | | |
+| `## Surface Routing` (+ chat-only behavior) | | |
+| `## Orchestration` | | |
+| `## Submission` (names tool + mapping) | | |
+| `## Example Prompts` | | |
+| Conditional sections (Detection/Installation/Auth/Endpoints/Commands/Risks) | | per flags |
+| Canonical headings | | |
+| Canonical order / anchors intact | | |
+| allowlist accuracy | | |
+| Contribution scope (no self-registration) | | SKILL.md / Examples / Conformance table |
+
+## Detailed Findings
+<Numbered. Each: severity (blocker/major/minor/nit) — what's wrong — spec ref — concrete fix.>
+
+## Live API / SDK Verification
+<Only if run. Table: Endpoint/Command | Tested how | Result ✅/⚠️/❌ | Evidence. + prose noting any contradiction between live behavior and the doc's claims. Update Verdict if live findings change it, noting the change explicitly.>
+
+## Security & Safety Notes
+<Specific concerns: untrusted calldata, SSRF, auth/key handling, PII, irreversibility, risk-tag honesty.>
+
+## Recommended Changes
+<Concise, prioritized bullets.>
+```
+
+## Notes
+- Verdict legend: ✅ conforms · 🟡 approve with changes · 🔴 request changes.
+- If a plugin predates a spec restructure, still evaluate against the **current** spec and note staleness.


### PR DESCRIPTION
## What

Adds a `plugin-review` skill under `.claude/skills/` that helps both plugin authors and reviewers validate Base MCP plugin files against the Plugin Specification.

## Why

Plugin authors currently have to manually cross-reference the spec to check conformance. This skill automates that by providing structured evaluation criteria, a report template, and a live-testing playbook — so authors can self-check before submitting a PR, and reviewers can produce consistent, evidence-based evaluations.

## What's included

| File | Purpose |
|---|---|
| `SKILL.md` | Workflow: fetch spec → read plugin → static conformance → optional live verification |
| `references/evaluation-criteria.md` | Every conformance dimension (frontmatter, sections, submission, allowlist, security) + severity rubric + cross-cutting gotchas (smart-wallet signatures, `irreversible` calibration, contribution scope) |
| `references/report-template.md` | Structured report format with conformance checklist |
| `references/comment-guidelines.md` | PR comment drafting rules (professional, concise, no praise, cite specifics) |
| `references/live-testing.md` | Read-only API/SDK/contract verification playbook with public RPCs |

## Key design decisions

- **Dual-use**: works for self-checks (authors) and PR reviews (reviewers)
- **Spec-first**: always fetches the current spec at runtime rather than embedding a stale copy
- **Read-only live testing**: exercises endpoints/SDKs/contracts without submitting transactions
- **Gotcha-aware**: encodes the recurring pitfalls (ERC-1271/6492 signatures, `irreversible` over-tagging, self-registration, allowlist accuracy)