### PR TITLE
docs: add --broadcast to forge create deploy commands

### DIFF
--- a/skills/build-on-base/references/deploy-contracts.md
+++ b/skills/build-on-base/references/deploy-contracts.md
@@ -113,6 +113,7 @@ base = { key = "${ETHERSCAN_API_KEY}", url = "https://api.basescan.org/api" }
 forge create src/MyContract.sol:MyContract \
   --rpc-url https://sepolia.base.org \
   --account <keystore-account> \
+  --broadcast \
   --verify \
   --etherscan-api-key $ETHERSCAN_API_KEY
 ```
@@ -123,6 +124,7 @@ forge create src/MyContract.sol:MyContract \
 forge create src/MyContract.sol:MyContract \
   --rpc-url https://mainnet.base.org \
   --account <keystore-account> \
+  --broadcast \
   --verify \
   --etherscan-api-key $ETHERSCAN_API_KEY
 ```


### PR DESCRIPTION
The testnet and mainnet forge create commands in deploy-contracts.md are missing --broadcast. In Foundry 1.0+, forge create without --broadcast only dry-runs (prints: 'To broadcast this transaction, add --broadcast to the previous command'), so the contract never deploys and --verify never runs.

Verified empirically with forge 1.7.1 + anvil. Added --broadcast to both real deploy commands; left the partial --etherscan-api-key example (not a full deploy command) untouched.

Docs-only.