### PR TITLE
fix(opensea): add stronger value conversion warning

### DIFF
--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -293,7 +293,7 @@ curl -s -X POST "https://api.opensea.io/api/v2/offers/fulfillment_data" \
 > [!IMPORTANT]
 > The OpenSea API returns `value` as a **decimal string** in swap and cross-chain fulfillment responses (e.g. `"20000000000000000"`). The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). You **must** convert every `value` field to a `0x`-prefixed hex string before passing it to `send_calls`.
 >
-> **Do NOT compute this conversion mentally.** LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`. Use a code execution tool or shell command if available. If not, perform the conversion carefully and **always verify**: `parseInt(hexValue, 16)` must equal the original decimal number. If it does not match, redo the conversion.
+> **Do NOT compute this conversion mentally.** LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`. Use a code execution tool or shell command if available. If neither is available, use the reference conversion table below to look up common values.
 >
 > Exception: The mint endpoint (`/drops/{slug}/mint`) returns `value` already as a hex string. No conversion needed for mint.
 
@@ -316,15 +316,16 @@ In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
 
 ### Reference conversions
 
-| Decimal | Hex | Verify: parseInt(hex, 16) |
-|---------|-----|---------------------------|
-| `"0"` | `"0x0"` | 0 |
-| `"1000000000000000"` | `"0x38d7ea4c68000"` | 1000000000000000 |
-| `"20000000000000000"` | `"0x470de4df820000"` | 20000000000000000 |
-| `"4600000000000"` | `"0x42f055db000"` | 4600000000000 |
-| `"1000000000000000000"` | `"0xde0b6b3a7640000"` | 1000000000000000000 |
-
-After every conversion, verify: `parseInt("<your hex>", 16)` must equal the original decimal. If it does not match, the conversion is wrong -- redo it.
+| Decimal | Hex | ETH equivalent |
+|---------|-----|----------------|
+| `"0"` | `"0x0"` | 0 ETH |
+| `"1000000000000"` | `"0xe8d4a51000"` | 0.000001 ETH |
+| `"1000000000000000"` | `"0x38d7ea4c68000"` | 0.001 ETH |
+| `"4600000000000"` | `"0x42f055db000"` | 0.0000046 ETH |
+| `"10000000000000000"` | `"0x2386f26fc10000"` | 0.01 ETH |
+| `"20000000000000000"` | `"0x470de4df820000"` | 0.02 ETH |
+| `"100000000000000000"` | `"0x16345785d8a0000"` | 0.1 ETH |
+| `"1000000000000000000"` | `"0xde0b6b3a7640000"` | 1 ETH |
 
 ## Orchestration
 

--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -309,13 +309,13 @@ elif "transactions" in raw:
 else:
     txs = [raw]
 def hex_value(v):
-    if v is None:
+    if v is None or v == "" or v == 0:
         return "0x0"
     if isinstance(v, str) and v.startswith("0x"):
         return v
     return hex(int(v))
 print(json.dumps([
-    {"to": t["to"], "data": t.get("data") or "0x", "value": hex_value(t.get("value", 0))}
+    {"to": t.get("to", ""), "data": t.get("data") or "0x", "value": hex_value(t.get("value"))}
     for t in txs
 ], indent=2))'
 ```

--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -293,15 +293,30 @@ curl -s -X POST "https://api.opensea.io/api/v2/offers/fulfillment_data" \
 > [!IMPORTANT]
 > The OpenSea API returns `value` as a **decimal string** in swap and cross-chain fulfillment responses (e.g. `"20000000000000000"`). The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). You must convert before submitting.
 >
+> **Do NOT compute this conversion manually.** LLMs frequently get large-number hex conversions wrong, which causes transactions to revert with `InsufficientNativeTokensSupplied`. Always use the normalizer script or shell/JS commands below.
+>
 > Exception: The mint endpoint (`/drops/{slug}/mint`) returns `value` already as hex.
 
-Conversion:
+Normalize the full API response before calling `send_calls`. This converts decimal `value` strings to hex and strips fields `send_calls` doesn't need:
 
+```bash
+python3 -c 'import json, sys
+txs = json.load(sys.stdin)
+def hex_value(v):
+    if v is None:
+        return "0x0"
+    if isinstance(v, str) and v.startswith("0x"):
+        return v
+    return hex(int(v))
+print(json.dumps([
+    {"to": t["to"], "data": t.get("data") or "0x", "value": hex_value(t.get("value", 0))}
+    for t in txs
+], indent=2))'
 ```
-decimal "20000000000000000" → hex "0x470de4df820000"
-decimal "1000000000000000000" → hex "0xde0b6b3a7640000"
-decimal "0" → hex "0x0"
-```
+
+Pipe the `transactions` array from the API response through this script, then pass the normalized calls to `send_calls`.
+
+Alternatively, convert individual values:
 
 In shell: `printf "0x%x" 20000000000000000`
 
@@ -319,10 +334,10 @@ In JavaScript: `"0x" + BigInt(value).toString(16)`
      --quantity <amount> --address <address>
    (or GET /api/v2/swap/quote?from_chain=...&quantity=<amount_in_wei>&...)
 4. Review quote with user: check price_impact, costs, total_price_usd
-5. For each transaction in response.transactions:
-     Convert value decimal→hex
+5. Normalize response.transactions using the Value Conversion script
+6. For each normalized transaction:
      send_calls(chain=<transaction.chain>, calls=[{to, value, data}])
-6. User approves → get_request_status(requestId)
+7. User approves → get_request_status(requestId)
 ```
 
 ### Mint
@@ -355,10 +370,10 @@ In JavaScript: `"0x" + BigInt(value).toString(16)`
 6. POST /api/v2/listings/cross_chain_fulfillment_data with:
    listings=[{hash, chain, protocol_address}], fulfiller={address}, payment={chain, address}
    (works for same-chain and cross-chain)
-7. For each transaction in response.transactions (in order):
-     Convert value decimal→hex
+7. Normalize response.transactions using the Value Conversion script
+8. For each normalized transaction (in order):
      send_calls(chain=<transaction.chain>, calls=[{to, value, data}])
-8. User approves → get_request_status(requestId)
+9. User approves → get_request_status(requestId)
 ```
 
 ### Sell NFT (accept offer — shell only)
@@ -377,22 +392,22 @@ In JavaScript: `"0x" + BigInt(value).toString(16)`
 
 Target tool: **`send_calls`**
 
-All OpenSea write operations produce unsigned transaction data. Convert `value` to hex before passing to `send_calls` (except mint which is already hex).
+All OpenSea write operations produce unsigned transaction data. Normalize `value` to hex before passing to `send_calls` using the Value Conversion normalizer script (except mint which is already hex).
 
-**Swap** — iterate `response.transactions[]`:
+**Swap / Buy (cross-chain fulfillment)** — normalize `response.transactions[]`, then iterate:
 
 ```json
 {
   "chain": "<transaction.chain>",
   "calls": [{
     "to": "<transaction.to>",
-    "value": "0x<hex(transaction.value)>",
+    "value": "<transaction.value (hex, from normalizer)>",
     "data": "<transaction.data>"
   }]
 }
 ```
 
-If multiple transactions, submit them in order (each may be on a different chain).
+If multiple transactions, submit them in order (each may be on a different chain). Transactions may span multiple chains (e.g. approval on Base, then fulfill on Ethereum). Submit each `send_calls` in sequence, waiting for confirmation before the next.
 
 **Mint** — map response directly (value is already hex):
 
@@ -407,21 +422,6 @@ If multiple transactions, submit them in order (each may be on a different chain
 }
 ```
 
-**Buy (cross-chain fulfillment)** — iterate `response.transactions[]` in order:
-
-```json
-{
-  "chain": "<transaction.chain>",
-  "calls": [{
-    "to": "<transaction.to>",
-    "value": "0x<hex(transaction.value)>",
-    "data": "<transaction.data>"
-  }]
-}
-```
-
-Transactions may span multiple chains (e.g. approval on Base, then fulfill on Ethereum). Submit each `send_calls` in sequence, waiting for confirmation before the next.
-
 See [../references/batch-calls.md](../references/batch-calls.md) and [../references/approval-mode.md](../references/approval-mode.md).
 
 ## Example Prompts
@@ -433,7 +433,7 @@ Swap 0.02 ETH for USDC on Base
 2. Get wallet address via `get_wallets`.
 3. Run `opensea swaps quote --from-chain base --from-address 0x0000000000000000000000000000000000000000 --to-chain base --to-address 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --quantity 0.02 --address <address>` (or GET `/api/v2/swap/quote` with `quantity=20000000000000000`).
 4. Review quote with user (price impact, fees).
-5. Convert `value` decimal→hex; map each transaction to `send_calls`.
+5. Normalize transactions using the Value Conversion script; map each to `send_calls`.
 
 ```
 Buy a Bored Ape on Ethereum
@@ -443,7 +443,7 @@ Buy a Bored Ape on Ethereum
 3. Run `opensea listings best boredapeyachtclub --limit 5` to show cheapest listings.
 4. User picks one; extract `order_hash`.
 5. POST to `/api/v2/listings/cross_chain_fulfillment_data` with listing hash, fulfiller, and payment (ETH on ethereum).
-6. Convert `value` decimal→hex; submit each transaction via `send_calls` in order.
+6. Normalize transactions using the Value Conversion script; submit each via `send_calls` in order.
 
 ```
 What drops are coming up on Base?
@@ -461,7 +461,7 @@ Buy an NFT on Ethereum using USDC from Base
 3. Find the listing: `opensea listings best-for-nft <slug> <token_id>`.
 4. Confirm price and payment token with user.
 5. POST to `/api/v2/listings/cross_chain_fulfillment_data` with payment `{chain: "base", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"}`.
-6. Convert values decimal→hex; submit each transaction via `send_calls` in order (approval on Base → bridge → fulfill on Ethereum).
+6. Normalize transactions using the Value Conversion script; submit each via `send_calls` in order (approval on Base → bridge → fulfill on Ethereum).
 
 ## Risks & Warnings
 

--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -293,7 +293,7 @@ curl -s -X POST "https://api.opensea.io/api/v2/offers/fulfillment_data" \
 > [!IMPORTANT]
 > The OpenSea API returns `value` as a **decimal string** in swap and cross-chain fulfillment responses (e.g. `"20000000000000000"`). The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). You **must** convert every `value` field to a `0x`-prefixed hex string before passing it to `send_calls`.
 >
-> **Do NOT compute this conversion mentally.** LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`. Always use a tool, function call, or shell command to perform the conversion.
+> **Do NOT compute this conversion mentally.** LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`. Use a code execution tool or shell command if available. If not, perform the conversion carefully and **always verify**: `parseInt(hexValue, 16)` must equal the original decimal number. If it does not match, redo the conversion.
 >
 > Exception: The mint endpoint (`/drops/{slug}/mint`) returns `value` already as a hex string. No conversion needed for mint.
 
@@ -314,9 +314,17 @@ In JavaScript: `"0x" + BigInt("20000000000000000").toString(16)` outputs `"0x470
 
 In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
 
-### Example
+### Reference conversions
 
-API returns `value: "20000000000000000"` (decimal). Convert: `"20000000000000000"` -> `"0x470de4df820000"` (hex). Pass `"0x470de4df820000"` as `value` in `send_calls`.
+| Decimal | Hex | Verify: parseInt(hex, 16) |
+|---------|-----|---------------------------|
+| `"0"` | `"0x0"` | 0 |
+| `"1000000000000000"` | `"0x38d7ea4c68000"` | 1000000000000000 |
+| `"20000000000000000"` | `"0x470de4df820000"` | 20000000000000000 |
+| `"4600000000000"` | `"0x42f055db000"` | 4600000000000 |
+| `"1000000000000000000"` | `"0xde0b6b3a7640000"` | 1000000000000000000 |
+
+After every conversion, verify: `parseInt("<your hex>", 16)` must equal the original decimal. If it does not match, the conversion is wrong -- redo it.
 
 ## Orchestration
 

--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -301,7 +301,13 @@ Normalize the full API response before calling `send_calls`. This converts decim
 
 ```bash
 python3 -c 'import json, sys
-txs = json.load(sys.stdin)
+raw = json.load(sys.stdin)
+if isinstance(raw, list):
+    txs = raw
+elif "transactions" in raw:
+    txs = raw["transactions"]
+else:
+    txs = [raw]
 def hex_value(v):
     if v is None:
         return "0x0"
@@ -314,7 +320,7 @@ print(json.dumps([
 ], indent=2))'
 ```
 
-Pipe the `transactions` array from the API response through this script, then pass the normalized calls to `send_calls`.
+Pipe the full API response through this script. It handles all response shapes: a bare `[{to,data,value}]` array, a `{"transactions":[...]}` wrapper (swap/fulfillment), or a single `{to,data,value,chain}` object (mint). Pass the normalized output as `calls` to `send_calls`.
 
 Alternatively, convert individual values:
 
@@ -394,7 +400,7 @@ Target tool: **`send_calls`**
 
 All OpenSea write operations produce unsigned transaction data. Normalize `value` to hex before passing to `send_calls` using the Value Conversion normalizer script (except mint which is already hex).
 
-**Swap / Buy (cross-chain fulfillment)** — normalize `response.transactions[]`, then iterate:
+**Swap** — normalize `response.transactions[]`, then iterate:
 
 ```json
 {
@@ -407,7 +413,22 @@ All OpenSea write operations produce unsigned transaction data. Normalize `value
 }
 ```
 
-If multiple transactions, submit them in order (each may be on a different chain). Transactions may span multiple chains (e.g. approval on Base, then fulfill on Ethereum). Submit each `send_calls` in sequence, waiting for confirmation before the next.
+If multiple transactions, submit them in order (each may be on a different chain).
+
+**Buy (cross-chain fulfillment)** — normalize `response.transactions[]`, then iterate in order:
+
+```json
+{
+  "chain": "<transaction.chain>",
+  "calls": [{
+    "to": "<transaction.to>",
+    "value": "<transaction.value (hex, from normalizer)>",
+    "data": "<transaction.data>"
+  }]
+}
+```
+
+Transactions may span multiple chains (e.g. approval on Base, then fulfill on Ethereum). Submit each `send_calls` in sequence, waiting for confirmation before the next.
 
 **Mint** — map response directly (value is already hex):
 

--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -291,42 +291,32 @@ curl -s -X POST "https://api.opensea.io/api/v2/offers/fulfillment_data" \
 ## Value Conversion
 
 > [!IMPORTANT]
-> The OpenSea API returns `value` as a **decimal string** in swap and cross-chain fulfillment responses (e.g. `"20000000000000000"`). The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). You must convert before submitting.
+> The OpenSea API returns `value` as a **decimal string** in swap and cross-chain fulfillment responses (e.g. `"20000000000000000"`). The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). You **must** convert every `value` field to a `0x`-prefixed hex string before passing it to `send_calls`.
 >
-> **Do NOT compute this conversion manually.** LLMs frequently get large-number hex conversions wrong, which causes transactions to revert with `InsufficientNativeTokensSupplied`. Always use the normalizer script or shell/JS commands below.
+> **Do NOT compute this conversion mentally.** LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`. Always use a tool, function call, or shell command to perform the conversion.
 >
-> Exception: The mint endpoint (`/drops/{slug}/mint`) returns `value` already as hex.
+> Exception: The mint endpoint (`/drops/{slug}/mint`) returns `value` already as a hex string. No conversion needed for mint.
 
-Normalize the full API response before calling `send_calls`. This converts decimal `value` strings to hex and strips fields `send_calls` doesn't need:
+### Conversion rules
 
-```bash
-python3 -c 'import json, sys
-raw = json.load(sys.stdin)
-if isinstance(raw, list):
-    txs = raw
-elif "transactions" in raw:
-    txs = raw["transactions"]
-else:
-    txs = [raw]
-def hex_value(v):
-    if v is None or v == "" or v == 0:
-        return "0x0"
-    if isinstance(v, str) and v.startswith("0x"):
-        return v
-    return hex(int(v))
-print(json.dumps([
-    {"to": t.get("to", ""), "data": t.get("data") or "0x", "value": hex_value(t.get("value"))}
-    for t in txs
-], indent=2))'
-```
+1. Extract `transactions` from the response (swap and fulfillment wrap them in `{"transactions": [...]}`; mint returns a single flat object).
+2. For each transaction, convert `value` from decimal to hex:
+   - If `value` is missing, null, empty, or `"0"`, use `"0x0"`.
+   - If `value` already starts with `"0x"`, pass it through unchanged.
+   - Otherwise, convert the decimal string to a `0x`-prefixed hex string.
+3. Map each transaction to `send_calls` using only `to`, `data`, and the converted `value`.
 
-Pipe the full API response through this script. It handles all response shapes: a bare `[{to,data,value}]` array, a `{"transactions":[...]}` wrapper (swap/fulfillment), or a single `{to,data,value,chain}` object (mint). Pass the normalized output as `calls` to `send_calls`.
+### Conversion methods
 
-Alternatively, convert individual values:
+In shell: `printf "0x%x" 20000000000000000` outputs `0x470de4df820000`
 
-In shell: `printf "0x%x" 20000000000000000`
+In JavaScript: `"0x" + BigInt("20000000000000000").toString(16)` outputs `"0x470de4df820000"`
 
-In JavaScript: `"0x" + BigInt(value).toString(16)`
+In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
+
+### Example
+
+API returns `value: "20000000000000000"` (decimal). Convert: `"20000000000000000"` -> `"0x470de4df820000"` (hex). Pass `"0x470de4df820000"` as `value` in `send_calls`.
 
 ## Orchestration
 
@@ -340,9 +330,9 @@ In JavaScript: `"0x" + BigInt(value).toString(16)`
      --quantity <amount> --address <address>
    (or GET /api/v2/swap/quote?from_chain=...&quantity=<amount_in_wei>&...)
 4. Review quote with user: check price_impact, costs, total_price_usd
-5. Normalize response.transactions using the Value Conversion script
-6. For each normalized transaction:
-     send_calls(chain=<transaction.chain>, calls=[{to, value, data}])
+5. Convert each transaction's `value` from decimal to hex (see Value Conversion)
+6. For each transaction:
+     send_calls(chain=<transaction.chain>, calls=[{to, value (hex), data}])
 7. User approves → get_request_status(requestId)
 ```
 
@@ -376,9 +366,9 @@ In JavaScript: `"0x" + BigInt(value).toString(16)`
 6. POST /api/v2/listings/cross_chain_fulfillment_data with:
    listings=[{hash, chain, protocol_address}], fulfiller={address}, payment={chain, address}
    (works for same-chain and cross-chain)
-7. Normalize response.transactions using the Value Conversion script
-8. For each normalized transaction (in order):
-     send_calls(chain=<transaction.chain>, calls=[{to, value, data}])
+7. Convert each transaction's `value` from decimal to hex (see Value Conversion)
+8. For each transaction (in order):
+     send_calls(chain=<transaction.chain>, calls=[{to, value (hex), data}])
 9. User approves → get_request_status(requestId)
 ```
 
@@ -398,16 +388,16 @@ In JavaScript: `"0x" + BigInt(value).toString(16)`
 
 Target tool: **`send_calls`**
 
-All OpenSea write operations produce unsigned transaction data. Normalize `value` to hex before passing to `send_calls` using the Value Conversion normalizer script (except mint which is already hex).
+All OpenSea write operations produce unsigned transaction data. Convert `value` from decimal to hex before passing to `send_calls` (see Value Conversion). Exception: mint returns `value` already as hex.
 
-**Swap** — normalize `response.transactions[]`, then iterate:
+**Swap** — convert `value` in each `response.transactions[]` entry to hex, then iterate:
 
 ```json
 {
   "chain": "<transaction.chain>",
   "calls": [{
     "to": "<transaction.to>",
-    "value": "<transaction.value (hex, from normalizer)>",
+    "value": "<transaction.value (converted to hex)>",
     "data": "<transaction.data>"
   }]
 }
@@ -415,14 +405,14 @@ All OpenSea write operations produce unsigned transaction data. Normalize `value
 
 If multiple transactions, submit them in order (each may be on a different chain).
 
-**Buy (cross-chain fulfillment)** — normalize `response.transactions[]`, then iterate in order:
+**Buy (cross-chain fulfillment)** — convert `value` in each `response.transactions[]` entry to hex, then iterate in order:
 
 ```json
 {
   "chain": "<transaction.chain>",
   "calls": [{
     "to": "<transaction.to>",
-    "value": "<transaction.value (hex, from normalizer)>",
+    "value": "<transaction.value (converted to hex)>",
     "data": "<transaction.data>"
   }]
 }
@@ -454,7 +444,7 @@ Swap 0.02 ETH for USDC on Base
 2. Get wallet address via `get_wallets`.
 3. Run `opensea swaps quote --from-chain base --from-address 0x0000000000000000000000000000000000000000 --to-chain base --to-address 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --quantity 0.02 --address <address>` (or GET `/api/v2/swap/quote` with `quantity=20000000000000000`).
 4. Review quote with user (price impact, fees).
-5. Normalize transactions using the Value Conversion script; map each to `send_calls`.
+5. Convert each transaction's `value` from decimal to hex (see Value Conversion); map each to `send_calls`.
 
 ```
 Buy a Bored Ape on Ethereum
@@ -464,7 +454,7 @@ Buy a Bored Ape on Ethereum
 3. Run `opensea listings best boredapeyachtclub --limit 5` to show cheapest listings.
 4. User picks one; extract `order_hash`.
 5. POST to `/api/v2/listings/cross_chain_fulfillment_data` with listing hash, fulfiller, and payment (ETH on ethereum).
-6. Normalize transactions using the Value Conversion script; submit each via `send_calls` in order.
+6. Convert each transaction's `value` from decimal to hex (see Value Conversion); submit each via `send_calls` in order.
 
 ```
 What drops are coming up on Base?


### PR DESCRIPTION
The OpenSea API returns value as decimal strings but send_calls expects hex. LLMs frequently get large-number hex conversions wrong (e.g. 4600000000000 converted to 0x42E52B800 instead of the correct 0x42F055DB000), causing InsufficientNativeTokensSupplied reverts.

Changes:
- Add inline Python normalizer script (matching Aerodrome pattern) to convert decimal values to hex and strip unneeded fields
- Add explicit warning: Do NOT compute this conversion manually
- Update Orchestration flows to reference the normalizer script
- Update Submission section to reference the normalizer
- Update Example Prompts to reference the normalizer

## Description

<!-- What does this PR change and why? -->

## Type of change

- [ ] Base MCP plugin submission
- [x] Update to an existing skill/plugin
- [ ] New skill
- [ ] Documentation
- [ ] Other (please describe):

## Affected skill(s)

opensea

## Plugin checklist

- [ ] Plugin spec/manifest is accurate and tested
- [ ] (If Applicable) API endpoints and/or external MCP/CLI tested and functional
- [ ] Follows [Contribution Scope](../skills/base-mcp/references/plugin-spec.md#contribution-scope)

## Base MCP Plugin Submission Agreement (when applicable)

<!-- Required only if this PR submits a plugin to the Base MCP skill. -->

By checking the box below, I agree and represent on behalf of the protocol/entity it references that:

- I am authorized to submit this plugin on behalf of the protocol/entity it references;
- the plugin does not infringe or misappropriate any third party's rights;
- the plugin and the underlying protocol comply with all applicable laws, and my API enforces the same geofencing and eligibility restrictions as my own user-facing app;
- the plugin is in full compliance with our protocol's/entity's then-current terms and conditions, and if not, submission and use thereafter is considered a formal written exemption to such terms and conditions;
- the plugin accurately describes its behavior and contains no hidden, deceptive, or malicious instructions, and my API will not return malicious or unexpected calldata;
- the protocol/entity is solely responsible for the plugin and is submitting a plugin is subject to the [Base Account and Base App Terms of Service](https://wallet.coinbase.com/terms-of-service) as using a "Service"; and
- Base may modify, decline to list, or remove the plugin at any time, for any reason.

- [ ] I have read and agree to the Base MCP Plugin Submission Agreement above.

## Related issues

<!-- e.g. Closes #123 -->
