### PR TITLE
feat: use value_hex from API responses instead of manual decimal-to-hex conversion

### DIFF
--- a/skills/base-mcp/plugins/opensea.md
+++ b/skills/base-mcp/plugins/opensea.md
@@ -3,7 +3,7 @@ title: "OpenSea Plugin"
 description: "NFT marketplace trading, token swaps, and drops/minting via OpenSea REST API + CLI → send_calls on Ethereum, Base, Polygon, Arbitrum, Optimism, and Avalanche."
 tags: [nft, marketplace, swap, drops, trading]
 name: opensea
-version: 0.3.0
+version: 0.4.0
 integration: hybrid
 chains: [ethereum, base, polygon, arbitrum, optimism, avalanche]
 requires:
@@ -167,12 +167,13 @@ Note: The REST API `quantity` parameter expects the amount in **smallest units**
     "chain": "base",
     "to": "0xSwapRouter",
     "data": "0x...",
-    "value": "20000000000000000"
+    "value": "20000000000000000",
+    "value_hex": "0x470de4df820000"
   }]
 }
 ```
 
-Each transaction in `transactions[]` contains `{chain, to, data, value}` — ready to map to `send_calls`.
+Each transaction in `transactions[]` contains `{chain, to, data, value, value_hex}`. Use `value_hex` (already a `0x`-prefixed hex string) when passing `value` to `send_calls`.
 
 ### NFT Drops & Minting
 
@@ -257,8 +258,8 @@ Set `payment.chain` to the listing chain and `payment.address` to the native tok
 ```json
 {
   "transactions": [
-    { "chain": "base", "to": "0x...", "data": "0x...", "value": "20000000000000000" },
-    { "chain": "ethereum", "to": "0x...", "data": "0x...", "value": "1000000000000000000" }
+    { "chain": "base", "to": "0x...", "data": "0x...", "value": "20000000000000000", "value_hex": "0x470de4df820000" },
+    { "chain": "ethereum", "to": "0x...", "data": "0x...", "value": "1000000000000000000", "value_hex": "0xde0b6b3a7640000" }
   ]
 }
 ```
@@ -291,41 +292,30 @@ curl -s -X POST "https://api.opensea.io/api/v2/offers/fulfillment_data" \
 ## Value Conversion
 
 > [!IMPORTANT]
-> The OpenSea API returns `value` as a **decimal string** in swap and cross-chain fulfillment responses (e.g. `"20000000000000000"`). The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). You **must** convert every `value` field to a `0x`-prefixed hex string before passing it to `send_calls`.
+> The `send_calls` tool expects `value` as a **hex string** (e.g. `"0x470de4df820000"`). The OpenSea API now returns a `value_hex` field alongside the decimal `value` in swap and fulfillment responses. **Always use `value_hex` when passing `value` to `send_calls`.**
 >
-> **Do NOT compute this conversion mentally.** LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`. Use a code execution tool or shell command if available. If neither is available, use the reference conversion table below to look up common values.
+> If `value_hex` is null or missing, fall back to converting the decimal `value` string to hex using a code execution tool or shell command. **Do NOT compute this conversion mentally** — LLMs frequently get large-number hex conversions wrong (e.g. converting `4600000000000` to `0x42E52B800` instead of the correct `0x42F055DB000`), which causes transactions to revert with `InsufficientNativeTokensSupplied`.
 >
 > Exception: The mint endpoint (`/drops/{slug}/mint`) returns `value` already as a hex string. No conversion needed for mint.
 
-### Conversion rules
+### Rules
 
 1. Extract `transactions` from the response (swap and fulfillment wrap them in `{"transactions": [...]}`; mint returns a single flat object).
-2. For each transaction, convert `value` from decimal to hex:
-   - If `value` is missing, null, empty, or `"0"`, use `"0x0"`.
-   - If `value` already starts with `"0x"`, pass it through unchanged.
-   - Otherwise, convert the decimal string to a `0x`-prefixed hex string.
-3. Map each transaction to `send_calls` using only `to`, `data`, and the converted `value`.
+2. For each transaction, get the hex value for `send_calls`:
+   - Use `value_hex` if present and non-null.
+   - If `value_hex` is null/missing: convert `value` from decimal to hex (see fallback methods below).
+   - If both are missing, null, or empty, use `"0x0"`.
+3. Map each transaction to `send_calls` using `to`, `data`, and the hex value.
 
-### Conversion methods
+### Fallback conversion methods
+
+Only needed if `value_hex` is null or missing:
 
 In shell: `printf "0x%x" 20000000000000000` outputs `0x470de4df820000`
 
 In JavaScript: `"0x" + BigInt("20000000000000000").toString(16)` outputs `"0x470de4df820000"`
 
 In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
-
-### Reference conversions
-
-| Decimal | Hex | ETH equivalent |
-|---------|-----|----------------|
-| `"0"` | `"0x0"` | 0 ETH |
-| `"1000000000000"` | `"0xe8d4a51000"` | 0.000001 ETH |
-| `"1000000000000000"` | `"0x38d7ea4c68000"` | 0.001 ETH |
-| `"4600000000000"` | `"0x42f055db000"` | 0.0000046 ETH |
-| `"10000000000000000"` | `"0x2386f26fc10000"` | 0.01 ETH |
-| `"20000000000000000"` | `"0x470de4df820000"` | 0.02 ETH |
-| `"100000000000000000"` | `"0x16345785d8a0000"` | 0.1 ETH |
-| `"1000000000000000000"` | `"0xde0b6b3a7640000"` | 1 ETH |
 
 ## Orchestration
 
@@ -339,9 +329,9 @@ In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
      --quantity <amount> --address <address>
    (or GET /api/v2/swap/quote?from_chain=...&quantity=<amount_in_wei>&...)
 4. Review quote with user: check price_impact, costs, total_price_usd
-5. Convert each transaction's `value` from decimal to hex (see Value Conversion)
+5. Use `value_hex` from each transaction (see Value Conversion)
 6. For each transaction:
-     send_calls(chain=<transaction.chain>, calls=[{to, value (hex), data}])
+     send_calls(chain=<transaction.chain>, calls=[{to, value: value_hex, data}])
 7. User approves → get_request_status(requestId)
 ```
 
@@ -375,9 +365,9 @@ In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
 6. POST /api/v2/listings/cross_chain_fulfillment_data with:
    listings=[{hash, chain, protocol_address}], fulfiller={address}, payment={chain, address}
    (works for same-chain and cross-chain)
-7. Convert each transaction's `value` from decimal to hex (see Value Conversion)
+7. Use `value_hex` from each transaction (see Value Conversion)
 8. For each transaction (in order):
-     send_calls(chain=<transaction.chain>, calls=[{to, value (hex), data}])
+     send_calls(chain=<transaction.chain>, calls=[{to, value: value_hex, data}])
 9. User approves → get_request_status(requestId)
 ```
 
@@ -397,16 +387,16 @@ In Python: `hex(20000000000000000)` outputs `"0x470de4df820000"`
 
 Target tool: **`send_calls`**
 
-All OpenSea write operations produce unsigned transaction data. Convert `value` from decimal to hex before passing to `send_calls` (see Value Conversion). Exception: mint returns `value` already as hex.
+All OpenSea write operations produce unsigned transaction data. Use `value_hex` from the API response when passing `value` to `send_calls` (see Value Conversion). Exception: mint returns `value` already as hex.
 
-**Swap** — convert `value` in each `response.transactions[]` entry to hex, then iterate:
+**Swap** — use `value_hex` from each `response.transactions[]` entry:
 
 ```json
 {
   "chain": "<transaction.chain>",
   "calls": [{
     "to": "<transaction.to>",
-    "value": "<transaction.value (converted to hex)>",
+    "value": "<transaction.value_hex>",
     "data": "<transaction.data>"
   }]
 }
@@ -414,14 +404,14 @@ All OpenSea write operations produce unsigned transaction data. Convert `value` 
 
 If multiple transactions, submit them in order (each may be on a different chain).
 
-**Buy (cross-chain fulfillment)** — convert `value` in each `response.transactions[]` entry to hex, then iterate in order:
+**Buy (cross-chain fulfillment)** — use `value_hex` from each `response.transactions[]` entry, iterate in order:
 
 ```json
 {
   "chain": "<transaction.chain>",
   "calls": [{
     "to": "<transaction.to>",
-    "value": "<transaction.value (converted to hex)>",
+    "value": "<transaction.value_hex>",
     "data": "<transaction.data>"
   }]
 }
@@ -453,7 +443,7 @@ Swap 0.02 ETH for USDC on Base
 2. Get wallet address via `get_wallets`.
 3. Run `opensea swaps quote --from-chain base --from-address 0x0000000000000000000000000000000000000000 --to-chain base --to-address 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --quantity 0.02 --address <address>` (or GET `/api/v2/swap/quote` with `quantity=20000000000000000`).
 4. Review quote with user (price impact, fees).
-5. Convert each transaction's `value` from decimal to hex (see Value Conversion); map each to `send_calls`.
+5. Use `value_hex` from each transaction as `value` in `send_calls`.
 
 ```
 Buy a Bored Ape on Ethereum
@@ -463,7 +453,7 @@ Buy a Bored Ape on Ethereum
 3. Run `opensea listings best boredapeyachtclub --limit 5` to show cheapest listings.
 4. User picks one; extract `order_hash`.
 5. POST to `/api/v2/listings/cross_chain_fulfillment_data` with listing hash, fulfiller, and payment (ETH on ethereum).
-6. Convert each transaction's `value` from decimal to hex (see Value Conversion); submit each via `send_calls` in order.
+6. Use `value_hex` from each transaction as `value`; submit each via `send_calls` in order.
 
 ```
 What drops are coming up on Base?
@@ -481,7 +471,7 @@ Buy an NFT on Ethereum using USDC from Base
 3. Find the listing: `opensea listings best-for-nft <slug> <token_id>`.
 4. Confirm price and payment token with user.
 5. POST to `/api/v2/listings/cross_chain_fulfillment_data` with payment `{chain: "base", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"}`.
-6. Convert each transaction's `value` from decimal to hex (see Value Conversion); submit each via `send_calls` in order (approval on Base → bridge → fulfill on Ethereum).
+6. Use `value_hex` from each transaction as `value`; submit each via `send_calls` in order (approval on Base → bridge → fulfill on Ethereum).
 
 ## Risks & Warnings
 


### PR DESCRIPTION
The OpenSea REST API now returns a value_hex field alongside the decimal value in swap and fulfillment transaction responses (os2-core PR #44861).

Updates the plugin to:
- Document value_hex in response shapes (swap quote, cross-chain fulfillment)
- Instruct agents to use value_hex directly when passing value to send_calls
- Demote manual conversion methods to fallback (only if value_hex is null)
- Update all orchestration flows, submission examples, and example prompts
- Bump version to 0.4.0

This eliminates the error-prone decimal-to-hex conversion that caused transaction reverts (InsufficientNativeTokensSupplied) on surfaces without code execution (Claude Desktop, ChatGPT).

## Description

<!-- What does this PR change and why? -->

## Type of change

- [ ] Base MCP plugin submission
- [x] Update to an existing skill/plugin
- [ ] New skill
- [ ] Documentation
- [ ] Other (please describe):

## Affected skill(s)

opensea

## Plugin checklist

- [ ] Plugin spec/manifest is accurate and tested
- [ ] (If Applicable) API endpoints and/or external MCP/CLI tested and functional
- [ ] Follows [Contribution Scope](../skills/base-mcp/references/plugin-spec.md#contribution-scope)

## Base MCP Plugin Submission Agreement (when applicable)

<!-- Required only if this PR submits a plugin to the Base MCP skill. -->

By checking the box below, I agree and represent on behalf of the protocol/entity it references that:

- I am authorized to submit this plugin on behalf of the protocol/entity it references;
- the plugin does not infringe or misappropriate any third party's rights;
- the plugin and the underlying protocol comply with all applicable laws, and my API enforces the same geofencing and eligibility restrictions as my own user-facing app;
- the plugin is in full compliance with our protocol's/entity's then-current terms and conditions, and if not, submission and use thereafter is considered a formal written exemption to such terms and conditions;
- the plugin accurately describes its behavior and contains no hidden, deceptive, or malicious instructions, and my API will not return malicious or unexpected calldata;
- the protocol/entity is solely responsible for the plugin and is submitting a plugin is subject to the [Base Account and Base App Terms of Service](https://wallet.coinbase.com/terms-of-service) as using a "Service"; and
- Base may modify, decline to list, or remove the plugin at any time, for any reason.

- [ ] I have read and agree to the Base MCP Plugin Submission Agreement above.

## Related issues

<!-- e.g. Closes #123 -->
