### PR TITLE
docs(base-mcp): make plugin specs MDX-safe

### DIFF
--- a/skills/base-mcp/plugins/clawnch.md
+++ b/skills/base-mcp/plugins/clawnch.md
@@ -468,7 +468,7 @@ dead address, `value: "0x0"`, amount in wei (whole tokens × 10^18).
 
 1. `web_request` GET `https://www.clawn.ch/api/tokens?limit=1&sort=volume&prices=1`.
 2. Take `tokens[0]`. Show: symbol, name, address, current price, 24h volume.
-3. Ask the user to confirm — "Buy 0.001 ETH of `<SYMBOL>` (`<address>`) at ~$<price>?".
+3. Ask the user to confirm — "Buy 0.001 ETH of `<SYMBOL>` (`<address>`) at `~$<price>`?".
 4. On confirmation: `swap` with `fromAsset=ETH`, `toAsset=<token.address>`, `amount="0.001"`, `chain="base"`.
 5. Open the approval URL; poll `get_request_status` once the user has approved.
 

--- a/skills/base-mcp/plugins/flaunch.md
+++ b/skills/base-mcp/plugins/flaunch.md
@@ -386,7 +386,7 @@ The token contract address can come from Flaunch discovery or direct user input.
 1. Resolve the token address from Flaunch discovery or use the address provided by the user.
 2. Confirm symbol/name/address when known.
 3. Warn about low liquidity and slippage.
-4. Ask the user to confirm: "Buy 0.001 ETH of <symbol> (<address>)?"
+4. Ask the user to confirm: "Buy 0.001 ETH of `<symbol>` (`<address>`)?"
 5. On confirmation, call Base MCP `swap` with `fromAsset="ETH"`, `toAsset="<token contract address>"`, `amount="0.001"`, and `chain="base"`.
 6. Surface the "Approve Transaction" link and poll request status only after the user acts.
 

--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -60,9 +60,9 @@ Use the returned key in the `X-API-KEY` header on all subsequent requests.
 - 5 requests/min for fulfillment endpoints
 - Keys expire after 30 days
 
-To upgrade to higher rate limits, visit <https://opensea.io/settings/developer>.
+To upgrade to higher rate limits, visit [OpenSea developer settings](https://opensea.io/settings/developer).
 
-Full documentation: <https://docs.opensea.io/reference/api-keys#instant-api-key-for-agents>
+Full documentation: [OpenSea API key docs](https://docs.opensea.io/reference/api-keys#instant-api-key-for-agents)
 
 Or set an existing key:
 


### PR DESCRIPTION
## Summary

- Escapes placeholder angle-bracket text in Clawnch and Flaunch examples so Mintlify does not parse it as JSX.
- Converts two OpenSea bare autolinks to Markdown links for the same reason.

## Why

`base/docs` mirrors these raw plugin specs under `docs/agents/skills/`; Mintlify parses them as MDX and reported these three parse errors during local preview.

## Verification

- `npx mintlify dev --no-open` in base/docs reached preview ready after these fixes were mirrored.