### PR TITLE
[codex] Fix builder code parsing in register script

### DIFF
--- a/skills/build-on-base/scripts/register.sh
+++ b/skills/build-on-base/scripts/register.sh
@@ -18,7 +18,11 @@ RESPONSE=$(curl -sf -X POST "$API_URL" \
   exit 1
 }
 
-BUILDER_CODE=$(echo "$RESPONSE" | grep -o '"builder_code":"[^"]*"' | cut -d'"' -f4)
+BUILDER_CODE=$(printf '%s' "$RESPONSE" | jq -r '.builder_code // empty') || {
+  echo "Error: Failed to parse API response" >&2
+  echo "Response: $RESPONSE" >&2
+  exit 1
+}
 
 if [ -z "$BUILDER_CODE" ]; then
   echo "Error: No builder_code in API response" >&2

--- a/skills/build-on-base/scripts/register_test.sh
+++ b/skills/build-on-base/scripts/register_test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$TMP_DIR/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "builder_code": "bc_a1b2c3d4",
+  "wallet_address": "0x123",
+  "usage_instructions": "Append this builder code to your onchain transactions."
+}
+JSON
+FAKE_CURL
+chmod +x "$TMP_DIR/curl"
+
+set +e
+output=$(PATH="$TMP_DIR:$PATH" bash "$SCRIPT_DIR/register.sh" "0x123" 2>&1)
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  echo "Expected register.sh to succeed, got exit $status:" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [ "$output" != "bc_a1b2c3d4" ]; then
+  echo "Expected builder code bc_a1b2c3d4, got: $output" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- parse the builder code API response with jq instead of a whitespace-sensitive grep pattern
- add a shell regression test that fakes the API response with pretty-printed JSON

## Root cause
The register script searched for `"builder_code":"..."`, so valid JSON with a space after the colon produced no match. Because the script runs with `set -euo pipefail`, the failed grep could exit before the existing empty-value guard ran.

Fixes #54.

## Validation
- `bash -n skills/build-on-base/scripts/register.sh`
- `bash -n skills/build-on-base/scripts/register_test.sh`
- `bash skills/build-on-base/scripts/register_test.sh`