### PR TITLE
feat(bitrefill): x402-native flows — connect→JWT, pay-per-call, re-ranked paths

### DIFF
--- a/skills/base-mcp/plugins/bitrefill.md
+++ b/skills/base-mcp/plugins/bitrefill.md
@@ -1,9 +1,9 @@
 ---
 title: "Bitrefill Plugin"
-description: "Buy gift cards, mobile top-ups, and eSIMs on Bitrefill via @bitrefill/cli (preferred when shell is available) or MCP on shell-less surfaces — authless by default — settling usdc_base x402 invoices through Base MCP on Base."
+description: "Buy gift cards, mobile top-ups, and eSIMs via Bitrefill x402 — connect once (SIWX→JWT) for fee-free browse through Base MCP, or pay-per-call x402; CLI and MCP for existing Bitrefill accounts."
 tags: [agent-commerce, gift-cards, esim, mobile-topup, payments]
 name: bitrefill
-version: 0.2.0
+version: 0.3.0
 integration: hybrid
 chains: [base]
 requires:
@@ -11,52 +11,69 @@ requires:
   allowlist: [api.bitrefill.com]
   externalMcp:
     name: bitrefill
+    transport: http
     url: https://api.bitrefill.com/mcp
   cliPackage: "@bitrefill/cli@latest"
-auth: none
+auth: siwe-jwt
 risk: [pii, irreversible]
 ---
 
 # Bitrefill Plugin
 
 > [!IMPORTANT]
-> Run Base MCP onboarding first (see SKILL.md). Default to **authless** guest checkout; escalate identity only for account-scoped features (`list-orders`, balance pay). When shell is available, prefer `@bitrefill/cli` via `npx` or a global install for **all** Bitrefill operations (see `## Detection`). Use Bitrefill MCP only on shell-less surfaces. Keep `buy-products` **out** of MCP `autoApprove`.
+> Run Base MCP onboarding first (see SKILL.md). **Path 1** (connect→JWT) is the default for agent-commerce: one SIWX signature, then fee-free browse via `web_request` until the token expires (~2h). Fall back to **Path 2** (pay-per-call x402) for multi-wallet or stateless agents. Use **Path 3** (CLI) or **Path 4** (MCP) only when the user has an existing Bitrefill account. Keep `buy-products` **out** of MCP `autoApprove`.
 
 ## Overview
 
-[Bitrefill](https://www.bitrefill.com) sells digital goods — gift cards, mobile top-ups, and eSIMs — across 180+ countries and 1,500+ brands. Codes deliver instantly after payment confirms. This plugin routes catalog search and invoice creation through `@bitrefill/cli` when shell is available, otherwise through Bitrefill MCP, then settles `usdc_base` purchases through Base MCP's **x402 payment** tool on Base. Bitrefill does not produce unsigned onchain calldata; the Base MCP leg is a payment submission (`x402` or `send`), not `send_calls`. Payment methods other than `usdc_base` (`balance`, `lightning`, `bitcoin`, etc.) are out of scope for the Base MCP leg — note them to the user but do not route them through Base MCP.
+[Bitrefill](https://www.bitrefill.com) sells digital goods — gift cards, mobile top-ups, and eSIMs — across 180+ countries and 1,500+ brands. Codes deliver instantly after payment confirms.
 
-Identity escalates only when needed: **Tier 1 authless** (default — browse and guest buy with no account) → **Tier 2 CLI auto `client_credentials`** (shell, zero human step) → **Tier 3 account binding** (`login` / `verify`, existing Bitrefill customers only). On shell surfaces, use the CLI for every Bitrefill call — it auto-provisions a headless machine session on the first command. On shell-less surfaces, use MCP with connector OAuth at install.
+Four execution paths, in preference order:
+
+1. **Connect → JWT (x402-native, zero agent egress)** — `POST /x402/connect` with one SIWX signature mints a session JWT. Send it as `X-Access-Token` on every gated `web_request` to `api.bitrefill.com` — no per-route micro-fees, no re-signing until expiry (~2h). Only `invoice/pay` costs money (Base MCP `x402`). All HTTP goes through Base MCP `web_request`; signing through Base MCP `sign`.
+2. **Pay-per-call x402** — each discovery route returns HTTP 402; Base MCP `x402` pays the micro-fee automatically. No session, no SIWX. Best for multi-wallet or stateless agents, or when SIWX helpers cannot run.
+3. **CLI** (`@bitrefill/cli`, shell) — efficient for users with an existing Bitrefill account (`login`/`verify`, `list-orders`, balance pay).
+4. **Bitrefill MCP** (`https://api.bitrefill.com/mcp`, shell-less) — best chat-client UX for existing Bitrefill users (OAuth at install).
+
+All paths converge on Base MCP **`x402`** (→ `send` USDC Base fallback) for invoice payment. Bitrefill does not produce unsigned onchain calldata — payment submission, not `send_calls`. Payment methods other than USDC x402 (`balance`, `lightning`, `bitcoin`, etc.) are out of scope for the Base MCP leg.
 
 ## Detection
 
-Order. First match wins.
+Pick a path before any Bitrefill call. Base MCP onboarding must be done first.
 
-1. **Shell + npm?** `bitrefill --help` or `npx @bitrefill/cli@latest --help` → CLI for all ops. First cmd auto-provisions `client_credentials`. Guest buy = no sign-in. Prefer `npx` if no global install.
-2. **No shell, MCP tools exposed?** (`search-products`, `product-details`, `buy-products`, …) → MCP.
-3. **Neither** → shell: `npx @bitrefill/cli@latest --help` then CLI; shell-less: install MCP (`## Installation`), reconnect; **stop** if both fail. `https://www.bitrefill.com` = human browse only — no scrape.
+**Agent-commerce (pay with crypto, no Bitrefill account):**
+
+1. Base MCP `sign` + `web_request` + `x402` available, agent can persist a token → **Path 1** (connect→JWT).
+2. Otherwise, or multi-wallet / no session persistence → **Path 2** (pay-per-call x402 via Base MCP `x402` on each 402).
+3. Cannot build SIWX message/header (sandbox blocks even the stdlib helpers in `## Auth`) → **Path 2** only; tell the user connect is unavailable.
+
+**Existing Bitrefill account:**
+
+4. Shell + npm (`npx @bitrefill/cli@latest --help`) → **Path 3** (CLI). First cmd auto-provisions `client_credentials`.
+5. No shell, Bitrefill MCP tools exposed (`search-products`, `buy-products`, …) → **Path 4** (MCP).
+6. Neither → install per `## Installation`, reconnect; **stop** if both fail.
+
+Never scrape `https://www.bitrefill.com` (403 from datacenters). Never call `api.bitrefill.com` directly when the agent has no HTTP tool — route everything through Base MCP `web_request` (paths 1–2) or CLI/MCP (paths 3–4).
 
 ## Installation
 
-### CLI (shell — preferred)
+### Path 1–2: x402-native (no install)
 
-`@bitrefill/cli` ≥ 0.3.0. Wraps same MCP; auto machine session. All Bitrefill ops when shell exists.
+Requires Base MCP only. Host `api.bitrefill.com` must be on the Base MCP `web_request` allowlist.
+
+### Path 3: CLI (shell)
+
+`@bitrefill/cli` ≥ 0.3.0. No global install required.
 
 ```bash
 npx @bitrefill/cli@latest --help
-npm install -g @bitrefill/cli    # global install alternative
+npm install -g @bitrefill/cli    # optional global install
 ```
 
-### Shell-less vs headless auth
+First command auto-provisions OAuth `client_credentials` → `~/.config/bitrefill-cli/<host>.v1.json`. Identity `unregistered` until `login`/`verify`.
 
-- **Shell + CLI:** all calls via CLI. First cmd → OAuth `client_credentials` → `~/.config/bitrefill-cli/<host>.v1.json`. Identity `unregistered` until `login`/`verify`. Zero human OAuth.
-- **Shell-less + MCP:** connector OAuth at install; harness persists tokens ([../references/install.md](../references/install.md)). MCP only when no shell.
+### Path 4: Bitrefill MCP (shell-less)
 
-No API keys, env vars, direct HTTP. Shell available → never MCP even if MCP tools exposed.
-
-### MCP (shell-less)
-
-`https://api.bitrefill.com/mcp` — OAuth at connector setup.
+`https://api.bitrefill.com/mcp` — OAuth at connector setup ([../references/install.md](../references/install.md)).
 
 - **Claude Code:** `claude mcp add bitrefill --url https://api.bitrefill.com/mcp`
 - **Codex:** `~/.codex/config.toml`:
@@ -87,30 +104,206 @@ No API keys, env vars, direct HTTP. Shell available → never MCP even if MCP to
   `buy-products` **out** of `autoApprove`.
 - **Claude.ai / Desktop:** Connectors → custom connector `bitrefill` → URL above.
 - **ChatGPT:** Apps & Connectors → URL above, Auth **OAuth**, Developer Mode for writes.
-- **Other:** Cursor JSON snippet; ask where MCP config lives.
 
-Reconnect/restart after install. Seven tools — read MCP catalog at runtime. Docs-only: `https://docs.bitrefill.com/mcp` — not for purchases.
+Reconnect/restart after install. Read the MCP tool catalog at runtime — do not hardcode tool lists.
+
+## Auth
+
+Path 1 uses **SIWX → JWT**. Path 2 needs no auth. Path 3 uses CLI `client_credentials` (+ optional `login`/`verify`). Path 4 uses connector OAuth at install.
+
+### Connect → JWT (Path 1)
+
+1. `web_request` `POST https://api.bitrefill.com/x402/connect` (empty body) → **402** with `payment-required` header (also mirrored in JSON body). Parse base64 → `extensions["sign-in-with-x"]`.
+2. `get_wallets` → `baseAccount.address` (often lowercase).
+3. Pick the Base chain from `supportedChains`: `{ chainId: "eip155:8453", type: "eip191" }`.
+4. Build the EIP-4361 message with the helpers below (address **must** be EIP-55 checksummed — server rejects lowercase).
+5. Base MCP `sign` with `type: "personal_sign"`, `data: { message: <exact string> }` → approval URL → `get_request_status` → `signature`.
+6. Assemble the **decomposed** payload (`domain`, `address`, `uri`, `version`, `chainId` as CAIP-2, `type`, `nonce`, `issuedAt`, optional fields, `signature` — **not** `{ message, signature }`). Base64-encode → `SIGN-IN-WITH-X` request header.
+7. Re-`POST /x402/connect` with that header → `{ token, token_header: "X-Access-Token", expires_in }` (default ~7200 s).
+8. Attach `X-Access-Token: <token>` (raw JWT, **no** `Bearer` prefix — Base MCP strips `Authorization`) on every subsequent gated `web_request`. Token bypasses micro-fees and SIWX re-signing; `invoice/pay` is never waived.
+
+Smart-wallet note: Base Account signatures verify server-side via EIP-1271/6492; header `type` stays `"eip191"`.
+
+**Path 2:** skip this section entirely — Base MCP `x402` handles each 402 micro-fee without SIWX.
+
+### SIWX helpers (no external libraries)
+
+Locked-down agent sandboxes may forbid `npm i` / `pip install`. These helpers use only built-ins. Verified against `siwe@2.3.2`, `@spruceid/siwe-parser`, and `@x402/extensions@2.3.0`. Base MCP `sign` performs the actual EIP-191 signing — the agent never holds a private key.
+
+**JavaScript** (Node 18+ / modern browser; `BigInt` required for keccak):
+
+```javascript
+const RC = [0x0000000000000001n,0x0000000000008082n,0x800000000000808an,0x8000000080008000n,0x000000000000808bn,0x0000000080000001n,0x8000000080008081n,0x8000000000008009n,0x000000000000008an,0x0000000000000088n,0x0000000080008009n,0x000000008000000an,0x000000008000808bn,0x800000000000008bn,0x8000000000008089n,0x8000000000008003n,0x8000000000008002n,0x8000000000000080n,0x000000000000800an,0x800000008000000an,0x8000000080008081n,0x8000000000008080n,0x0000000080000001n,0x8000000080008008n];
+const PI = [10,7,11,17,18,3,5,16,8,21,24,4,15,23,19,13,12,2,20,14,22,9,6,1];
+const R = [1,3,6,10,15,21,28,36,45,55,2,14,27,41,56,8,25,43,62,18,39,61,20,44];
+const MASK = (1n << 64n) - 1n;
+function rotl(x, n) { n = BigInt(n); return ((x << n) | (x >> (64n - n))) & MASK; }
+function keccakF(s) {
+  const bc = new Array(5).fill(0n);
+  for (let round = 0; round < 24; round++) {
+    for (let i = 0; i < 5; i++) bc[i] = s[i]^s[i+5]^s[i+10]^s[i+15]^s[i+20];
+    for (let i = 0; i < 5; i++) { const t = bc[(i+4)%5]^rotl(bc[(i+1)%5],1); for (let j = 0; j < 25; j += 5) s[j+i] ^= t; }
+    let t = s[1];
+    for (let i = 0; i < 24; i++) { const j = PI[i], tmp = s[j]; s[j] = rotl(t, R[i]); t = tmp; }
+    for (let j = 0; j < 25; j += 5) { for (let i = 0; i < 5; i++) bc[i] = s[j+i]; for (let i = 0; i < 5; i++) s[j+i] ^= (~bc[(i+1)%5]) & bc[(i+2)%5]; }
+    s[0] ^= RC[round];
+  }
+}
+function keccak256Hex(input) {
+  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input;
+  const rate = 136, padded = new Uint8Array(Math.ceil((bytes.length + 2) / rate) * rate);
+  padded.set(bytes); padded[bytes.length] = 0x01; padded[padded.length - 1] |= 0x80;
+  const st = new Array(25).fill(0n);
+  for (let off = 0; off < padded.length; off += rate) {
+    for (let i = 0; i < rate / 8; i++) { let v = 0n; for (let b = 0; b < 8; b++) v |= BigInt(padded[off + i*8 + b]) << BigInt(b*8); st[i] ^= v; }
+    keccakF(st);
+  }
+  let hex = "";
+  for (let i = 0; i < 4; i++) for (let b = 0; b < 8; b++) hex += ((Number((st[i] >> BigInt(b*8)) & 0xffn)).toString(16)).padStart(2, "0");
+  return hex;
+}
+function toChecksumAddress(addr) {
+  const lower = addr.toLowerCase().replace(/^0x/, "");
+  const hash = keccak256Hex(lower);
+  let out = "0x";
+  for (let i = 0; i < lower.length; i++) out += parseInt(hash[i], 16) >= 8 ? lower[i].toUpperCase() : lower[i];
+  return out;
+}
+function buildSiweMessage(info, address, chainIdCaip2) {
+  const chainNum = parseInt(/^eip155:(\d+)$/.exec(chainIdCaip2)[1], 10);
+  const suffix = [`URI: ${info.uri}`,`Version: ${info.version}`,`Chain ID: ${chainNum}`,`Nonce: ${info.nonce}`,`Issued At: ${info.issuedAt}`];
+  if (info.expirationTime) suffix.push(`Expiration Time: ${info.expirationTime}`);
+  if (info.notBefore) suffix.push(`Not Before: ${info.notBefore}`);
+  if (info.requestId) suffix.push(`Request ID: ${info.requestId}`);
+  if (info.resources?.length) suffix.push(["Resources:", ...info.resources.map(r => `- ${r}`)].join("\n"));
+  let prefix = `${info.domain} wants you to sign in with your Ethereum account:\n${address}`;
+  if (info.statement) prefix = `${prefix}\n\n${info.statement}\n`;
+  return `${prefix}\n${suffix.join("\n")}`;
+}
+function encodeSiwxHeader(payload) {
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  return btoa(Array.from(bytes, b => String.fromCharCode(b)).join(""));
+}
+```
+
+**Python** (3.9+; stdlib only):
+
+```python
+import base64, json, struct
+RC = [0x0000000000000001,0x0000000000008082,0x800000000000808A,0x8000000080008000,0x000000000000808B,0x0000000080000001,0x8000000080008081,0x8000000000008009,0x000000000000008A,0x0000000000000088,0x0000000080008009,0x000000008000000A,0x000000008000808B,0x800000000000008B,0x8000000000008089,0x8000000000008003,0x8000000000008002,0x8000000000000080,0x000000000000800A,0x800000008000000A,0x8000000080008081,0x8000000000008080,0x0000000080000001,0x8000000080008008]
+PI = [10,7,11,17,18,3,5,16,8,21,24,4,15,23,19,13,12,2,20,14,22,9,6,1]
+R = [1,3,6,10,15,21,28,36,45,55,2,14,27,41,56,8,25,43,62,18,39,61,20,44]
+MASK = (1 << 64) - 1
+def _rotl(x, n): n &= 63; return ((x << n) | (x >> (64 - n))) & MASK
+def _keccak_f(st):
+    bc = [0]*5
+    for _ in range(24):
+        for i in range(5): bc[i] = st[i]^st[i+5]^st[i+10]^st[i+15]^st[i+20]
+        for i in range(5):
+            t = bc[(i+4)%5] ^ _rotl(bc[(i+1)%5], 1)
+            for j in range(0,25,5): st[j+i] ^= t
+        t = st[1]
+        for i in range(24): j, tmp = PI[i], st[PI[i]]; st[j] = _rotl(t, R[i]); t = tmp
+        for j in range(0,25,5):
+            for i in range(5): bc[i] = st[j+i]
+            for i in range(5): st[j+i] ^= (~bc[(i+1)%5]) & bc[(i+2)%5]
+        st[0] ^= RC[_]
+def keccak256_hex(data):
+    if isinstance(data, str): data = data.encode()
+    rate = 136; padded = bytearray(data); padded.append(0x01)
+    while len(padded) % rate != rate - 1: padded.append(0)
+    padded.append(0x80)
+    st = [0]*25
+    for off in range(0, len(padded), rate):
+        block = padded[off:off+rate]
+        for i in range(rate//8):
+            v = sum(block[i*8+b] << (b*8) for b in range(8))
+            st[i] ^= v
+        _keccak_f(st)
+    return b"".join(struct.pack("<Q", st[i]) for i in range(4)).hex()
+def to_checksum_address(addr):
+    lower = addr.lower().replace("0x", "")
+    h = keccak256_hex(lower)
+    return "0x" + "".join(ch.upper() if int(h[i],16) >= 8 else ch for i, ch in enumerate(lower))
+def build_siwe_message(info, address, chain_id_caip2):
+    chain_num = int(chain_id_caip2.split(":")[1])
+    suffix = [f"URI: {info['uri']}", f"Version: {info['version']}", f"Chain ID: {chain_num}", f"Nonce: {info['nonce']}", f"Issued At: {info['issuedAt']}"]
+    if info.get("expirationTime"): suffix.append(f"Expiration Time: {info['expirationTime']}")
+    if info.get("notBefore"): suffix.append(f"Not Before: {info['notBefore']}")
+    if info.get("requestId"): suffix.append(f"Request ID: {info['requestId']}")
+    if info.get("resources"): suffix.append("Resources:\n" + "\n".join(f"- {r}" for r in info["resources"]))
+    prefix = f"{info['domain']} wants you to sign in with your Ethereum account:\n{address}"
+    if info.get("statement"): prefix = prefix + "\n\n" + info["statement"] + "\n"
+    return prefix + "\n" + "\n".join(suffix)
+def encode_siwx_header(payload):
+    return base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+```
+
+**Decomposed header payload** (after `sign` returns `signature`):
+
+```json
+{
+  "domain": "api.bitrefill.com",
+  "address": "0x<EIP-55 checksummed>",
+  "statement": "<info.statement if present>",
+  "uri": "https://api.bitrefill.com/x402/connect",
+  "version": "1",
+  "chainId": "eip155:8453",
+  "type": "eip191",
+  "nonce": "<info.nonce>",
+  "issuedAt": "<info.issuedAt>",
+  "expirationTime": "<info.expirationTime if present>",
+  "resources": ["https://api.bitrefill.com/x402/connect"],
+  "signature": "0x<from get_request_status>"
+}
+```
 
 ## Surface Routing
 
-| Capability | Shell (CLI harness) | No shell (MCP) |
-| --- | --- | --- |
-| Search / browse | **CLI** (`npx @bitrefill/cli@latest`) | MCP |
-| Invoice (`buy-products`) | **CLI** | MCP |
-| Pay `usdc_base` | Base MCP x402 → `send` fallback | Same |
-| Balance / lightning / other crypto | Bitrefill-native **CLI** — no Base MCP | MCP |
-| Poll / redeem | **CLI** | MCP |
-| Account (`list-orders`, `login`) | **CLI** | MCP |
+HTTP routing for paths 1–2 follows [../references/custom-plugins.md](../references/custom-plugins.md): harness HTTP tool if available, else Base MCP `web_request` (allowlisted `api.bitrefill.com`). Chat-only surfaces without POST → paths 1–2 still work via `web_request`.
 
-Shell + npm → CLI every row, even if MCP also exposed.
+| Capability | Path 1 (connect→JWT) | Path 2 (pay-per-call) | Path 3 (CLI) | Path 4 (MCP) |
+| --- | --- | --- | --- | --- |
+| Connect / session | `sign` + `web_request` `/x402/connect` | — | — | — |
+| Search / browse | `web_request` + `X-Access-Token` | `web_request` + `x402` per 402 | CLI | MCP tools |
+| Product detail | `web_request` + token | `web_request` + `x402` | CLI | MCP |
+| Invoice create | `web_request` + token | `web_request` + `x402` | CLI / MCP `buy-products` | MCP |
+| Pay invoice | Base MCP `x402` on `/x402/invoice/pay` | Same | Base MCP `x402` on `x402_payment_url` | Same |
+| Poll / redeem | `web_request` `/x402/invoice/status` | Same (+ SIWX for codes) | CLI | MCP |
+| Order history (wallet) | `web_request` `/x402/my/orders` + token | SIWX per request | CLI `list-orders` (T3 login) | MCP `list-orders` |
+| Account login | — | — | CLI `login`/`verify` | MCP OAuth |
 
-**Tiers:** T1 authless (search, guest buy `--email`, invoice poll) · T2 CLI auto session (`whoami` → `unregistered` + `client_id`) · T3 `login`→`verify` (`list-orders`, balance pay, account orders; `whoami` → `registered`).
+Paths 1–2 work on chat-only surfaces (no shell). Path 3 requires shell. Path 4 requires the Bitrefill MCP connector.
 
-No shell, no MCP → install MCP + OAuth, reconnect, **stop**. No env/API/HTTP fallback. No scrape `www.bitrefill.com` (403 datacenter).
+## Endpoints
+
+Paths 1–2 use the x402 storefront at `https://api.bitrefill.com` (no `/api` prefix). Every gated response embeds `next_step: { url, body }` chaining search → detail → create → pay → status.
+
+**402 envelope:** `payment-required` header is base64 JSON (`x402Version`, `accepts[]`, `extensions`, …), mirrored into the JSON body for agents that cannot read headers.
+
+**Multi-chain `accepts[]`:** micro-fees and invoice pay offer `exact` USDC on Base (`eip155:8453`), Arbitrum, Polygon, and Solana simultaneously. Amounts are 6-decimal base units (`2000` = $0.002). Base MCP `x402` picks the chain the wallet has funds on.
+
+| Method | Path | Gate | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/x402/gift-cards/search` | $0.002 | Search gift cards (`q`, `country`) |
+| `GET` | `/x402/esims/search` | $0.002 | Search eSIMs |
+| `GET` | `/x402/topups/search` | $0.002 | Search mobile top-ups |
+| `GET` | `/x402/products/detail` | $0.001 | Product detail + packages (`slug`) |
+| `GET` | `/x402/checkout/info` | $0.001 | Route map / supported networks |
+| `POST` | `/x402/invoice/create` | $0.002 | Price-locked quote (1–15 items, `package_value`) |
+| `POST` | `/x402/invoice/pay` | Invoice amount | Settle with USDC x402 |
+| `GET` | `/x402/invoice/status` | $0.001 or SIWX | Poll; redemption codes for SIWX payer only |
+| `POST` | `/x402/connect` | SIWX | Mint session JWT |
+| `GET` | `/x402/my/orders` | SIWX or JWT | Wallet-scoped order history |
+| `GET` | `/x402/my/esims` | SIWX or JWT | Wallet-scoped eSIM list |
+
+With a valid `X-Access-Token`, the gate hook bypasses micro-fees and SIWX on all gated routes except `/x402/connect` itself (cannot mint a token with a token) and `invoice/pay` (invoice amount never waived).
+
+Paths 3–4 use CLI commands or MCP tools instead of these HTTP routes for catalog/invoice — but invoice payment still lands on `/x402/invoice/pay` via the `x402_payment_url` from `buy-products`.
 
 ## Commands
 
-Shell → `npx @bitrefill/cli@latest` or global `bitrefill`. `--json` before subcmd: result stdout, status stderr.
+Path 3 only. `npx @bitrefill/cli@latest` or global `bitrefill`. `--json` before subcmd: result stdout, status stderr.
 
 **Identity:** `whoami` · `login --email` · `verify --code [--otp]` · `logout` · `reset` · `manifest` · `llm-context`
 
@@ -118,90 +311,72 @@ Shell → `npx @bitrefill/cli@latest` or global `bitrefill`. `--json` before sub
 npx @bitrefill/cli@latest --json whoami
 npx @bitrefill/cli@latest login --email "user@example.com"
 npx @bitrefill/cli@latest verify --code "123456"
-npx @bitrefill/cli@latest verify --code "123456" --otp "654321"
-npx @bitrefill/cli@latest logout && npx @bitrefill/cli@latest reset
-npx @bitrefill/cli@latest manifest
-npx @bitrefill/cli@latest llm-context -o BITREFILL-MCP.md
 ```
 
-`whoami --json` → `{ identity, client_id?, email? }`. `browser_url` in login/verify → user opens passkey flow. `reset` rotates session; re-auth drops bound email.
+`whoami --json` → `{ identity, client_id?, email? }`. T3 (`registered`) required for `list-orders` and balance pay.
 
-**Search:** `--country` Alpha-2 uppercase. `--product_type` `giftcard`|`esim`.
+**Search / buy / track:**
 
 ```bash
 npx @bitrefill/cli@latest search-products --query "Steam" --country US
-npx @bitrefill/cli@latest --json search-products --query "eSIM" --product_type esim --country IT
-```
-
-**Details:** `package_value` → `package_id` in buy — only from response.
-
-```bash
 npx @bitrefill/cli@latest get-product-details --product_id "steam-usa" --currency USDC
-```
-
-**Guest buy:**
-
-```bash
 npx @bitrefill/cli@latest buy-products \
   --cart_items '[{"product_id":"steam-usa","package_id":5}]' \
   --payment_method usdc_base \
   --return_payment_link true \
   --email "user@example.com"
-```
-
-→ `invoice_id`, `payment_link`, `x402_payment_url`, `payment_info`.
-
-**Track:**
-
-```bash
 npx @bitrefill/cli@latest get-invoice-by-id --invoice_id "UUID"
-npx @bitrefill/cli@latest get-order-by-id --order_id "ID"   # T3
 ```
 
-Invoices ~30 min TTL — stale → new invoice.
+`package_id` only from `get-product-details` response (`package_value`). Invoices ~30 min TTL.
 
 ## Orchestration
 
-### Search + buy (default, no account)
+### Path 1: Connect → browse → buy
 
 1. Base MCP onboarding done.
-2. Transport per `## Detection`.
-3. Search + details (CLI if shell else MCP, `currency=USDC`).
-4. Quote → **explicit approval**.
-5. `buy-products` `usdc_base` `return_payment_link=true`; CLI `--email`; MCP max 15 items.
-6. Save `invoice_id`, `x402_payment_url`, `payment_info`.
+2. Connect per `## Auth` → store `token`, note `expires_in`.
+3. `web_request` `GET /x402/gift-cards/search?q=…&country=US` with `X-Access-Token` (or esims/topups routes).
+4. Follow `next_step` → `GET /x402/products/detail` → confirm quote with user.
+5. `POST /x402/invoice/create` with cart items (`slug`, `package_value`) + token.
+6. `POST /x402/invoice/pay` via Base MCP `x402` (`## Submission`) → user approves.
+7. `GET /x402/invoice/status` with token until `complete` → deliver redemption securely (`## Risks`).
 
-### CLI headless session
+### Path 2: Pay-per-call x402
 
-First CLI cmd → `client_credentials`. Optional `whoami --json`. Stale auth → `reset` retry.
+1. Base MCP onboarding done.
+2. `web_request` any gated route → 402 → Base MCP `x402` with the request URL (tool handles micro-fee payment) → retry with `payment-signature` header the tool provides.
+3. Follow `next_step` chain through detail → create → pay.
+4. Invoice pay: Base MCP `x402` on `/x402/invoice/pay` with `{ invoice_id }`.
+5. Poll `/x402/invoice/status`; redemption codes require SIWX (same helpers as Path 1, or pay again).
 
-### Account flows (T3)
+### Path 3: CLI (existing account)
 
-Before `list-orders` / balance / account orders: `login` → `verify` (+ `--otp` / `browser_url`). `whoami` = `registered`. Then account tools.
+1. `npx @bitrefill/cli@latest` for all Bitrefill ops when shell exists.
+2. T3: `login` → `verify` before `list-orders` / balance pay.
+3. Search → details → `buy-products` `usdc_base` → Base MCP `x402` on `x402_payment_url` → poll → redeem.
 
-### Settle (`usdc_base`)
+### Path 4: MCP (existing account, shell-less)
 
-1. Base MCP x402 tool on `x402_payment_url`; else `send` (`## Submission`).
-2. Approval URL → [approval-mode.md](../references/approval-mode.md).
-3. `get_request_status` once after user approves.
-
-### Poll + redeem
-
-`get-invoice-by-id` until `complete` → `get-order-by-id` + redemption. Secure delivery (`## Risks`). Log invoice/product/amount/method/time.
+1. Bitrefill MCP installed + OAuth ([../references/install.md](../references/install.md)).
+2. MCP `search-products` → `product-details` → `buy-products` (explicit user approval).
+3. Base MCP `x402` on returned `x402_payment_url` → MCP `get-invoice-by-id` → redemption.
 
 ## Submission
 
-Payment submission, not calldata batch.
+Payment submission, not calldata batch. Defer exact parameter names to the live Base MCP tool descriptions.
 
-**Primary — x402:**
+**Primary — `x402`:** micro-fees (Path 2) and invoice payment (all paths).
 
 ```json
-{ "url": "<x402_payment_url from buy-products>" }
+{ "url": "https://api.bitrefill.com/x402/invoice/pay" }
 ```
 
-→ `approvalUrl`, `requestId`. [approval-mode.md](../references/approval-mode.md).
+Body includes `{ "invoice_id": "<uuid>" }` when the tool schema requires it. For micro-fee 402 loops, pass the gated URL that returned 402. → `approvalUrl`, `requestId`. [approval-mode.md](../references/approval-mode.md).
 
-**Fallback — `send` USDC Base:**
+**SIWX connect — `sign`:** Path 1 only. `type: "personal_sign"`, `data: { message: <buildSiweMessage output> }` → approval → `get_request_status` → `signature`.
+
+**Fallback — `send` USDC Base** (when `x402` unavailable):
 
 ```json
 {
@@ -212,52 +387,48 @@ Payment submission, not calldata batch.
 }
 ```
 
-Match Base MCP `send` schema. Amount = quote.
-
-**Not Base MCP:** balance+`auto_pay` (T3) · lightning/bitcoin/etc native · poll/redeem via CLI/MCP only.
+**Not Base MCP:** balance+`auto_pay` (T3 CLI/MCP) · lightning/bitcoin/etc · CLI/MCP poll/redeem without x402 HTTP.
 
 ## Example Prompts
 
-### $25 Amazon US gift card, USDC Base (authless)
+### $25 Amazon US gift card — connect path (Path 1)
 
-1. CLI search → details → confirm.
-2. `buy-products` + `--email`.
-3. Base MCP x402 → poll invoice → order redemption.
+1. Connect per `## Auth` → JWT.
+2. Search `gift-cards` US + token → detail → confirm price.
+3. `invoice/create` → Base MCP `x402` `invoice/pay` → poll status → deliver code securely.
 
-### 1GB Europe eSIM
+### Browse with multiple wallets, no session (Path 2)
 
-1. CLI search IT esim → `"1GB, 7 Days"` exact.
-2. Buy + x402 + poll → deliver eSIM URL secure.
+1. `web_request` search → 402 → Base MCP `x402` pays micro-fee → retry.
+2. Repeat per gated step; invoice pay via `x402`.
+3. No `X-Access-Token`; each wallet pays its own fees.
 
-### Invoice status
+### Order history — existing account, shell (Path 3)
 
-1. `get-invoice-by-id`. Complete → `get-order-by-id` if user asked redemption.
+1. `whoami` → `login`/`verify` if needed → `list-orders`.
 
-### Steam US browse (shell-less)
+### Buy Steam card — chat client, Bitrefill account (Path 4)
 
 1. Install MCP + OAuth if missing.
-2. MCP search. No auto-buy.
-
-### Order history (T3)
-
-1. CLI: `whoami` → `login`/`verify` if needed → `list-orders`.
-2. MCP shell-less: auth connector → `list-orders`.
+2. MCP search → details → user approves → `buy-products` → Base MCP `x402` → poll invoice.
 
 ## Risks & Warnings
 
-- **`pii`** — Redemption codes, eSIM QR URLs, PINs, and receipt emails are bearer/cash-like personal data. Never paste codes in group chats, public channels, logs, version control, or voice/TTS output. Prefer in-memory handling; advise the user to redeem ASAP. Only return a code when the user explicitly asks.
-- **`irreversible`** — Digital goods deliver instantly and are non-refundable once fulfilled (EU change-of-mind does not apply). Always confirm product, denomination, price, and payment method before `buy-products`. Never auto-buy without explicit user approval for the current session.
-- **Spending cap** — Use a dedicated, low-balance Base Account for `usdc_base` payments. This plugin is not a wallet — never give the agent seed phrases or high-balance accounts.
-- **Invoice expiry** — Invoices expire (~30 min typical). If expired, create a new invoice; do not retry payment on a stale `x402_payment_url`.
-- **Package IDs** — Only values from `product-details` / `get-product-details`. Case-sensitive (`"1GB, 7 Days"`, `"1 Month"`).
+- **`pii`** — Redemption codes, eSIM QR URLs, PINs, and receipt emails are bearer/cash-like personal data. Never paste codes in group chats, public channels, logs, version control, or voice/TTS output. Only return a code when the user explicitly asks.
+- **`irreversible`** — Digital goods deliver instantly and are non-refundable once fulfilled. Always confirm product, denomination, price, and payment method before purchase. Never auto-buy without explicit user approval.
+- **Spending cap** — Use a dedicated, low-balance Base Account for USDC payments. Never give the agent seed phrases or high-balance accounts.
+- **Invoice expiry** — Invoices expire (~15 min price lock, ~30 min typical). Stale `x402_payment_url` → create a new invoice.
+- **Connect token** — `X-Access-Token` is a bearer secret (~2 h TTL). Never log it, commit it, or echo it in chat. Re-connect when expired.
+- **EIP-55 checksum** — SIWX rejects lowercase addresses from `get_wallets`. Always run `toChecksumAddress` before `buildSiweMessage`.
+- **Package values** — Only from product detail response. Case-sensitive (`"1GB, 7 Days"`, `"1 Month"`). MCP uses `package_value` (not composite `package_id`).
 - **CLI session token** — `~/.config/bitrefill-cli/<host>.v1.json` sensitive; `reset` rotates.
-- **Account binding loss** — Re-auth clears email; re `login`/`verify` before account tools.
 
 ## Notes
 
 - USDC Base: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
-- Country: Alpha-2 uppercase
-- `package_id`: numeric | duration string | named string; from `package_value`
-- Identity: `unregistered` | `registered`; state `~/.config/bitrefill-cli/<host>.v1.json`
-- Agent: `--json`, `manifest`, `llm-context`
+- x402 also accepts USDC on Arbitrum, Polygon, Solana in `accepts[]`; Base MCP `x402` selects by wallet funds
+- Country: Alpha-2 uppercase (`US`, `IT`)
+- `X-Access-Token` header (not `Authorization: Bearer`) — Base MCP strips `Authorization`
+- Fee schedule: search $0.002 · detail/checkout $0.001 · invoice create $0.002 · status $0.001
+- Connect-JWT TTL: `X402_CONNECT_TOKEN_TTL_MINUTES` (default 120)
 - Docs: [github.com/bitrefill/agents](https://github.com/bitrefill/agents), [docs.bitrefill.com](https://docs.bitrefill.com)

--- a/skills/base-mcp/plugins/bitrefill.md
+++ b/skills/base-mcp/plugins/bitrefill.md
@@ -1,9 +1,9 @@
 ---
 title: "Bitrefill Plugin"
-description: "Buy gift cards, mobile top-ups, and eSIMs via Bitrefill x402 — connect once (SIWX→JWT) for fee-free browse through Base MCP, or pay-per-call x402; CLI and MCP for existing Bitrefill accounts."
+description: "Shop 1,500+ brands in 180+ countries — Amazon, Steam, Netflix, mobile top-ups, and travel eSIMs — paid with USDC on Base. Your agent searches, checks out, and delivers gift-card codes and eSIM details in chat. No Bitrefill account required."
 tags: [agent-commerce, gift-cards, esim, mobile-topup, payments]
 name: bitrefill
-version: 0.3.0
+version: 0.4.0
 integration: hybrid
 chains: [base]
 requires:
@@ -21,70 +21,51 @@ risk: [pii, irreversible]
 # Bitrefill Plugin
 
 > [!IMPORTANT]
-> Run Base MCP onboarding first (see SKILL.md). **Path 1** (connect→JWT) is the default for agent-commerce: one SIWX signature, then fee-free browse via `web_request` until the token expires (~2h). Fall back to **Path 2** (pay-per-call x402) for multi-wallet or stateless agents. Use **Path 3** (CLI) or **Path 4** (MCP) only when the user has an existing Bitrefill account. Keep `buy-products` **out** of MCP `autoApprove`.
+> Complete Base MCP onboarding first (`SKILL.md`). **Path 1** (connect→JWT) is the default for agent-commerce. Fall back to **Path 2** (pay-per-call x402) for multi-wallet or stateless agents. Use **Path 3** (CLI) or **Path 4** (Bitrefill MCP) only when the user has an existing Bitrefill account. Keep `buy-products` **out** of Bitrefill MCP `autoApprove`.
 
 ## Overview
 
-[Bitrefill](https://www.bitrefill.com) sells digital goods — gift cards, mobile top-ups, and eSIMs — across 180+ countries and 1,500+ brands. Codes deliver instantly after payment confirms.
+**Turn USDC on Base into everyday spending — inside the conversation.**
 
-Four execution paths, in preference order:
+[Bitrefill](https://www.bitrefill.com) is the world's largest crypto-native storefront for digital goods: gift cards (Amazon, Apple, Steam, Uber, and 1,500+ more), mobile refills in 180+ countries, and data eSIMs for travel. Pay with USDC on Base from your Base Account; codes and install links land in chat — often in seconds, sometimes within a few minutes (see **Business domain**).
 
-1. **Connect → JWT (x402-native, zero agent egress)** — `POST /x402/connect` with one SIWX signature mints a session JWT. Send it as `X-Access-Token` on every gated `web_request` to `api.bitrefill.com` — no per-route micro-fees, no re-signing until expiry (~2h). Only `invoice/pay` costs money (Base MCP `x402`). All HTTP goes through Base MCP `web_request`; signing through Base MCP `sign`.
-2. **Pay-per-call x402** — each discovery route returns HTTP 402; Base MCP `x402` pays the micro-fee automatically. No session, no SIWX. Best for multi-wallet or stateless agents, or when SIWX helpers cannot run.
-3. **CLI** (`@bitrefill/cli`, shell) — efficient for users with an existing Bitrefill account (`login`/`verify`, `list-orders`, balance pay).
-4. **Bitrefill MCP** (`https://api.bitrefill.com/mcp`, shell-less) — best chat-client UX for existing Bitrefill users (OAuth at install).
+**Why agents love it:** one session can go from *"I need a $25 Amazon US card"* to a delivered PIN — search, pick a denomination, confirm, pay, poll, redeem — without leaving the thread. No Bitrefill signup on the default path: sign in once with your wallet, browse fee-free, pay only at checkout.
 
-All paths converge on Base MCP **`x402`** (→ `send` USDC Base fallback) for invoice payment. Bitrefill does not produce unsigned onchain calldata — payment submission, not `send_calls`. Payment methods other than USDC x402 (`balance`, `lightning`, `bitcoin`, etc.) are out of scope for the Base MCP leg.
+**Already on Bitrefill?** Link an existing account via CLI or the Bitrefill MCP and shop your usual catalog the same way.
+
+Path selection, API routes, and Base MCP wiring: **Detection** · **Submission**
 
 ## Detection
 
-Pick a path before any Bitrefill call. Base MCP onboarding must be done first.
+**Path 1 — Connect → JWT (default):** one wallet sign-in → session token (~2 h); browse/create/status without micro-fees; pay at checkout only.
 
-**Agent-commerce (pay with crypto, no Bitrefill account):**
+**Path 2 — Pay-per-call x402:** no session; HTTP 402 + micro-fee on each gated call.
 
-1. Base MCP `sign` + `web_request` + `x402` available, agent can persist a token → **Path 1** (connect→JWT).
-2. Otherwise, or multi-wallet / no session persistence → **Path 2** (pay-per-call x402 via Base MCP `x402` on each 402).
-3. Cannot build SIWX message/header (sandbox blocks even the stdlib helpers in `## Auth`) → **Path 2** only; tell the user connect is unavailable.
+**Path 3 — CLI:** existing Bitrefill account via `@bitrefill/cli` (shell).
+
+**Path 4 — Bitrefill MCP:** existing account via `https://api.bitrefill.com/mcp` (OAuth, shell-less).
+
+After Base MCP is available (`SKILL.md`), pick a path:
+
+**Agent-commerce (USDC on Base, no Bitrefill account):**
+
+1. Base MCP `sign` + `web_request` + x402 payment tools available, agent can persist a JWT → **Path 1**.
+2. Otherwise, or multi-wallet / no session persistence → **Path 2**.
+3. Cannot run SIWX helpers (no shell/Node for checksum + message build) → **Path 2** only; tell the user connect is unavailable.
 
 **Existing Bitrefill account:**
 
-4. Shell + npm (`npx @bitrefill/cli@latest --help`) → **Path 3** (CLI). First cmd auto-provisions `client_credentials`.
-5. No shell, Bitrefill MCP tools exposed (`search-products`, `buy-products`, …) → **Path 4** (MCP).
-6. Neither → install per `## Installation`, reconnect; **stop** if both fail.
+4. Shell + `npx @bitrefill/cli@latest --help` → **Path 3**.
+5. Bitrefill MCP tools exposed (`search-products`, `buy-products`, …) → **Path 4**.
+6. Neither → install per **Path 4 setup** below; **stop** if both fail.
 
-Never scrape `https://www.bitrefill.com` (403 from datacenters). Never call `api.bitrefill.com` directly when the agent has no HTTP tool — route everything through Base MCP `web_request` (paths 1–2) or CLI/MCP (paths 3–4).
+Never scrape `https://www.bitrefill.com` (403 from datacenters). Paths 1–2: Base MCP `web_request` to allowlisted `api.bitrefill.com` (`custom-plugins.md`). Paths 3–4: Bitrefill CLI or Bitrefill MCP.
 
-## Installation
+## Path 4 setup (Bitrefill MCP)
 
-### Path 1–2: x402-native (no install)
+`https://api.bitrefill.com/mcp` — OAuth at connector setup.
 
-Requires Base MCP only. Host `api.bitrefill.com` must be on the Base MCP `web_request` allowlist.
-
-### Path 3: CLI (shell)
-
-`@bitrefill/cli` ≥ 0.3.0. No global install required.
-
-```bash
-npx @bitrefill/cli@latest --help
-npm install -g @bitrefill/cli    # optional global install
-```
-
-First command auto-provisions OAuth `client_credentials` → `~/.config/bitrefill-cli/<host>.v1.json`. Identity `unregistered` until `login`/`verify`.
-
-### Path 4: Bitrefill MCP (shell-less)
-
-`https://api.bitrefill.com/mcp` — OAuth at connector setup ([../references/install.md](../references/install.md)).
-
-- **Claude Code:** `claude mcp add bitrefill --url https://api.bitrefill.com/mcp`
-- **Codex:** `~/.codex/config.toml`:
-
-  ```toml
-  [mcp_servers.bitrefill]
-  url = "https://api.bitrefill.com/mcp"
-  ```
-
-  Then `codex mcp login bitrefill` once (terminal, outside chat).
-- **Cursor / JSON:** `.cursor/mcp.json` or `~/.cursor/mcp.json`:
+- **Cursor:** `.cursor/mcp.json` or `~/.cursor/mcp.json`:
 
   ```json
   {
@@ -92,9 +73,9 @@ First command auto-provisions OAuth `client_credentials` → `~/.config/bitrefil
       "bitrefill": {
         "url": "https://api.bitrefill.com/mcp",
         "autoApprove": [
-          "search-products", "product-details",
+          "search-products", "get-product-details",
           "list-invoices", "get-invoice-by-id",
-          "list-orders", "get-order-by-id"
+          "submit-prepayment-step", "update-order"
         ]
       }
     }
@@ -102,333 +83,358 @@ First command auto-provisions OAuth `client_credentials` → `~/.config/bitrefil
   ```
 
   `buy-products` **out** of `autoApprove`.
-- **Claude.ai / Desktop:** Connectors → custom connector `bitrefill` → URL above.
-- **ChatGPT:** Apps & Connectors → URL above, Auth **OAuth**, Developer Mode for writes.
+- **Claude Code:** `claude mcp add bitrefill --url https://api.bitrefill.com/mcp`
+- Reconnect/restart after install. MCP tools (verified): `search-products`, `get-product-details`, `buy-products`, `submit-prepayment-step`, `list-invoices`, `get-invoice-by-id`, `update-order`.
 
-Reconnect/restart after install. Read the MCP tool catalog at runtime — do not hardcode tool lists.
+## Auth and SIWX
 
-## Auth
+Path 1 connect uses **SIWX → JWT**. Path 2 needs no auth. Post-purchase **redemption codes** on `invoice/status` require SIWX from the **paying wallet** (Path 1 JWT covers browse/status polling; if codes are missing, run **SIWX for codes** below). Path 3/4 use CLI/MCP OAuth.
 
-Path 1 uses **SIWX → JWT**. Path 2 needs no auth. Path 3 uses CLI `client_credentials` (+ optional `login`/`verify`). Path 4 uses connector OAuth at install.
+### EIP-55 checksum (required)
+
+The address in the signed message and SIWX payload must be **EIP-55 checksummed** (mixed case). Lowercase addresses from `get_wallets` cause the API to reject the signature and return another `402`. Always run `toChecksumAddress` before building the message.
+
+Base Account signatures are ERC-1271/6492 wrapped (~224 bytes). Pass the **full** signature unchanged; header `type` stays `"eip191"`. Wallet reads and write approvals follow `approval-mode.md`.
+
+### SIWX timing
+
+Challenge nonce expires in **5 minutes** and is **single-use**. Fetch challenge → build message → `sign` → send header within that window. If connect returns `402` again, fetch a fresh challenge and repeat — do not reuse a stale nonce or signature.
 
 ### Connect → JWT (Path 1)
 
-1. `web_request` `POST https://api.bitrefill.com/x402/connect` (empty body) → **402** with `payment-required` header (also mirrored in JSON body). Parse base64 → `extensions["sign-in-with-x"]`.
-2. `get_wallets` → `baseAccount.address` (often lowercase).
-3. Pick the Base chain from `supportedChains`: `{ chainId: "eip155:8453", type: "eip191" }`.
-4. Build the EIP-4361 message with the helpers below (address **must** be EIP-55 checksummed — server rejects lowercase).
-5. Base MCP `sign` with `type: "personal_sign"`, `data: { message: <exact string> }` → approval URL → `get_request_status` → `signature`.
-6. Assemble the **decomposed** payload (`domain`, `address`, `uri`, `version`, `chainId` as CAIP-2, `type`, `nonce`, `issuedAt`, optional fields, `signature` — **not** `{ message, signature }`). Base64-encode → `SIGN-IN-WITH-X` request header.
-7. Re-`POST /x402/connect` with that header → `{ token, token_header: "X-Access-Token", expires_in }` (default ~7200 s).
-8. Attach `X-Access-Token: <token>` (raw JWT, **no** `Bearer` prefix — Base MCP strips `Authorization`) on every subsequent gated `web_request`. Token bypasses micro-fees and SIWX re-signing; `invoice/pay` is never waived.
+1. `web_request` `POST https://api.bitrefill.com/x402/connect` with body `{}` and header `Content-Type: application/json` → **402** whose JSON body includes `extensions["sign-in-with-x"].info` (domain, uri, version, nonce, issuedAt, expirationTime, statement, resources) and `supportedChains`.
+2. `get_wallets` → wallet address.
+3. Pick Base: `{ chainId: "eip155:8453", type: "eip191" }` from `supportedChains`.
+4. Build EIP-4361 message with **SIWX helpers** below (`toChecksumAddress` → `buildSiweMessage`). The `uri` in the challenge for connect is `https://api.bitrefill.com/x402/connect`.
+5. `sign` with `type: "personal_sign"`, `data: { message: <exact string> }` → follow `approval-mode.md` → `signature`.
+6. Build **decomposed** payload (not `{ message, signature }`), base64-encode → `sign-in-with-x` request header (see payload shape below).
+7. `web_request` `POST https://api.bitrefill.com/x402/connect` with body `{}`, `Content-Type: application/json`, and header `sign-in-with-x: <base64>` → **200** with `{ token, token_header: "X-Access-Token", expires_in }` (default ~7200 s).
+8. Store `token` in memory only. Attach `X-Access-Token: <token>` (raw JWT, **no** `Bearer`) on every subsequent gated `web_request`. Re-connect when expired.
 
-Smart-wallet note: Base Account signatures verify server-side via EIP-1271/6492; header `type` stays `"eip191"`.
+### SIWX for codes (after `invoice/pay`)
 
-**Path 2:** skip this section entirely — Base MCP `x402` handles each 402 micro-fee without SIWX.
+When `invoice/status` returns delivery complete but no `redemption_info`, or Path 2 without JWT:
 
-### SIWX helpers (no external libraries)
+1. `web_request` `GET https://api.bitrefill.com/x402/invoice/status?invoice_id=<uuid>` → **402** with SIWX challenge (save the full JSON body).
+2. Build message from challenge `info` — **`uri` must match the challenged route** (includes `?invoice_id=`).
+3. `sign` → follow `approval-mode.md` within 5 minutes.
+4. `web_request` same URL with `sign-in-with-x` header → **200** with `redemption_info.orders[].redemption_info` (`code`, `pin`, `extra_fields`).
+5. **403** → signing wallet is not the invoice payer. Sign with the wallet that paid.
 
-Locked-down agent sandboxes may forbid `npm i` / `pip install`. These helpers use only built-ins. Verified against `siwe@2.3.2`, `@spruceid/siwe-parser`, and `@x402/extensions@2.3.0`. Base MCP `sign` performs the actual EIP-191 signing — the agent never holds a private key.
+`my/orders` and `my/esims` use the same SIWX flow (Path 1 JWT also works on these routes).
 
-**JavaScript** (Node 18+ / modern browser; `BigInt` required for keccak):
+### Decomposed SIWX payload
 
-```javascript
-const RC = [0x0000000000000001n,0x0000000000008082n,0x800000000000808an,0x8000000080008000n,0x000000000000808bn,0x0000000080000001n,0x8000000080008081n,0x8000000000008009n,0x000000000000008an,0x0000000000000088n,0x0000000080008009n,0x000000008000000an,0x000000008000808bn,0x800000000000008bn,0x8000000000008089n,0x8000000000008003n,0x8000000000008002n,0x8000000000000080n,0x000000000000800an,0x800000008000000an,0x8000000080008081n,0x8000000000008080n,0x0000000080000001n,0x8000000080008008n];
-const PI = [10,7,11,17,18,3,5,16,8,21,24,4,15,23,19,13,12,2,20,14,22,9,6,1];
-const R = [1,3,6,10,15,21,28,36,45,55,2,14,27,41,56,8,25,43,62,18,39,61,20,44];
-const MASK = (1n << 64n) - 1n;
-function rotl(x, n) { n = BigInt(n); return ((x << n) | (x >> (64n - n))) & MASK; }
-function keccakF(s) {
-  const bc = new Array(5).fill(0n);
-  for (let round = 0; round < 24; round++) {
-    for (let i = 0; i < 5; i++) bc[i] = s[i]^s[i+5]^s[i+10]^s[i+15]^s[i+20];
-    for (let i = 0; i < 5; i++) { const t = bc[(i+4)%5]^rotl(bc[(i+1)%5],1); for (let j = 0; j < 25; j += 5) s[j+i] ^= t; }
-    let t = s[1];
-    for (let i = 0; i < 24; i++) { const j = PI[i], tmp = s[j]; s[j] = rotl(t, R[i]); t = tmp; }
-    for (let j = 0; j < 25; j += 5) { for (let i = 0; i < 5; i++) bc[i] = s[j+i]; for (let i = 0; i < 5; i++) s[j+i] ^= (~bc[(i+1)%5]) & bc[(i+2)%5]; }
-    s[0] ^= RC[round];
-  }
-}
-function keccak256Hex(input) {
-  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input;
-  const rate = 136, padded = new Uint8Array(Math.ceil((bytes.length + 2) / rate) * rate);
-  padded.set(bytes); padded[bytes.length] = 0x01; padded[padded.length - 1] |= 0x80;
-  const st = new Array(25).fill(0n);
-  for (let off = 0; off < padded.length; off += rate) {
-    for (let i = 0; i < rate / 8; i++) { let v = 0n; for (let b = 0; b < 8; b++) v |= BigInt(padded[off + i*8 + b]) << BigInt(b*8); st[i] ^= v; }
-    keccakF(st);
-  }
-  let hex = "";
-  for (let i = 0; i < 4; i++) for (let b = 0; b < 8; b++) hex += ((Number((st[i] >> BigInt(b*8)) & 0xffn)).toString(16)).padStart(2, "0");
-  return hex;
-}
-function toChecksumAddress(addr) {
-  const lower = addr.toLowerCase().replace(/^0x/, "");
-  const hash = keccak256Hex(lower);
-  let out = "0x";
-  for (let i = 0; i < lower.length; i++) out += parseInt(hash[i], 16) >= 8 ? lower[i].toUpperCase() : lower[i];
-  return out;
-}
-function buildSiweMessage(info, address, chainIdCaip2) {
-  const chainNum = parseInt(/^eip155:(\d+)$/.exec(chainIdCaip2)[1], 10);
-  const suffix = [`URI: ${info.uri}`,`Version: ${info.version}`,`Chain ID: ${chainNum}`,`Nonce: ${info.nonce}`,`Issued At: ${info.issuedAt}`];
-  if (info.expirationTime) suffix.push(`Expiration Time: ${info.expirationTime}`);
-  if (info.notBefore) suffix.push(`Not Before: ${info.notBefore}`);
-  if (info.requestId) suffix.push(`Request ID: ${info.requestId}`);
-  if (info.resources?.length) suffix.push(["Resources:", ...info.resources.map(r => `- ${r}`)].join("\n"));
-  let prefix = `${info.domain} wants you to sign in with your Ethereum account:\n${address}`;
-  if (info.statement) prefix = `${prefix}\n\n${info.statement}\n`;
-  return `${prefix}\n${suffix.join("\n")}`;
-}
-function encodeSiwxHeader(payload) {
-  const bytes = new TextEncoder().encode(JSON.stringify(payload));
-  return btoa(Array.from(bytes, b => String.fromCharCode(b)).join(""));
-}
-```
-
-**Python** (3.9+; stdlib only):
-
-```python
-import base64, json, struct
-RC = [0x0000000000000001,0x0000000000008082,0x800000000000808A,0x8000000080008000,0x000000000000808B,0x0000000080000001,0x8000000080008081,0x8000000000008009,0x000000000000008A,0x0000000000000088,0x0000000080008009,0x000000008000000A,0x000000008000808B,0x800000000000008B,0x8000000000008089,0x8000000000008003,0x8000000000008002,0x8000000000000080,0x000000000000800A,0x800000008000000A,0x8000000080008081,0x8000000000008080,0x0000000080000001,0x8000000080008008]
-PI = [10,7,11,17,18,3,5,16,8,21,24,4,15,23,19,13,12,2,20,14,22,9,6,1]
-R = [1,3,6,10,15,21,28,36,45,55,2,14,27,41,56,8,25,43,62,18,39,61,20,44]
-MASK = (1 << 64) - 1
-def _rotl(x, n): n &= 63; return ((x << n) | (x >> (64 - n))) & MASK
-def _keccak_f(st):
-    bc = [0]*5
-    for _ in range(24):
-        for i in range(5): bc[i] = st[i]^st[i+5]^st[i+10]^st[i+15]^st[i+20]
-        for i in range(5):
-            t = bc[(i+4)%5] ^ _rotl(bc[(i+1)%5], 1)
-            for j in range(0,25,5): st[j+i] ^= t
-        t = st[1]
-        for i in range(24): j, tmp = PI[i], st[PI[i]]; st[j] = _rotl(t, R[i]); t = tmp
-        for j in range(0,25,5):
-            for i in range(5): bc[i] = st[j+i]
-            for i in range(5): st[j+i] ^= (~bc[(i+1)%5]) & bc[(i+2)%5]
-        st[0] ^= RC[_]
-def keccak256_hex(data):
-    if isinstance(data, str): data = data.encode()
-    rate = 136; padded = bytearray(data); padded.append(0x01)
-    while len(padded) % rate != rate - 1: padded.append(0)
-    padded.append(0x80)
-    st = [0]*25
-    for off in range(0, len(padded), rate):
-        block = padded[off:off+rate]
-        for i in range(rate//8):
-            v = sum(block[i*8+b] << (b*8) for b in range(8))
-            st[i] ^= v
-        _keccak_f(st)
-    return b"".join(struct.pack("<Q", st[i]) for i in range(4)).hex()
-def to_checksum_address(addr):
-    lower = addr.lower().replace("0x", "")
-    h = keccak256_hex(lower)
-    return "0x" + "".join(ch.upper() if int(h[i],16) >= 8 else ch for i, ch in enumerate(lower))
-def build_siwe_message(info, address, chain_id_caip2):
-    chain_num = int(chain_id_caip2.split(":")[1])
-    suffix = [f"URI: {info['uri']}", f"Version: {info['version']}", f"Chain ID: {chain_num}", f"Nonce: {info['nonce']}", f"Issued At: {info['issuedAt']}"]
-    if info.get("expirationTime"): suffix.append(f"Expiration Time: {info['expirationTime']}")
-    if info.get("notBefore"): suffix.append(f"Not Before: {info['notBefore']}")
-    if info.get("requestId"): suffix.append(f"Request ID: {info['requestId']}")
-    if info.get("resources"): suffix.append("Resources:\n" + "\n".join(f"- {r}" for r in info["resources"]))
-    prefix = f"{info['domain']} wants you to sign in with your Ethereum account:\n{address}"
-    if info.get("statement"): prefix = prefix + "\n\n" + info["statement"] + "\n"
-    return prefix + "\n" + "\n".join(suffix)
-def encode_siwx_header(payload):
-    return base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
-```
-
-**Decomposed header payload** (after `sign` returns `signature`):
+Base64 of this JSON (send as `sign-in-with-x` header):
 
 ```json
 {
   "domain": "api.bitrefill.com",
   "address": "0x<EIP-55 checksummed>",
-  "statement": "<info.statement if present>",
-  "uri": "https://api.bitrefill.com/x402/connect",
+  "statement": "<info.statement>",
+  "uri": "<info.uri — must match the route being authenticated>",
   "version": "1",
   "chainId": "eip155:8453",
   "type": "eip191",
   "nonce": "<info.nonce>",
   "issuedAt": "<info.issuedAt>",
-  "expirationTime": "<info.expirationTime if present>",
-  "resources": ["https://api.bitrefill.com/x402/connect"],
-  "signature": "0x<from get_request_status>"
+  "expirationTime": "<info.expirationTime>",
+  "resources": ["<info.resources[]>"],
+  "signature": "0x<full signature from get_request_status>"
 }
 ```
 
-## Surface Routing
+Chain ID is numeric (`8453`) inside the signed message but CAIP-2 (`eip155:8453`) in the payload.
 
-HTTP routing for paths 1–2 follows [../references/custom-plugins.md](../references/custom-plugins.md): harness HTTP tool if available, else Base MCP `web_request` (allowlisted `api.bitrefill.com`). Chat-only surfaces without POST → paths 1–2 still work via `web_request`.
+### SIWX message shape
 
-| Capability | Path 1 (connect→JWT) | Path 2 (pay-per-call) | Path 3 (CLI) | Path 4 (MCP) |
-| --- | --- | --- | --- | --- |
-| Connect / session | `sign` + `web_request` `/x402/connect` | — | — | — |
-| Search / browse | `web_request` + `X-Access-Token` | `web_request` + `x402` per 402 | CLI | MCP tools |
-| Product detail | `web_request` + token | `web_request` + `x402` | CLI | MCP |
-| Invoice create | `web_request` + token | `web_request` + `x402` | CLI / MCP `buy-products` | MCP |
-| Pay invoice | Base MCP `x402` on `/x402/invoice/pay` | Same | Base MCP `x402` on `x402_payment_url` | Same |
-| Poll / redeem | `web_request` `/x402/invoice/status` | Same (+ SIWX for codes) | CLI | MCP |
-| Order history (wallet) | `web_request` `/x402/my/orders` + token | SIWX per request | CLI `list-orders` (T3 login) | MCP `list-orders` |
-| Account login | — | — | CLI `login`/`verify` | MCP OAuth |
+```
+<domain> wants you to sign in with your Ethereum account:
+<checksummed_address>
 
-Paths 1–2 work on chat-only surfaces (no shell). Path 3 requires shell. Path 4 requires the Bitrefill MCP connector.
+<statement>
+
+URI: <uri>
+Version: 1
+Chain ID: 8453
+Nonce: <nonce>
+Issued At: <issuedAt>
+Expiration Time: <expirationTime>
+Resources:
+- <resource_url>
+```
+
+### SIWX helpers (no external libraries)
+
+Verified against `siwe@2.3.2` and `@x402/extensions@2.3.0`. Run in Node 18+ or any JS shell.
+
+**JavaScript:**
+
+```javascript
+const RC = [
+  0x0000000000000001n,0x0000000000008082n,0x800000000000808an,0x8000000080008000n,
+  0x000000000000808bn,0x0000000080000001n,0x8000000080008081n,0x8000000000008009n,
+  0x000000000000008an,0x0000000000000088n,0x0000000080008009n,0x000000008000000an,
+  0x000000008000808bn,0x800000000000008bn,0x8000000000008089n,0x8000000000008003n,
+  0x8000000000008002n,0x8000000000000080n,0x000000000000800an,0x800000008000000an,
+  0x8000000080008081n,0x8000000000008080n,0x0000000080000001n,0x8000000080008008n];
+const ROT = [0,1,62,28,27,36,44,6,55,20,3,10,43,25,39,41,45,15,21,8,18,2,61,56,14];
+const MASK = (1n<<64n)-1n;
+const rotl = (x,n)=> n===0n ? x : ((x<<n)|(x>>(64n-n)))&MASK;
+function keccakF(s){
+  for(let round=0;round<24;round++){
+    const C=new Array(5);
+    for(let x=0;x<5;x++) C[x]=s[x]^s[x+5]^s[x+10]^s[x+15]^s[x+20];
+    const D=new Array(5);
+    for(let x=0;x<5;x++) D[x]=C[(x+4)%5]^rotl(C[(x+1)%5],1n);
+    for(let x=0;x<5;x++) for(let y=0;y<5;y++) s[x+5*y]^=D[x];
+    const B=new Array(25);
+    for(let x=0;x<5;x++) for(let y=0;y<5;y++) B[y+5*((2*x+3*y)%5)]=rotl(s[x+5*y],BigInt(ROT[x+5*y]));
+    for(let x=0;x<5;x++) for(let y=0;y<5;y++) s[x+5*y]=B[x+5*y]^(((~B[((x+1)%5)+5*y])&B[((x+2)%5)+5*y])&MASK);
+    s[0]^=RC[round];
+  }
+}
+function keccak256(bytes){
+  const rate=136; const s=new Array(25).fill(0n);
+  const padded=new Uint8Array(Math.ceil((bytes.length+1)/rate)*rate);
+  padded.set(bytes); padded[bytes.length]^=0x01; padded[padded.length-1]^=0x80;
+  for(let off=0;off<padded.length;off+=rate){
+    for(let i=0;i<rate/8;i++){
+      let lane=0n;
+      for(let j=7;j>=0;j--) lane=(lane<<8n)|BigInt(padded[off+i*8+j]);
+      s[i]^=lane;
+    }
+    keccakF(s);
+  }
+  const out=new Uint8Array(32);
+  for(let i=0;i<4;i++){ let lane=s[i]; for(let j=0;j<8;j++){ out[i*8+j]=Number(lane&0xffn); lane>>=8n; } }
+  return Buffer.from(out).toString('hex');
+}
+function toChecksumAddress(addr){
+  const a=String(addr).toLowerCase().replace(/^0x/,'');
+  const hash=keccak256(Buffer.from(a,'ascii'));
+  let out='0x';
+  for(let i=0;i<a.length;i++) out += parseInt(hash[i],16)>=8 ? a[i].toUpperCase() : a[i];
+  return out;
+}
+function buildSiweMessage(info, address, chainIdCaip2){
+  const chainNum = parseInt(/^eip155:(\d+)$/.exec(chainIdCaip2)[1], 10);
+  let prefix = `${info.domain} wants you to sign in with your Ethereum account:\n${address}`;
+  if (info.statement) prefix += '\n\n' + info.statement;
+  const suffix = [
+    `URI: ${info.uri}`, `Version: ${info.version}`, `Chain ID: ${chainNum}`,
+    `Nonce: ${info.nonce}`, `Issued At: ${info.issuedAt}`,
+  ];
+  if (info.expirationTime) suffix.push(`Expiration Time: ${info.expirationTime}`);
+  if (info.notBefore) suffix.push(`Not Before: ${info.notBefore}`);
+  if (info.requestId) suffix.push(`Request ID: ${info.requestId}`);
+  if (info.resources?.length) suffix.push(['Resources:', ...info.resources.map(r=>`- ${r}`)].join('\n'));
+  return prefix + '\n\n' + suffix.join('\n');
+}
+function buildSiwxPayload(info, address, signature, chainIdCaip2){
+  const payload = {
+    domain: info.domain, address, statement: info.statement, uri: info.uri,
+    version: info.version, chainId: chainIdCaip2, type: 'eip191',
+    nonce: info.nonce, issuedAt: info.issuedAt, expirationTime: info.expirationTime,
+    resources: info.resources, signature,
+  };
+  if (info.notBefore) payload.notBefore = info.notBefore;
+  if (info.requestId) payload.requestId = info.requestId;
+  return payload;
+}
+function encodeSiwxHeader(payload){
+  return Buffer.from(JSON.stringify(payload)).toString('base64');
+}
+```
+
+Run the JavaScript block in Node (`node -e '…'`) or any harness with `BigInt`. Do not hand-type checksummed addresses. If no JavaScript runtime is available, use **Path 2** (no connect SIWX) or obtain checksum/message from a one-line Node invocation before calling `sign`.
+
+## Business domain
+
+Bitrefill API names do not match everyday ecommerce wording — map them when talking to users:
+
+| API term | Means | User-facing |
+| --- | --- | --- |
+| **invoice** | Price-locked checkout (cart + total), not a billing document | "your order" / "checkout" |
+| **order** | One cart line item (one product/denomination) | "item" |
+
+Flow: `invoice/create` → `invoice/pay` → backend **async fulfillment** of each order. Gift-card codes are often near-instant; some products take minutes. **Poll** `invoice/status` until `delivery_status` is `all_delivered` — do not treat payment confirmation as delivery.
+
+If an item is still not fulfilled after **3 hours**, or the user hits any service issue, point them to [help.bitrefill.com](https://help.bitrefill.com).
 
 ## Endpoints
 
-Paths 1–2 use the x402 storefront at `https://api.bitrefill.com` (no `/api` prefix). Every gated response embeds `next_step: { url, body }` chaining search → detail → create → pay → status.
+Base URL: `https://api.bitrefill.com` (no `/api` prefix on x402 routes). Every gated response embeds `next_step: { url, body }` chaining search → detail → create → pay → status.
 
-**402 envelope:** `payment-required` header is base64 JSON (`x402Version`, `accepts[]`, `extensions`, …), mirrored into the JSON body for agents that cannot read headers.
+**402 envelope:** `payment-required` header is base64 JSON, mirrored into the JSON body.
 
-**Multi-chain `accepts[]`:** micro-fees and invoice pay offer `exact` USDC on Base (`eip155:8453`), Arbitrum, Polygon, and Solana simultaneously. Amounts are 6-decimal base units (`2000` = $0.002). Base MCP `x402` picks the chain the wallet has funds on.
-
-| Method | Path | Gate | Purpose |
+| Method | Path | Cost | Auth (no JWT) |
 | --- | --- | --- | --- |
-| `GET` | `/x402/gift-cards/search` | $0.002 | Search gift cards (`q`, `country`) |
-| `GET` | `/x402/esims/search` | $0.002 | Search eSIMs |
-| `GET` | `/x402/topups/search` | $0.002 | Search mobile top-ups |
-| `GET` | `/x402/products/detail` | $0.001 | Product detail + packages (`slug`) |
-| `GET` | `/x402/checkout/info` | $0.001 | Route map / supported networks |
-| `POST` | `/x402/invoice/create` | $0.002 | Price-locked quote (1–15 items, `package_value`) |
-| `POST` | `/x402/invoice/pay` | Invoice amount | Settle with USDC x402 |
-| `GET` | `/x402/invoice/status` | $0.001 or SIWX | Poll; redemption codes for SIWX payer only |
-| `POST` | `/x402/connect` | SIWX | Mint session JWT |
-| `GET` | `/x402/my/orders` | SIWX or JWT | Wallet-scoped order history |
-| `GET` | `/x402/my/esims` | SIWX or JWT | Wallet-scoped eSIM list |
+| `GET` | `/x402/gift-cards/search?q=&country=` | $0.002 | x402 |
+| `GET` | `/x402/esims/search?q=` | $0.002 | x402 |
+| `GET` | `/x402/topups/search?q=` | $0.002 | x402 |
+| `GET` | `/x402/checkout/info` | $0.001 | x402 |
+| `GET` | `/x402/products/detail?slug=` | $0.001 | x402 |
+| `POST` | `/x402/invoice/create` | $0.002 | x402 |
+| `POST` | `/x402/invoice/pay` | invoice amount | x402 (never JWT-waived) |
+| `GET` | `/x402/invoice/status?invoice_id=` | $0.001 or SIWX | x402 or SIWX |
+| `POST` | `/x402/connect` | free | SIWX → JWT |
+| `GET` | `/x402/my/orders` | free | SIWX or JWT |
+| `GET` | `/x402/my/esims` | free | SIWX or JWT |
 
-With a valid `X-Access-Token`, the gate hook bypasses micro-fees and SIWX on all gated routes except `/x402/connect` itself (cannot mint a token with a token) and `invoice/pay` (invoice amount never waived).
+With valid **`X-Access-Token`**, the gate bypasses micro-fees and SIWX on all gated routes except `/x402/connect` (cannot mint with a token) and `invoice/pay` (invoice amount never waived).
 
-Paths 3–4 use CLI commands or MCP tools instead of these HTTP routes for catalog/invoice — but invoice payment still lands on `/x402/invoice/pay` via the `x402_payment_url` from `buy-products`.
+**Repeat reads:** paying a route once grants that wallet fee-free access to the same path for 30 days. SIWX routes still need a signature per request when not using JWT.
 
-## Commands
+### Payment (Base USDC)
 
-Path 3 only. `npx @bitrefill/cli@latest` or global `bitrefill`. `--json` before subcmd: result stdout, status stderr.
+| Field | Value |
+| --- | --- |
+| Network (CAIP-2) | `eip155:8453` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| payTo | `0x480CD46E6faDe651a0437DeaddA53D5c8e7D846A` |
 
-**Identity:** `whoami` · `login --email` · `verify --code [--otp]` · `logout` · `reset` · `manifest` · `llm-context`
+All checkout and x402 pay flows use **USDC on Base only**.
 
-```bash
-npx @bitrefill/cli@latest --json whoami
-npx @bitrefill/cli@latest login --email "user@example.com"
-npx @bitrefill/cli@latest verify --code "123456"
+### `package_value` (critical)
+
+Use the **exact** string from `products/detail` `packages[].package_value` — do not transform.
+
+| Type | Format | Example |
+| --- | --- | --- |
+| Gift cards | Bare integer string | `"10"`, `"50"` |
+| Top-ups | Bare integer string | `"5"`, `"20"` |
+| eSIMs | Descriptive label | `"1GB, 7 Days"`, `"Unlimited, 15 Days"` |
+
+Wrong `package_value` → HTTP **500** on `invoice/create` (no charge). Confirm no charge before retry (see **Notes**).
+
+### Request shapes
+
+**invoice/create** — gift card:
+
+```json
+{ "items": [{ "product_id": "amazon_it-italy", "package_value": "10" }] }
 ```
 
-`whoami --json` → `{ identity, client_id?, email? }`. T3 (`registered`) required for `list-orders` and balance pay.
+Top-up with phone (`recipient_required: true` on detail):
 
-**Search / buy / track:**
-
-```bash
-npx @bitrefill/cli@latest search-products --query "Steam" --country US
-npx @bitrefill/cli@latest get-product-details --product_id "steam-usa" --currency USDC
-npx @bitrefill/cli@latest buy-products \
-  --cart_items '[{"product_id":"steam-usa","package_id":5}]' \
-  --payment_method usdc_base \
-  --return_payment_link true \
-  --email "user@example.com"
-npx @bitrefill/cli@latest get-invoice-by-id --invoice_id "UUID"
+```json
+{ "items": [{ "product_id": "iliad-italy", "package_value": "10", "refill_input": "+39XXXXXXXXXX" }] }
 ```
 
-`package_id` only from `get-product-details` response (`package_value`). Invoices ~30 min TTL.
+Response: `{ "invoice_id", "price_usdc", "price_usd", "expires_in_minutes", "next_step" }`.
+
+**invoice/pay** — `{ "invoice_id": "<uuid>" }`. Success: `{ "success": true, "status": "payment_confirmed", "transaction", "next_step" }`.
+
+**invoice/status** — without SIWX/JWT: status fields only. With SIWX from payer or Path 1 JWT: adds `redemption_info.orders[].redemption_info` (`code`, `pin`, `extra_fields`).
+
+## Surface routing
+
+| Capability | Path 1 | Path 2 | Path 3 | Path 4 |
+| --- | --- | --- | --- | --- |
+| Connect / JWT | `sign` + `web_request` `/connect` | — | — | — |
+| Search / browse | `web_request` + `X-Access-Token` | x402 pay per route | CLI | `search-products` |
+| Product detail | `web_request` + token | x402 | CLI | `get-product-details` |
+| Invoice create | `web_request` + token | x402 | CLI / MCP | `buy-products` |
+| Pay invoice | Base MCP x402 tools | Same | x402 or `send` | Same |
+| Poll status | `web_request` + token | x402 or token-less poll + SIWX for codes | CLI | `get-invoice-by-id` |
+| Redemption codes | JWT or SIWX on `invoice/status` | SIWX from payer | CLI | `get-invoice-by-id` → `orders[].redemption_info` |
+| Order history | `web_request` `/my/orders` + token | SIWX per request | CLI | `list-invoices` |
+
+## Claude `show_widget`
+
+On **claude.ai**, render search/detail/invoice/status via the built-in **`show_widget`** tool — inline in chat, not Artifacts, not HTML in prose. Narrative stays in the message; only the visual goes in `widget_code` (`title`: snake_case).
+
+Fragment order: `<style>` → HTML → `<script>`. No `html`/`head`/`body`. Host CSS vars only (`var(--color-*)`); no `font-family`; no shadows/gradients/blur/`transition: all`. Body ≥16px; interactive `min-height: 44px`.
+
+One primary + one secondary CTA. Primary follows `next_step` ("See details for …" → "Buy … on …" → "Confirm and pay … USDC" → "Check delivery status"); wire it with `sendPrompt(...)`. Secondary is lateral escape only. Selection: transparent 2px border + outline at rest; selected `var(--color-border-info)` + `var(--color-background-info)`. Pre-select defaults so primary is actionable on first paint.
 
 ## Orchestration
 
-### Path 1: Connect → browse → buy
+### Path 1: Connect → browse → buy (default)
 
-1. Base MCP onboarding done.
-2. Connect per `## Auth` → store `token`, note `expires_in`.
-3. `web_request` `GET /x402/gift-cards/search?q=…&country=US` with `X-Access-Token` (or esims/topups routes).
-4. Follow `next_step` → `GET /x402/products/detail` → confirm quote with user.
-5. `POST /x402/invoice/create` with cart items (`slug`, `package_value`) + token.
-6. `POST /x402/invoice/pay` via Base MCP `x402` (`## Submission`) → user approves.
-7. `GET /x402/invoice/status` with token until `complete` → deliver redemption securely (`## Risks`).
+1. **Connect** — SIWX flow above → store JWT and `expires_in`. Do this **once** per session.
+2. **Confirm funds** — when needed, check USDC on Base before pay.
+3. **Search** — `web_request` `GET /x402/gift-cards/search?q=<term>&country=<ISO>` with `X-Access-Token`. Take `slug` from `products[]`. (Or `esims/search`, `topups/search`.)
+4. **Detail** — `web_request` `GET /x402/products/detail?slug=<slug>` + token. Confirm `in_stock`, `currency`, `packages[]`, `recipient_required`.
+5. **Create** — `web_request` `POST /x402/invoice/create` + token with `{ "items": [{ "product_id": "<slug>", "package_value": "<exact>" }] }` (+ `refill_input` if top-up). Read `invoice_id`, `price_usd`.
+6. **Confirm with user** — show exact USDC total, product, denomination. Get explicit approval to pay.
+7. **Pay** — x402 on `POST https://api.bitrefill.com/x402/invoice/pay` with `{ invoice_id }`, `maxPayment` just above `price_usd` → `approval-mode.md` → complete x402 request.
+8. **Poll** — `web_request` `GET /x402/invoice/status?invoice_id=<id>` + token until `delivery_status` is `all_delivered`.
+9. **Codes** — if `redemption_info` missing, run **SIWX for codes** with the paying wallet. Deliver `code` / `pin` securely (**Risks & Warnings**).
 
 ### Path 2: Pay-per-call x402
 
-1. Base MCP onboarding done.
-2. `web_request` any gated route → 402 → Base MCP `x402` with the request URL (tool handles micro-fee payment) → retry with `payment-signature` header the tool provides.
-3. Follow `next_step` chain through detail → create → pay.
-4. Invoice pay: Base MCP `x402` on `/x402/invoice/pay` with `{ invoice_id }`.
-5. Poll `/x402/invoice/status`; redemption codes require SIWX (same helpers as Path 1, or pay again).
+1. Confirm USDC on Base when needed.
+2. For each gated step: `web_request` → 402 → x402 pay that URL/method/body, `maxPayment: "0.01"` → `approval-mode.md`.
+3. Follow `next_step` through detail → create → pay.
+4. Invoice pay: `maxPayment` just above `price_usd`.
+5. Poll status; **SIWX for codes** from paying wallet.
 
-### Path 3: CLI (existing account)
+### Path 3: CLI
 
-1. `npx @bitrefill/cli@latest` for all Bitrefill ops when shell exists.
-2. T3: `login` → `verify` before `list-orders` / balance pay.
-3. Search → details → `buy-products` `usdc_base` → Base MCP `x402` on `x402_payment_url` → poll → redeem.
+```bash
+npx @bitrefill/cli@latest --help
+npx @bitrefill/cli@latest --json whoami
+npx @bitrefill/cli@latest search-products --query "Steam" --country US
+npx @bitrefill/cli@latest buy-products \
+  --cart_items '[{"product_id":"steam-usa","package_id":5}]' \
+  --payment_method usdc_base --return_payment_link true
+```
 
-### Path 4: MCP (existing account, shell-less)
+T3 (`login`/`verify`) for `list-orders`. Create with `--payment_method usdc_base`.
 
-1. Bitrefill MCP installed + OAuth ([../references/install.md](../references/install.md)).
-2. MCP `search-products` → `product-details` → `buy-products` (explicit user approval).
-3. Base MCP `x402` on returned `x402_payment_url` → MCP `get-invoice-by-id` → redemption.
+**Pay the Base invoice** — once `buy-products` returns `invoice_id`, agent picks one (follow `agent_instructions`):
+
+1. **x402** — pay `x402_payment_url` via Base MCP x402 tools → `approval-mode.md`.
+2. **Direct send** — `send` to `payment_info` address/amount on `base` → `approval-mode.md` → poll CLI/`get-invoice-by-id` until paid.
+
+Confirm amount and destination with the user. Poll until fulfilled (see **Business domain**).
+
+### Path 4: MCP
+
+Install + OAuth → `search-products` → `get-product-details` → user approves → `buy-products` with `payment_method: "usdc_base"` → pay → poll → redeem.
+
+**Pay the Base invoice** — same as Path 3: x402 on `x402_payment_url` or `send` to `payment_info`. Poll `get-invoice-by-id` until `invoice_status` is `payment_confirmed`, then until `invoice_status: complete` / `orders_delivery_status: all_delivered`. Redemption: `orders[].redemption_info`.
 
 ## Submission
 
-Payment submission, not calldata batch. Defer exact parameter names to the live Base MCP tool descriptions.
+Bitrefill uses Base MCP for reads, SIWX, x402, and direct USDC — not `send_calls`. Read tool names and schemas from the MCP catalog (`SKILL.md`).
 
-**Primary — `x402`:** micro-fees (Path 2) and invoice payment (all paths).
+| Bitrefill step | Base MCP | Bitrefill-specific |
+| --- | --- | --- |
+| Paths 1–2 API calls | `web_request` | Host `api.bitrefill.com` (allowlisted). Headers: `X-Access-Token` (raw JWT, not `Authorization`), `sign-in-with-x`, `Content-Type`. HTTP routing: `custom-plugins.md` |
+| SIWX connect / codes | `get_wallets`, `sign` | Decomposed SIWX payload in `sign-in-with-x` header — see **Auth**. EIP-55 checksum required |
+| x402 micro-fees, `invoice/pay`, Path 3/4 `x402_payment_url` | x402 tools from MCP catalog | `maxPayment`: `"0.01"` for micro-fees; slightly above invoice `price_usd` for pay |
+| Path 3/4 direct USDC | `send` | `{ chain: "base", asset: "USDC", recipient, amount }` from `payment_info` |
 
-```json
-{ "url": "https://api.bitrefill.com/x402/invoice/pay" }
-```
+All write paths: `approval-mode.md`. On 402 responses, pay the **Base USDC** (`eip155:8453`) entry from `accepts[]`.
 
-Body includes `{ "invoice_id": "<uuid>" }` when the tool schema requires it. For micro-fee 402 loops, pass the gated URL that returned 402. → `approvalUrl`, `requestId`. [approval-mode.md](../references/approval-mode.md).
+## Example prompts
 
-**SIWX connect — `sign`:** Path 1 only. `type: "personal_sign"`, `data: { message: <buildSiweMessage output> }` → approval → `get_request_status` → `signature`.
+**$25 Amazon US — Path 1:** Connect → JWT → search + token → detail → create → confirm → x402 pay → poll → deliver code.
 
-**Fallback — `send` USDC Base** (when `x402` unavailable):
+**Browse, no session — Path 2:** x402 micro-fee on each search/detail/create; SIWX for codes after pay.
 
-```json
-{
-  "chain": "base",
-  "to": "<payment_info.address>",
-  "amount": "<payment_info.altcoinPrice or quoted USDC>",
-  "asset": "USDC"
-}
-```
-
-**Not Base MCP:** balance+`auto_pay` (T3 CLI/MCP) · lightning/bitcoin/etc · CLI/MCP poll/redeem without x402 HTTP.
-
-## Example Prompts
-
-### $25 Amazon US gift card — connect path (Path 1)
-
-1. Connect per `## Auth` → JWT.
-2. Search `gift-cards` US + token → detail → confirm price.
-3. `invoice/create` → Base MCP `x402` `invoice/pay` → poll status → deliver code securely.
-
-### Browse with multiple wallets, no session (Path 2)
-
-1. `web_request` search → 402 → Base MCP `x402` pays micro-fee → retry.
-2. Repeat per gated step; invoice pay via `x402`.
-3. No `X-Access-Token`; each wallet pays its own fees.
-
-### Order history — existing account, shell (Path 3)
-
-1. `whoami` → `login`/`verify` if needed → `list-orders`.
-
-### Buy Steam card — chat client, Bitrefill account (Path 4)
-
-1. Install MCP + OAuth if missing.
-2. MCP search → details → user approves → `buy-products` → Base MCP `x402` → poll invoice.
+**Existing account — Path 3/4:** CLI or MCP catalog → Base USDC invoice → x402 or `send` → poll → redeem.
 
 ## Risks & Warnings
 
-- **`pii`** — Redemption codes, eSIM QR URLs, PINs, and receipt emails are bearer/cash-like personal data. Never paste codes in group chats, public channels, logs, version control, or voice/TTS output. Only return a code when the user explicitly asks.
-- **`irreversible`** — Digital goods deliver instantly and are non-refundable once fulfilled. Always confirm product, denomination, price, and payment method before purchase. Never auto-buy without explicit user approval.
-- **Spending cap** — Use a dedicated, low-balance Base Account for USDC payments. Never give the agent seed phrases or high-balance accounts.
-- **Invoice expiry** — Invoices expire (~15 min price lock, ~30 min typical). Stale `x402_payment_url` → create a new invoice.
-- **Connect token** — `X-Access-Token` is a bearer secret (~2 h TTL). Never log it, commit it, or echo it in chat. Re-connect when expired.
-- **EIP-55 checksum** — SIWX rejects lowercase addresses from `get_wallets`. Always run `toChecksumAddress` before `buildSiweMessage`.
-- **Package values** — Only from product detail response. Case-sensitive (`"1GB, 7 Days"`, `"1 Month"`). MCP uses `package_value` (not composite `package_id`).
-- **CLI session token** — `~/.config/bitrefill-cli/<host>.v1.json` sensitive; `reset` rotates.
+- **`pii`** — Redemption codes, eSIM QR URLs, PINs are bearer credentials. Never log, commit, or paste in public channels. Return codes only when the user explicitly asks.
+- **`irreversible`** — Digital goods are non-refundable once fulfilled. Confirm product, denomination, price, and payment before pay.
+- **Invoice expiry** — ~15 min price lock. Stale pay URL → create a new invoice.
+- **Connect token** — `X-Access-Token` is a bearer secret (~2 h). Never echo in chat. Re-connect when expired.
+- **EIP-55 checksum** — mandatory for every SIWX flow; use helpers above.
+- **CLI session** — `~/.config/bitrefill-cli/<host>.v1.json` is sensitive.
 
 ## Notes
 
-- USDC Base: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
-- x402 also accepts USDC on Arbitrum, Polygon, Solana in `accepts[]`; Base MCP `x402` selects by wallet funds
-- Country: Alpha-2 uppercase (`US`, `IT`)
-- `X-Access-Token` header (not `Authorization: Bearer`) — Base MCP strips `Authorization`
-- Fee schedule: search $0.002 · detail/checkout $0.001 · invoice create $0.002 · status $0.001
-- Connect-JWT TTL: `X402_CONNECT_TOKEN_TTL_MINUTES` (default 120)
+- Country codes: Alpha-2 uppercase (`US`, `IT`).
+- `X-Access-Token` header only — Base MCP strips `Authorization`.
+- Fee schedule: search $0.002 · detail/checkout $0.001 · create $0.002 · status $0.001.
+- Connect JWT TTL: default 120 minutes.
+- **HTTP 500 on invoice/create** — wrong `package_value`; retry without paying until onchain history confirms no charge.
+- **402 after SIWX send** — stale nonce, wrong checksum, or malformed payload; re-fetch challenge and re-sign within 5 minutes.
+- **403 on SIWX route** — wrong wallet; sign with the invoice payer.
+- **`INVOICE_NOT_PAYABLE` on pay** — already settled; poll status instead.
 - Docs: [github.com/bitrefill/agents](https://github.com/bitrefill/agents), [docs.bitrefill.com](https://docs.bitrefill.com)


### PR DESCRIPTION
## Summary

Updates the Bitrefill Base MCP plugin for clearer agent UX and tighter Base-only scope:

- **Marketing overview** — ASO-style description and benefit-led overview; technical path detail moved to **Detection**
- **Business domain** — maps Bitrefill `invoice`/`order` terminology to user-facing language; async fulfillment + help.bitrefill.com escalation
- **Claude `show_widget`** — inline UI guidance for claude.ai generative UI (not Artifacts)
- **Path 3/4 pay** — after Base USDC invoice create, agent chooses x402 on `x402_payment_url` or direct `send` to `payment_info`
- **MCP tool names** — corrected to verified catalog (`get-product-details`, `list-invoices`, `get-invoice-by-id`, etc.)
- **No base-skill overlap** — defers onboarding, approval flow, and tool catalog to `SKILL.md`, `approval-mode.md`, `custom-plugins.md`; adds canonical **Submission** section
- **Base USDC only** — removed non-Base payment network references

Prior commit on this branch adds x402-native flows (connect→JWT default, pay-per-call fallback), SIWX helpers, and endpoint docs.

## Test plan

- [x] Bitrefill MCP tools verified live (`search-products`, `get-product-details`, `list-invoices`, `get-invoice-by-id`)
- [x] Base MCP tools verified against MCP schemas (`web_request`, x402, `send`, `sign`)
- [ ] Maintainer review of x402 flow accuracy against live `api.bitrefill.com`