### PR TITLE
fix: add --broadcast to forge create examples and fix broken links

### DIFF
--- a/skills/build-on-base/references/agents/register.md
+++ b/skills/build-on-base/references/agents/register.md
@@ -20,7 +20,7 @@ Every agent needs a wallet to sign transactions. Ask the user before doing anyth
 
 1. **Ask: "Do you have a wallet? If yes, share your wallet address."**
 2. **If yes** — take the wallet address they provide and move to Phase 2.
-3. **If no** — direct them to the Base wallet setup guide: https://docs.base.org/ai-agents/guides/wallet-setup — do not proceed until they have a wallet and can provide their address.
+3. **If no** — direct them to create a Base Account at https://base.app — do not proceed until they have a wallet and can provide their address.
 
 ---
 

--- a/skills/build-on-base/references/deploy-contracts.md
+++ b/skills/build-on-base/references/deploy-contracts.md
@@ -82,7 +82,7 @@ A BaseScan API key is required for the `--verify` flag to auto-verify contracts 
 
 > **Agent behavior:** If you have browser access, navigate to the BaseScan site and create the key. Otherwise, ask the user to complete these steps and provide the API key.
 
-1. Go to [basescan.org/myapikey](https://basescan.org/apidashboard) (or [etherscan.io/myapikey](https://etherscan.io/apidashboard) — same account works)
+1. Go to [basescan.org/apidashboard](https://basescan.org/apidashboard) (or [etherscan.io/apidashboard](https://etherscan.io/apidashboard) — same account works)
 2. Sign in or create a free account
 3. Click **Add** to create a new API key
 4. Copy the key and set it in your environment:
@@ -113,6 +113,7 @@ base = { key = "${ETHERSCAN_API_KEY}", url = "https://api.basescan.org/api" }
 forge create src/MyContract.sol:MyContract \
   --rpc-url https://sepolia.base.org \
   --account <keystore-account> \
+  --broadcast \
   --verify \
   --etherscan-api-key $ETHERSCAN_API_KEY
 ```
@@ -123,6 +124,7 @@ forge create src/MyContract.sol:MyContract \
 forge create src/MyContract.sol:MyContract \
   --rpc-url https://mainnet.base.org \
   --account <keystore-account> \
+  --broadcast \
   --verify \
   --etherscan-api-key $ETHERSCAN_API_KEY
 ```

--- a/skills/build-on-base/references/migrations/minikit-to-farcaster/mapping.md
+++ b/skills/build-on-base/references/migrations/minikit-to-farcaster/mapping.md
@@ -409,7 +409,7 @@ function AuthButton() {
 
 ## useNotification
 
-Notifications require server-side implementation. See [NOTIFICATIONS.md](NOTIFICATIONS.md) for details.
+Notifications require server-side implementation. See the [Farcaster Mini App notifications guide](https://miniapps.farcaster.xyz/docs/guides/notifications) for details.
 
 ### Before (MiniKit)
 ```typescript
@@ -449,4 +449,4 @@ function NotifyButton() {
 }
 ```
 
-See [NOTIFICATIONS.md](NOTIFICATIONS.md) for server-side implementation.
+See the [Farcaster Mini App notifications guide](https://miniapps.farcaster.xyz/docs/guides/notifications) for server-side implementation.


### PR DESCRIPTION
## What

Four small, verified doc fixes in `build-on-base`:

1. **`forge create` won't deploy without `--broadcast`** — `references/deploy-contracts.md`
   Since Foundry v1.0, `forge create` only *simulates* unless `--broadcast` is passed. The testnet and mainnet examples were missing it, so following them verbatim on a current Foundry prints a successful-looking result but never sends the deploy transaction. Added `--broadcast` to both commands.

2. **Broken `NOTIFICATIONS.md` links** — `references/migrations/minikit-to-farcaster/mapping.md`
   The `useNotification` section linked to `NOTIFICATIONS.md` twice, but no such file exists anywhere in the repo. Replaced both with the Farcaster Mini App notifications guide (`https://miniapps.farcaster.xyz/docs/guides/notifications`).

3. **Link text / URL mismatch** — `references/deploy-contracts.md`
   The API key step's link text said `basescan.org/myapikey` / `etherscan.io/myapikey` while the URLs pointed to `/apidashboard`. Updated the text to match the (current) URLs.

4. **Broken wallet-setup link** — `references/agents/register.md`
   `https://docs.base.org/ai-agents/guides/wallet-setup` does not exist as a wallet guide — it resolves to the Base MCP quickstart page, and no wallet-setup page is listed in `docs.base.org/llms.txt`. Since the step is for a user who has *no wallet*, pointed them to the Base App (`https://base.app`) where they can create a Base Account and obtain an address.

## Why

Each is an objectively verifiable error a reader would hit directly — a deploy command that silently no-ops, dead links, and a link whose destination doesn't match its promised content. Docs-only, no behavioral/spec changes.

## Testing

- Confirmed `NOTIFICATIONS.md` does not exist in the repo.
- Confirmed no other `--broadcast` reference existed in the skill.
- Verified via fetch that `docs.base.org/ai-agents/guides/wallet-setup` serves MCP-connection content (not wallet setup) and that no wallet-setup page is listed in `llms.txt`; confirmed `https://base.app` is the live Base Account entry point.