### PR TITLE
Add Perplexity to Base MCP quickstart install guide

### DIFF
--- a/skills/base-mcp/references/install.md
+++ b/skills/base-mcp/references/install.md
@@ -49,6 +49,25 @@ ChatGPT prompts for authorization the first time a wallet tool is called.
 
 ---
 
+## Perplexity
+
+**Step 1 — Add the MCP connector**
+
+1. Go to **[perplexity.ai/computer/connectors](https://www.perplexity.ai/computer/connectors)**
+2. Search for **Base** and select **Base by Coinbase**
+3. Click **Connect** and authorize with your Base Account
+
+**Step 2 — Add the skill**
+
+1. Download the Base MCP skill zip from **[github.com/base/skills](https://github.com/base/skills)**  
+   (Code → Download ZIP, or grab the latest release)
+2. Go to **[perplexity.ai/computer/skills](https://www.perplexity.ai/computer/skills)**
+3. Click **Create skill** and upload the zip file
+
+Perplexity prompts for authorization the first time a wallet tool is called.
+
+---
+
 ## Claude Code
 
 Add to the current project:


### PR DESCRIPTION
## Summary

- Adds a **Perplexity** section to `skills/base-mcp/references/install.md`, positioned after ChatGPT and Claude
- Documents the two-step setup: (1) adding the "Base by Coinbase" connector via `perplexity.ai/computer/connectors`, (2) uploading the skill zip via `perplexity.ai/computer/skills`

## Test plan

- [ ] Verify the Perplexity section renders correctly in the docs
- [ ] Confirm connector link (`perplexity.ai/computer/connectors`) resolves and "Base by Coinbase" is discoverable by searching "Base"
- [ ] Confirm skills link (`perplexity.ai/computer/skills`) resolves and "Create skill" flow accepts a zip upload