### PR TITLE
docs: fix broken links in minikit-to-farcaster migration guide

### DIFF
--- a/skills/build-on-base/references/migrations/minikit-to-farcaster/dependencies.md
+++ b/skills/build-on-base/references/migrations/minikit-to-farcaster/dependencies.md
@@ -51,4 +51,4 @@ nvm install 22 && nvm use 22
 npm install @farcaster/quick-auth
 ```
 
-See [AUTH.md](AUTH.md) for server-side token verification.
+See [auth.md](auth.md) for server-side token verification.

--- a/skills/build-on-base/references/migrations/minikit-to-farcaster/examples.md
+++ b/skills/build-on-base/references/migrations/minikit-to-farcaster/examples.md
@@ -67,7 +67,7 @@ useEffect(() => {
 const { fid, username } = user ?? {};
 ```
 
-Or use FrameProvider (see [PROVIDER.md](PROVIDER.md)):
+Or use FrameProvider (see [provider.md](provider.md)):
 ```typescript
 import { useFrameContext } from '@/components/providers/FrameProvider';
 

--- a/skills/build-on-base/references/migrations/minikit-to-farcaster/mapping.md
+++ b/skills/build-on-base/references/migrations/minikit-to-farcaster/mapping.md
@@ -409,7 +409,7 @@ function AuthButton() {
 
 ## useNotification
 
-Notifications require server-side implementation. See [NOTIFICATIONS.md](NOTIFICATIONS.md) for details.
+Notifications require server-side implementation. See the [Farcaster notifications guide](https://miniapps.farcaster.xyz/docs/guides/notifications) for details.
 
 ### Before (MiniKit)
 ```typescript
@@ -449,4 +449,4 @@ function NotifyButton() {
 }
 ```
 
-See [NOTIFICATIONS.md](NOTIFICATIONS.md) for server-side implementation.
+See the [Farcaster notifications guide](https://miniapps.farcaster.xyz/docs/guides/notifications) for server-side implementation.


### PR DESCRIPTION
Fixes three broken markdown links in the minikit-to-farcaster migration references. All target files verified on disk (case-sensitive) and the external URL fetched live.

- **dependencies.md**: `AUTH.md` to `auth.md` (actual file is lowercase; 404 on GitHub / case-sensitive filesystems)
- **examples.md**: `PROVIDER.md` to `provider.md` (same case-sensitivity issue)
- **mapping.md** (x2): `NOTIFICATIONS.md` does not exist anywhere in the repo; repointed to the official Farcaster notifications guide (verified live), consistent with the existing miniapps.farcaster.xyz link in dependencies.md

Docs-only, no code changes.