### PR TITLE
feat: add vibenet skill for EIP-8130 devnet, verified against live behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ vite.config.ts.timestamp-*
 
 .DS_Store
 .DS_Store
+# Skill eval workspaces (local scratch, not shipped)
+skills/*-workspace/

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@
 
 ## Recommended Skills
 
-Two consolidated skills that cover the most common use cases. Each uses progressive reference loading — the skill loads a single entry point and pulls in detailed references only when needed.
+Consolidated skills that cover the most common use cases. Each uses progressive reference loading — the skill loads a single entry point and pulls in detailed references only when needed.
 
 | Skill | Install | Description |
 | ----- | ------- | ----------- |
 | [build-on-base](./skills/build-on-base/SKILL.md) | `npx skills add base/skills --skill build-on-base` | Complete Base development playbook: network, contracts, wallet auth, payments, attribution, and migrations. Consolidates all individual skills into one. |
 | [base-mcp](./skills/base-mcp/SKILL.md) | `npx skills add base/skills --skill base-mcp` | Base MCP server — gives your AI assistant a wallet via mcp.base.org. Sending, swapping, signing, batched calls, balances, and partner plugins for lending, swaps, and more. |
+| [vibenet](./skills/vibenet/SKILL.md) | `npx skills add base/skills --skill vibenet` | Build on vibenet, Base's devnet for native account abstraction (EIP-8130) with viem: smart accounts, batched calls, session keys and policies, and ERC-8168 payer gas sponsorship. |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -75,60 +75,6 @@ Create an EIP-8130 smart account on vibenet and fund it from the faucet
 Deploy a smart account on vibenet with sponsored gas, so the user needs no ETH
 ```
 
-```text
-Authorize a session key on my 8130 account with a weekly USDC spend limit
-```
-
-### Example: gasless onboarding on vibenet
-
-A worked example of what the `vibenet` skill produces — creating an EIP-8130
-smart account and deploying it with zero user funds, via an ERC-8168 payer:
-
-```ts
-import type { Hex } from "viem";
-import { createPublicClient, http } from "viem";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-import {
-  allPhasesSucceeded,
-  newSmartAccount8130,
-  waitForTransactionReceipt8130,
-} from "viem/experimental/eip8130";
-import { createPayerClient, sendSponsoredCalls } from "viem/experimental/eip8168";
-
-const chain = {
-  id: 84538453,
-  name: "vibenet",
-  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-  rpcUrls: { default: { http: ["https://rpc.vibes.base.org"] } },
-};
-const client = createPublicClient({ chain, transport: http() });
-
-// The address is derived locally — synchronous, no RPC, nothing on-chain yet.
-// (The fork types `signer` for P-256 keys, so a K1 account needs a cast.)
-const signer = privateKeyToAccount(generatePrivateKey());
-const account = newSmartAccount8130({ signer: signer as never });
-
-// There is no deploy step: the account is created by its first transaction.
-// The payer covers gas, so this works at a zero balance — no faucet needed.
-const payerClient = createPayerClient({
-  url: "https://api.vibes.base.org/api/vibenet/account/payer",
-});
-const { transactionHash: hash } = (await sendSponsoredCalls(client, {
-  account,
-  payerClient,
-  accountChanges: [account.createChange], // only on the first tx
-  calls: [{ to: account.address, value: 0n, data: "0x" }],
-  context: { flow: "onboarding" },
-})) as unknown as { transactionHash: Hex };
-
-const receipt = await waitForTransactionReceipt8130(client, { hash });
-if (!allPhasesSucceeded(receipt)) throw new Error("a phase reverted");
-```
-
-See the [vibenet skill](./skills/vibenet/SKILL.md) for the install steps (the
-8130 tooling ships on a viem fork branch), the account lifecycle, session keys,
-and the devnet's sharper edges.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Consolidated skills that cover the most common use cases. Each uses progressive 
 | ----- | ------- | ----------- |
 | [build-on-base](./skills/build-on-base/SKILL.md) | `npx skills add base/skills --skill build-on-base` | Complete Base development playbook: network, contracts, wallet auth, payments, attribution, and migrations. Consolidates all individual skills into one. |
 | [base-mcp](./skills/base-mcp/SKILL.md) | `npx skills add base/skills --skill base-mcp` | Base MCP server — gives your AI assistant a wallet via mcp.base.org. Sending, swapping, signing, batched calls, balances, and partner plugins for lending, swaps, and more. |
-| [vibenet](./skills/vibenet/SKILL.md) | `npx skills add base/skills --skill vibenet` | Build on vibenet, Base's devnet for native account abstraction (EIP-8130) with viem: smart accounts, batched calls, session keys and policies, and ERC-8168 payer gas sponsorship. |
+| [vibenet](./skills/vibenet/SKILL.md) | `npx skills add base/skills --skill vibenet` | Build on [vibenet](https://chain.base.org/vibenet), the Base Vibes devnet for native account abstraction (EIP-8130) with viem: smart accounts, batched calls, session keys and policies, and ERC-8168 payer gas sponsorship. |
 
 ## Installation
 
@@ -66,6 +66,68 @@ Convert my existing Farcaster miniapp to a standard app on Base
 ```text
 Register my trading bot and add builder code attribution to its transactions
 ```
+
+```text
+Create an EIP-8130 smart account on vibenet and fund it from the faucet
+```
+
+```text
+Deploy a smart account on vibenet with sponsored gas, so the user needs no ETH
+```
+
+```text
+Authorize a session key on my 8130 account with a weekly USDC spend limit
+```
+
+### Example: gasless onboarding on vibenet
+
+A worked example of what the `vibenet` skill produces — creating an EIP-8130
+smart account and deploying it with zero user funds, via an ERC-8168 payer:
+
+```ts
+import type { Hex } from "viem";
+import { createPublicClient, http } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import {
+  allPhasesSucceeded,
+  newSmartAccount8130,
+  waitForTransactionReceipt8130,
+} from "viem/experimental/eip8130";
+import { createPayerClient, sendSponsoredCalls } from "viem/experimental/eip8168";
+
+const chain = {
+  id: 84538453,
+  name: "vibenet",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.vibes.base.org"] } },
+};
+const client = createPublicClient({ chain, transport: http() });
+
+// The address is derived locally — synchronous, no RPC, nothing on-chain yet.
+// (The fork types `signer` for P-256 keys, so a K1 account needs a cast.)
+const signer = privateKeyToAccount(generatePrivateKey());
+const account = newSmartAccount8130({ signer: signer as never });
+
+// There is no deploy step: the account is created by its first transaction.
+// The payer covers gas, so this works at a zero balance — no faucet needed.
+const payerClient = createPayerClient({
+  url: "https://api.vibes.base.org/api/vibenet/account/payer",
+});
+const { transactionHash: hash } = (await sendSponsoredCalls(client, {
+  account,
+  payerClient,
+  accountChanges: [account.createChange], // only on the first tx
+  calls: [{ to: account.address, value: 0n, data: "0x" }],
+  context: { flow: "onboarding" },
+})) as unknown as { transactionHash: Hex };
+
+const receipt = await waitForTransactionReceipt8130(client, { hash });
+if (!allPhasesSucceeded(receipt)) throw new Error("a phase reverted");
+```
+
+See the [vibenet skill](./skills/vibenet/SKILL.md) for the install steps (the
+8130 tooling ships on a viem fork branch), the account lifecycle, session keys,
+and the devnet's sharper edges.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "skills",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "skills"
+    }
+  }
+}

--- a/skills/vibenet/SKILL.md
+++ b/skills/vibenet/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: vibenet
+description: >-
+  Build on vibenet — Base's devnet for native account abstraction (EIP-8130)
+  and payer gas sponsorship (ERC-8168) using the viem experimental module. Use
+  whenever the user mentions vibenet, EIP-8130, ERC-8168, 8130 accounts, native
+  account abstraction, session keys, actors, policies, payers, or gas
+  sponsorship on Base — or is writing code that creates or operates 8130 smart
+  accounts, authorizes session-key actors, sends batched calls, sponsors gas
+  with a payer, or wires a frontend/script against the vibenet devnet or Base
+  Sepolia.
+---
+
+# Vibenet
+
+Vibenet is Base's devnet for **EIP-8130 native account abstraction**: account
+abstraction in the protocol itself. Accounts are portable across EVM chains,
+support multiple signer types (secp256k1, P-256, WebAuthn), key rotation
+without changing address, scoped session-key actors, on-chain policies, and
+native **ERC-8168** gas sponsorship. The tooling lives in viem's
+`experimental/eip8130` module (fork branch — not yet in npm `viem`).
+
+## Network
+
+| Endpoint | Value |
+|----------|-------|
+| Chain ID | `84538453` |
+| Public execution RPC (Node/scripts) | `https://rpc.vibes.base.org` — 8130-capable (`AA_TX_TYPE` / `0x79`) |
+| Browser RPC proxy (CORS-safe) | `https://vibes.base.org/api/vibenet/account/rpc` — passes through all `eth_*`, including `0x79` broadcasts and receipt polling |
+| Hosted payer (ERC-8168) | `https://vibes.base.org/api/vibenet/account/payer` |
+| Faucet | `POST https://vibes.base.org/api/vibenet/faucet/drip` with `{ "address": "0x…" }` |
+| Base Sepolia (also 8130-enabled) | `https://sepolia.base.org`, chain id `84532` |
+
+Install viem from the fork branch, then import from
+`viem/experimental/eip8130` (and `viem/experimental/eip8168` for payers):
+
+```bash
+bun add "viem@github:chunter-cb/viem#feat/eip-8130"
+```
+
+**npm cannot install this branch directly from git** — the fork's workspace
+uses pnpm's `catalog:` protocol, so `npm install "viem@github:…"` fails, and
+even the bun git install yields an unbuilt monorepo. The reliable path for
+npm projects is clone → build → depend on the built package (which lives in
+the fork's `src/` directory):
+
+```bash
+git clone -b feat/eip-8130 https://github.com/chunter-cb/viem viem-fork
+cd viem-fork && npx pnpm install --ignore-scripts && npx pnpm run build
+# then in your app: npm install "viem@file:../viem-fork/src"
+```
+
+In TypeScript projects, set `"target": "ES2020"` (or later) in
+`tsconfig.json` — the 8130 module uses BigInt literals, which the common
+ES2017 default rejects at build time.
+
+## Safety Guardrails
+
+- **Never commit private keys** — generate throwaway keys for devnet scripts,
+  read real ones from env vars.
+- **`key.k1(...)` builds an actor identity, not a signer** — passing it (or a
+  raw private-key hex) as `signer` fails with an opaque `pad()` TypeError. Use
+  `privateKeyToAccount(pk)`.
+- **Verify config changes by on-chain read-back** (`isActor8130` /
+  `getConfigSequence8130`), never by receipt logs or `status: success` — a
+  skipped authorize is silent.
+- **Read the live config sequence right before signing** — a hardcoded
+  sequence causes silent no-ops.
+
+## Task Routing
+
+Read the reference for your task:
+
+| Task | When to Use | Reference |
+|------|-------------|-----------|
+| **Accounts & transactions** | Create an 8130 smart account, send batched calls, attribution metadata, gas estimation, reading account state, locking, gotchas | [references/eip8130-accounts.md](references/eip8130-accounts.md) |
+| **Session keys & policies** | Authorize/revoke actors, scopes, SessionPolicy spend limits, config sequences, verifying "silent" changes | [references/session-keys-and-policies.md](references/session-keys-and-policies.md) |
+| **Gas sponsorship** | Sponsor gas with a payer (ERC-8168), gasless onboarding, `send` vs `sign` modes | [references/payer-sponsorship.md](references/payer-sponsorship.md) |
+
+## Operating Procedure
+
+1. **Classify the task** using the table above and read the relevant reference
+   before implementing.
+2. **Pick the right RPC**: `rpc.vibes.base.org` from Node/scripts; the
+   `account/rpc` browser proxy from web UIs (same chain, CORS-safe).
+3. **Implement** with explicit chain id, the fork-branch install, and read-back
+   verification for any account-config change.
+4. **Deliver** runnable code, install commands, and any manual steps (env
+   vars, faucet funding).
+
+## For Edge Cases and Latest API Changes
+
+- **EIP-8130 spec**: [eip.tools/eip/8130](https://eip.tools/eip/8130)
+  (payer standard: [eip.tools/eip/8168](https://eip.tools/eip/8168))
+- **viem fork**: `github.com/chunter-cb/viem`, branch `feat/eip-8130`
+  (API surface: `src/experimental/eip8130/index.ts`; docs:
+  `site/pages/experimental/eip8130`)
+- **Deep guide (chaptered)**: `github.com/chunter-cb/eip-8130-web` (`/guide/*`)
+- **Session-key walkthrough**:
+  [gist.github.com/chunter-cb/bf70c53a5ab6d8361ce7f4215b776114](https://gist.github.com/chunter-cb/bf70c53a5ab6d8361ce7f4215b776114)
+
+## Installation
+
+```bash
+npx skills add base/skills --skill vibenet
+```

--- a/skills/vibenet/SKILL.md
+++ b/skills/vibenet/SKILL.md
@@ -25,34 +25,63 @@ native **ERC-8168** gas sponsorship. The tooling lives in viem's
 | Endpoint | Value |
 |----------|-------|
 | Chain ID | `84538453` |
-| Public execution RPC (Node/scripts) | `https://rpc.vibes.base.org` — 8130-capable (`AA_TX_TYPE` / `0x79`) |
-| Browser RPC proxy (CORS-safe) | `https://vibes.base.org/api/vibenet/account/rpc` — passes through all `eth_*`, including `0x79` broadcasts and receipt polling |
-| Hosted payer (ERC-8168) | `https://vibes.base.org/api/vibenet/account/payer` |
-| Faucet | `POST https://vibes.base.org/api/vibenet/faucet/drip` with `{ "address": "0x…" }` |
+| Public execution RPC | `https://rpc.vibes.base.org` — 8130-capable (`AA_TX_TYPE` / `0x79`), serves `access-control-allow-origin: *` |
+| Browser RPC proxy | `https://api.vibes.base.org/api/vibenet/account/rpc` — passes through all `eth_*`, including `0x79` broadcasts and receipt polling |
+| Hosted payer (ERC-8168) | `https://api.vibes.base.org/api/vibenet/account/payer` |
+| Faucet | `POST https://api.vibes.base.org/api/vibenet/faucet/drip` with `{ "address": "0x…" }` |
+| Faucet status | `GET https://api.vibes.base.org/api/vibenet/faucet/status` — drip size, cooldowns, USDV/NFV token addresses |
+| Chain health | `GET https://api.vibes.base.org/api/vibenet/chain-health` — `{ healthy, head, headAgeSecs, … }` |
+| Landing page / explorer | `https://chain.base.org/vibenet`, `https://chain.base.org/vibenet/explorer` |
 | Base Sepolia (also 8130-enabled) | `https://sepolia.base.org`, chain id `84532` |
 
-Install viem from the fork branch, then import from
-`viem/experimental/eip8130` (and `viem/experimental/eip8168` for payers):
+**The API host is `api.vibes.base.org`, not `vibes.base.org`.** The bare host
+302-redirects to the `chain.base.org/vibenet` HTML page; viem's HTTP transport
+then tries to parse that as JSON and throws `Unrecognized token '<'`, which
+reads like a code bug rather than a wrong URL.
 
-```bash
-bun add "viem@github:chunter-cb/viem#feat/eip-8130"
-```
+All `api.vibes.base.org` endpoints (RPC proxy, payer, faucet) send permissive
+CORS headers, and so does `rpc.vibes.base.org` — so browser apps can talk to
+either. Prefer `rpc.vibes.base.org` for execution and reserve the `account/rpc`
+proxy for when you specifically want the hosted path.
 
-**npm cannot install this branch directly from git** — the fork's workspace
-uses pnpm's `catalog:` protocol, so `npm install "viem@github:…"` fails, and
-even the bun git install yields an unbuilt monorepo. The reliable path for
-npm projects is clone → build → depend on the built package (which lives in
-the fork's `src/` directory):
+The tooling is **not published to npm** and cannot be installed from git
+directly: the fork's workspace uses pnpm's `catalog:` protocol, so
+`npm install "viem@github:…"` fails outright, and `bun add "viem@github:…"`
+"succeeds" but leaves you an unbuilt monorepo with no `exports` field. Clone,
+build, then depend on the built package (which lives in the fork's `src/`):
 
 ```bash
 git clone -b feat/eip-8130 https://github.com/chunter-cb/viem viem-fork
 cd viem-fork && npx pnpm install --ignore-scripts && npx pnpm run build
-# then in your app: npm install "viem@file:../viem-fork/src"
+
+# then in your app — --install-links is required:
+npm install --install-links "viem@file:../viem-fork/src"
 ```
 
-In TypeScript projects, set `"target": "ES2020"` (or later) in
-`tsconfig.json` — the 8130 module uses BigInt literals, which the common
-ES2017 default rejects at build time.
+Then import from `viem/experimental/eip8130` (and `viem/experimental/eip8168`
+for payers). Core helpers like `createPublicClient` / `parseEther` come from
+plain `viem` — the 8130 module does not re-export them.
+
+**Use `--install-links`.** Without it npm symlinks `node_modules/viem` to a path
+outside the project root, and Turbopack/Next.js then fails with
+`Module not found: Can't resolve 'viem'` for a package that is plainly there
+(`tsc` resolves it fine, which makes it look like a bundler bug).
+
+If your TypeScript build rejects the module's BigInt literals, set
+`"target": "ES2020"` or later in `tsconfig.json`. Next.js 16's generated config
+already works as-is, since its `lib` includes `esnext`.
+
+## Accounts Have No Deploy Step
+
+Creating an account derives a CREATE2 address locally — synchronous, zero RPC,
+`eth_getCode` still `0x`. It becomes real as a **side effect of its first
+transaction**, which carries `account.createChange` alongside your actual calls.
+There is nothing else to call. The shortest path from nothing to a deployed
+account is a *sponsored* first tx (no faucet, no funding); the self-paid route
+needs the address funded first. Read deployment state from `eth_getCode`, never
+from optimistic local state — it decides whether the next tx carries
+`createChange`. Full lifecycle:
+[references/eip8130-accounts.md](references/eip8130-accounts.md).
 
 ## Safety Guardrails
 
@@ -73,7 +102,7 @@ Read the reference for your task:
 
 | Task | When to Use | Reference |
 |------|-------------|-----------|
-| **Accounts & transactions** | Create an 8130 smart account, send batched calls, attribution metadata, gas estimation, reading account state, locking, gotchas | [references/eip8130-accounts.md](references/eip8130-accounts.md) |
+| **Accounts & transactions** | Create an 8130 smart account, the counterfactual→deployed lifecycle, send batched calls, attribution metadata, gas estimation, reading account state, locking, gotchas | [references/eip8130-accounts.md](references/eip8130-accounts.md) |
 | **Session keys & policies** | Authorize/revoke actors, scopes, SessionPolicy spend limits, config sequences, verifying "silent" changes | [references/session-keys-and-policies.md](references/session-keys-and-policies.md) |
 | **Gas sponsorship** | Sponsor gas with a payer (ERC-8168), gasless onboarding, `send` vs `sign` modes | [references/payer-sponsorship.md](references/payer-sponsorship.md) |
 
@@ -81,8 +110,9 @@ Read the reference for your task:
 
 1. **Classify the task** using the table above and read the relevant reference
    before implementing.
-2. **Pick the right RPC**: `rpc.vibes.base.org` from Node/scripts; the
-   `account/rpc` browser proxy from web UIs (same chain, CORS-safe).
+2. **Pick the right RPC**: `rpc.vibes.base.org` works from both Node and the
+   browser; `api.vibes.base.org/api/vibenet/account/rpc` is the hosted proxy to
+   the same chain. Never `vibes.base.org` — that host is not an API.
 3. **Implement** with explicit chain id, the fork-branch install, and read-back
    verification for any account-config change.
 4. **Deliver** runnable code, install commands, and any manual steps (env

--- a/skills/vibenet/SKILL.md
+++ b/skills/vibenet/SKILL.md
@@ -2,7 +2,7 @@
 name: vibenet
 description: >-
   Build on vibenet — Base's devnet for native account abstraction (EIP-8130)
-  and payer gas sponsorship (ERC-8168) using the viem experimental module. Use
+  and payer gas sponsorship (ERC-8168) using viem's eip8130 module. Use
   whenever the user mentions vibenet, EIP-8130, ERC-8168, 8130 accounts, native
   account abstraction, session keys, actors, policies, payers, or gas
   sponsorship on Base — or is writing code that creates or operates 8130 smart
@@ -17,8 +17,8 @@ Vibenet is Base's devnet for **EIP-8130 native account abstraction**: account
 abstraction in the protocol itself. Accounts are portable across EVM chains,
 support multiple signer types (secp256k1, P-256, WebAuthn), key rotation
 without changing address, scoped session-key actors, on-chain policies, and
-native **ERC-8168** gas sponsorship. The tooling lives in viem's
-`experimental/eip8130` module (fork branch — not yet in npm `viem`).
+native **ERC-8168** gas sponsorship. The tooling lives in viem's `eip8130`
+module (fork branch — not yet in npm `viem`).
 
 ## Network
 
@@ -44,23 +44,27 @@ CORS headers, and so does `rpc.vibes.base.org` — so browser apps can talk to
 either. Prefer `rpc.vibes.base.org` for execution and reserve the `account/rpc`
 proxy for when you specifically want the hosted path.
 
-The tooling is **not published to npm** and cannot be installed from git
-directly: the fork's workspace uses pnpm's `catalog:` protocol, so
-`npm install "viem@github:…"` fails outright, and `bun add "viem@github:…"`
-"succeeds" but leaves you an unbuilt monorepo with no `exports` field. Clone,
-build, then depend on the built package (which lives in the fork's `src/`):
+The 8130 modules are additive to viem itself, proposed upstream in
+[wevm/viem#5004](https://github.com/wevm/viem/pull/5004) (still an open draft —
+not yet released to npm). Until it ships, build from the fork branch the PR is
+opened from: `chunter-cb/viem` `feat/eip-8130-production`. It is **not
+installable from git directly**: viem's workspace uses pnpm's `catalog:`
+protocol, so `npm install "viem@github:…"` fails outright, and
+`bun add "viem@github:…"` "succeeds" but leaves you an unbuilt monorepo with no
+`exports` field. Clone, build, then depend on the built package (which lives in
+viem's `src/`):
 
 ```bash
-git clone -b feat/eip-8130 https://github.com/chunter-cb/viem viem-fork
+git clone -b feat/eip-8130-production https://github.com/chunter-cb/viem viem-fork
 cd viem-fork && npx pnpm install --ignore-scripts && npx pnpm run build
 
 # then in your app — --install-links is required:
 npm install --install-links "viem@file:../viem-fork/src"
 ```
 
-Then import from `viem/experimental/eip8130` (and `viem/experimental/eip8168`
-for payers). Core helpers like `createPublicClient` / `parseEther` come from
-plain `viem` — the 8130 module does not re-export them.
+Then import from `viem/eip8130` (and `viem/eip8168` for payers). Core helpers
+like `createPublicClient` / `parseEther` come from plain `viem` — the 8130
+module does not re-export them.
 
 **Use `--install-links`.** Without it npm symlinks `node_modules/viem` to a path
 outside the project root, and Turbopack/Next.js then fails with
@@ -90,8 +94,8 @@ from optimistic local state — it decides whether the next tx carries
 - **`key.k1(...)` builds an actor identity, not a signer** — passing it (or a
   raw private-key hex) as `signer` fails with an opaque `pad()` TypeError. Use
   `privateKeyToAccount(pk)`.
-- **Verify config changes by on-chain read-back** (`isActor8130` /
-  `getConfigSequence8130`), never by receipt logs or `status: success` — a
+- **Verify config changes by on-chain read-back** (`isActor` /
+  `getConfigSequence`), never by receipt logs or `status: success` — a
   skipped authorize is silent.
 - **Read the live config sequence right before signing** — a hardcoded
   sequence causes silent no-ops.
@@ -122,9 +126,9 @@ Read the reference for your task:
 
 - **EIP-8130 spec**: [eip.tools/eip/8130](https://eip.tools/eip/8130)
   (payer standard: [eip.tools/eip/8168](https://eip.tools/eip/8168))
-- **viem fork**: `github.com/chunter-cb/viem`, branch `feat/eip-8130`
-  (API surface: `src/experimental/eip8130/index.ts`; docs:
-  `site/pages/experimental/eip8130`)
+- **viem fork**: [`chunter-cb/viem` `feat/eip-8130-production`](https://github.com/chunter-cb/viem/tree/feat/eip-8130-production)
+  (upstream PR: [wevm/viem#5004](https://github.com/wevm/viem/pull/5004); API
+  surface: `src/eip8130/index.ts`; docs: `site/pages/eip8130`)
 - **Deep guide (chaptered)**: `github.com/chunter-cb/eip-8130-web` (`/guide/*`)
 - **Session-key walkthrough**:
   [gist.github.com/chunter-cb/bf70c53a5ab6d8361ce7f4215b776114](https://gist.github.com/chunter-cb/bf70c53a5ab6d8361ce7f4215b776114)

--- a/skills/vibenet/SKILL.md
+++ b/skills/vibenet/SKILL.md
@@ -46,13 +46,27 @@ proxy for when you specifically want the hosted path.
 
 The 8130 modules are additive to viem itself, proposed upstream in
 [wevm/viem#5004](https://github.com/wevm/viem/pull/5004) (still an open draft —
-not yet released to npm). Until it ships, build from the fork branch the PR is
-opened from: `chunter-cb/viem` `feat/eip-8130-production`. It is **not
-installable from git directly**: viem's workspace uses pnpm's `catalog:`
-protocol, so `npm install "viem@github:…"` fails outright, and
+not yet released to npm). Until it ships, they have to be built from the fork
+branch the PR is opened from: `chunter-cb/viem` `feat/eip-8130-production`.
+
+**Use the bundled installer** — it does the whole clone→build→link dance, which
+is error-prone by hand:
+
+```bash
+scripts/setup-viem-8130.sh [APP_DIR]   # defaults to the current directory
+```
+
+When PR #5004 merges and a viem release ships the modules, this collapses to
+`npm install viem@latest` — the imports (`viem/eip8130`, `viem/eip8168`) and
+APIs are unchanged, so no code moves.
+
+<details><summary>What the script does, and why each step is needed</summary>
+
+The tooling is **not installable from git directly**: viem's workspace uses
+pnpm's `catalog:` protocol, so `npm install "viem@github:…"` fails outright, and
 `bun add "viem@github:…"` "succeeds" but leaves you an unbuilt monorepo with no
-`exports` field. Clone, build, then depend on the built package (which lives in
-viem's `src/`):
+`exports` field. So you clone, build, then depend on the built package (which
+lives in viem's `src/`):
 
 ```bash
 git clone -b feat/eip-8130-production https://github.com/chunter-cb/viem viem-fork
@@ -62,14 +76,15 @@ cd viem-fork && npx pnpm install --ignore-scripts && npx pnpm run build
 npm install --install-links "viem@file:../viem-fork/src"
 ```
 
+**`--install-links` is required.** Without it npm symlinks `node_modules/viem`
+to a path outside the project root, and Turbopack/Next.js then fails with
+`Module not found: Can't resolve 'viem'` for a package that is plainly there
+(`tsc` resolves it fine, which makes it look like a bundler bug).
+</details>
+
 Then import from `viem/eip8130` (and `viem/eip8168` for payers). Core helpers
 like `createPublicClient` / `parseEther` come from plain `viem` — the 8130
 module does not re-export them.
-
-**Use `--install-links`.** Without it npm symlinks `node_modules/viem` to a path
-outside the project root, and Turbopack/Next.js then fails with
-`Module not found: Can't resolve 'viem'` for a package that is plainly there
-(`tsc` resolves it fine, which makes it look like a bundler bug).
 
 If your TypeScript build rejects the module's BigInt literals, set
 `"target": "ES2020"` or later in `tsconfig.json`. Next.js 16's generated config
@@ -117,8 +132,8 @@ Read the reference for your task:
 2. **Pick the right RPC**: `rpc.vibes.base.org` works from both Node and the
    browser; `api.vibes.base.org/api/vibenet/account/rpc` is the hosted proxy to
    the same chain. Never `vibes.base.org` — that host is not an API.
-3. **Implement** with explicit chain id, the fork-branch install, and read-back
-   verification for any account-config change.
+3. **Implement** with explicit chain id, the `scripts/setup-viem-8130.sh`
+   install, and read-back verification for any account-config change.
 4. **Deliver** runnable code, install commands, and any manual steps (env
    vars, faucet funding).
 

--- a/skills/vibenet/references/eip8130-accounts.md
+++ b/skills/vibenet/references/eip8130-accounts.md
@@ -1,15 +1,15 @@
 # EIP-8130 accounts and transactions (viem)
 
 Creating 8130 smart accounts and sending batched calls on vibenet / Base
-Sepolia with viem's `experimental/eip8130` module. For network endpoints and
-install, see the [skill root](../SKILL.md).
+Sepolia with viem's `eip8130` module. For network endpoints and install, see
+the [skill root](../SKILL.md).
 
 ## Core concepts
 
 - **Account** — a viem-style account object with `.address` (deterministic,
   CREATE2-derived), `.create()` / `.createChange` (first-tx deploy change), and
-  `signTransaction`. Create via `newSmartAccount8130` / `to8130Account` /
-  `toEoa8130Account`. Creating one puts it in a *counterfactual* state — see
+  `signTransaction`. Create via `newSmartAccount` / `toAccount` /
+  `toEoaAccount`. Creating one puts it in a *counterfactual* state — see
   [Account lifecycle](#account-lifecycle-there-is-no-deploy-step).
 - **Signer** — a signing object that can produce `sender_auth`. For K1, use
   `privateKeyToAccount(pk)` (a viem `LocalAccount`). For P-256 / WebAuthn use
@@ -17,7 +17,7 @@ install, see the [skill root](../SKILL.md).
 - **Actor** — an on-chain identity (`{ actorId, authenticator }`), built with
   `key.k1(address)` / `key.p256(...)` / `key.webAuthn(...)`. Used for
   `initialActors`, `authorizeActor`, `revokeActor` — **not** as the `signer`
-  passed to `newSmartAccount8130`.
+  passed to `newSmartAccount`.
 - **Scope** (`actorScope`) — `scopeUnrestricted` (0x00) is admin. Bits:
   `sender` `policy` `nonce` `selfPayer` `sponsorPayer`. A policy-bearing actor
   must be restricted (non-zero scope), or `authorizeActor` throws.
@@ -39,7 +39,7 @@ install, see the [skill root](../SKILL.md).
 and nothing you call moves it between them directly.
 
 ```
-newSmartAccount8130({ signer })     →  COUNTERFACTUAL
+newSmartAccount({ signer })     →  COUNTERFACTUAL
   address derived locally (CREATE2), synchronous, zero RPC calls.
   eth_getCode returns 0x. The account does not exist on-chain.
 
@@ -58,7 +58,7 @@ That leaves exactly two routes from counterfactual to deployed:
 | Route | Needs funding first? | How |
 |---|---|---|
 | **Sponsored** (shortest path) | No | `sendSponsoredCalls` with `accountChanges: [account.createChange]`. The payer pays gas, so this works at a zero balance — no faucet, no cooldown. See [payer-sponsorship.md](payer-sponsorship.md). |
-| **Self-paid** | Yes | Faucet-fund `account.address`, then `sendCalls8130` with `accountChanges: [account.createChange]`. The account pays its own deploy+batch gas. |
+| **Self-paid** | Yes | Faucet-fund `account.address`, then `sendCalls` with `accountChanges: [account.createChange]`. The account pays its own deploy+batch gas. |
 
 Reach for the sponsored route when onboarding a user or writing a first
 example — it removes the faucet from the critical path entirely.
@@ -89,9 +89,9 @@ Once deployed, **omit `accountChanges` on every subsequent transaction.**
 import { createPublicClient, http, parseEther, toHex } from "viem";
 import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
 import {
-  newSmartAccount8130, sendCalls8130, estimateGas8130, encodeWalletCalls,
-  waitForTransactionReceipt8130, allPhasesSucceeded,
-} from "viem/experimental/eip8130";
+  newSmartAccount, sendCalls, estimateGas, encodeWalletCalls,
+  waitForTransactionReceipt, allPhasesSucceeded,
+} from "viem/eip8130";
 
 const chainId = 84538453; // vibenet (Base Sepolia = 84532)
 const RPC_URL = "https://rpc.vibes.base.org"; // 8130-capable public RPC
@@ -113,10 +113,10 @@ const signer = privateKeyToAccount(generatePrivateKey());
 // 2) Deterministic account — address exists before any tx. The owner is an
 //    admin actor (scope 0x00), so sends default to ORDERED (sequenced) nonces,
 //    which are expiry-free. (Nonce-free/expiring mode is opt-in via
-//    `nonceKey: nonceKeyMax` — see Gotchas for its current known bug.)
-//    key.k1(signer.address) is what newSmartAccount8130 uses internally for
+//    `nonceKey: nonceKeyMax` — see Gotchas for a historical timing caveat.)
+//    key.k1(signer.address) is what newSmartAccount uses internally for
 //    the primary actor — you only call key.* when authorizing extra actors.
-const account = newSmartAccount8130({ signer }); // synchronous — no await
+const account = newSmartAccount({ signer }); // synchronous — no await
 // (The fork's TS types may require casting a K1 LocalAccount when passing
 // it as `signer`.)
 
@@ -134,13 +134,13 @@ await fetch("https://api.vibes.base.org/api/vibenet/faucet/drip", {
 
 const calls = [{ to: "0x…recipient", value: parseEther("0.001") }];
 const wire = encodeWalletCalls({ account: account.address, calls: [calls] });
-const gas = await estimateGas8130(client, {
+const gas = await estimateGas(client, {
   sender: account.address,
   accountChanges: [account.createChange],
   calls: wire,
 });
 
-const hash = await sendCalls8130(client, {
+const hash = await sendCalls(client, {
   account,
   accountChanges: [account.createChange], // omit on subsequent txs
   calls,
@@ -149,7 +149,7 @@ const hash = await sendCalls8130(client, {
 });
 
 // 4) Wait and check every phase succeeded.
-const receipt = await waitForTransactionReceipt8130(client, { hash });
+const receipt = await waitForTransactionReceipt(client, { hash });
 if (!allPhasesSucceeded(receipt)) throw new Error("a phase reverted");
 ```
 
@@ -160,7 +160,7 @@ account-change application is not covered (see
 changes need a read-back instead). UIs that display per-phase results should
 render `phaseStatuses` and treat `allPhasesSucceeded(receipt)` as the overall
 verdict; don't rely on `receipt.status` alone. For the exact field shape,
-check `src/experimental/eip8130` on the fork branch — it is experimental and
+check `src/eip8130` on the fork branch — it is experimental and
 may shift.
 
 ## Canonical deployment
@@ -170,42 +170,43 @@ Canonical contract addresses per chain come from `getEip8130Deployment(chainId)`
 `authenticators.*`, `policies.{manager,sessionPolicy}`.
 
 The current canonical deployment uses AccountConfiguration
-`0x53648Cf00356fbAA1F2B531715c6B64AaBDE1555`, DefaultAccount
-`0x58da469ef71Dd4B092B010CdA37DE124C926EebD`, PolicyManager
-`0x6e9E627770C1c90371A2E4CB9474A7Af577a4306`, and SessionPolicy
-`0x58ef2d572a1bC528f0B9121d686B2618809604Dc`.
+`0x81305d4f4976220D2af17E5Dc246848E235600AC`, DefaultAccount
+`0x813078f98b3eb214046C8Dc93A771ac9de5AaDEf`, PolicyManager
+`0x813077055d1110F92191ccE13018f51820B40ac1`, and SessionPolicy
+`0x813070914C530d030f4Efd8Fa99C18e836435e55`.
 
 ## Account creation modes
 
-- `newSmartAccount8130({ signer })` — new CREATE2 smart account (most common).
+- `newSmartAccount({ signer })` — new CREATE2 smart account (most common).
   `signer` must be a signing account (`privateKeyToAccount(pk)`, `toP256Signer`,
   or `toWebAuthnSigner`) — **not** `key.k1(...)`.
-- `to8130Account({ signer, userSalt, code, initialActors, authenticator, accountConfigAddress })`
+- `toAccount({ signer, userSalt, code, initialActors, authenticator, accountConfigAddress })`
   — full control over salt / initial actors.
-- `to8130Account({ signer, address, authenticator })` — a configured (non-default)
+- `toAccount({ signer, address, authenticator })` — a configured (non-default)
   actor on an existing/delegated account.
-- `toEoa8130Account(signer)` — an EOA acting as its own default K1 actor
+- `toEoaAccount(signer)` — an EOA acting as its own default K1 actor
   (raw 65-byte sig, EIP-7702 delegation via `account.delegate(impl)`).
 
 ## Reading account state (viem actions)
 
 All take `(client, params)` and read the on-chain `AccountConfiguration`:
-`getActorConfig8130`, `isActor8130`, `getPolicy8130`, `getSessionSpend8130`,
-`getLockStatus8130` / `isLocked8130`, `getConfigSequence8130`,
-`getTransactionCount8130`, `getTransaction8130`, `getTransactionReceipt8130`,
-`waitForTransactionReceipt8130`.
+`getActorConfig`, `isActor`, `getPolicy`, `getSessionSpend`,
+`getLockStatus` / `isLocked`, `getConfigSequence`,
+`getTransactionCount`, `getTransaction`, `getTransactionReceipt`,
+`waitForTransactionReceipt`.
 
 ## Locking
 
-`lockCall` / `initiateUnlockCall` build `applySignedLockChanges` calls; hash the
-change to sign with `hashLockChange8130` (`lockChangeTypehash`). `lockCall`
-requires `unlockDelay >= 1`.
+`lockChange({ unlockDelay })` / `unlockChange()` build lock/unlock account
+changes — include them in `accountChanges` (signed like any other config
+change), no separate hash step. `lockChange` requires `unlockDelay >= 1`
+(`maxUnlockDelay` caps it at `0xffff`).
 
 ## Gotchas
 
 - **`key.k1` ≠ signer.** `key.k1(address)` builds an actor id for authorize /
   `initialActors`. Passing it (or a raw private-key hex) as `signer` to
-  `newSmartAccount8130` fails with an opaque `pad()` TypeError — use
+  `newSmartAccount` fails with an opaque `pad()` TypeError — use
   `privateKeyToAccount(pk)`.
 - Fund `account.address` **before** a self-paid first tx — the deploy+batch pays
   gas from the account (unless a payer sponsors it).
@@ -223,9 +224,9 @@ requires `unlockDelay >= 1`.
   untouched address, not to `value` in general. Cause unconfirmed; if you are
   onboarding a fresh recipient, fund it from the faucet first or expect the
   revert.
-- Attribution goes in `dataSuffix` on `sendCalls8130` (maps to signed `metadata`).
-- **Always pass explicit `gas`** to `sendCalls8130` (estimate with
-  `estimateGas8130`, add ~20% headroom, as in the example above). Omitting it
+- Attribution goes in `dataSuffix` on `sendCalls` (maps to signed `metadata`).
+- **Always pass explicit `gas`** to `sendCalls` (estimate with
+  `estimateGas`, add ~20% headroom, as in the example above). Omitting it
   gets the tx rejected with the misleading error
   `transaction type not supported` — live-confirmed, and easy to misread as
   an RPC capability problem.
@@ -247,11 +248,12 @@ requires `unlockDelay >= 1`.
   returns `healthy: false, reason: "halted"` with a rising `headAgeSecs`. Wait
   for it to recover; there is nothing to fix client-side. Worth surfacing in any
   UI or script that sends transactions.
-- **Nonce-free (expiring) sends have a known bug (planned fix July 22, 2026):**
-  the node can intermittently reject a valid `0x79` with a misleading
-  `transaction type not supported` (the short `expiry` lapses before
-  validation). Until then, prefer **ordered (expiry-free)** sends — the default
-  for admin and `SCOPE_NONCE` actors — which are unaffected.
+- **Nonce-free (expiring) sends historically had a timing bug** — the node
+  could intermittently reject a valid `0x79` with a misleading
+  `transaction type not supported` when the short `expiry` lapsed before
+  validation. The `feat/eip-8130-production` branch no longer flags it, but if
+  you hit it, prefer **ordered (expiry-free)** sends — the default for admin and
+  `SCOPE_NONCE` actors — which are unaffected.
 - Contract addresses are bytecode-derived — the deployed system must be compiled
   with the same solc as `canonicalEip8130Deployment`, or account creation fails
   with "create address mismatch".

--- a/skills/vibenet/references/eip8130-accounts.md
+++ b/skills/vibenet/references/eip8130-accounts.md
@@ -9,7 +9,8 @@ install, see the [skill root](../SKILL.md).
 - **Account** — a viem-style account object with `.address` (deterministic,
   CREATE2-derived), `.create()` / `.createChange` (first-tx deploy change), and
   `signTransaction`. Create via `newSmartAccount8130` / `to8130Account` /
-  `toEoa8130Account`.
+  `toEoa8130Account`. Creating one puts it in a *counterfactual* state — see
+  [Account lifecycle](#account-lifecycle-there-is-no-deploy-step).
 - **Signer** — a signing object that can produce `sender_auth`. For K1, use
   `privateKeyToAccount(pk)` (a viem `LocalAccount`). For P-256 / WebAuthn use
   `toP256Signer` / `toWebAuthnSigner`.
@@ -32,12 +33,62 @@ install, see the [skill root](../SKILL.md).
 - **Payer (ERC-8168)** — a service that co-signs `payer_auth` to pay gas. See
   [payer-sponsorship.md](payer-sponsorship.md).
 
+## Account lifecycle: there is no deploy step
+
+**The single most common point of confusion.** An 8130 account has two states,
+and nothing you call moves it between them directly.
+
+```
+newSmartAccount8130({ signer })     →  COUNTERFACTUAL
+  address derived locally (CREATE2), synchronous, zero RPC calls.
+  eth_getCode returns 0x. The account does not exist on-chain.
+
+first transaction (carries account.createChange)  →  DEPLOYED
+  eth_getCode returns an EIP-1167 minimal proxy delegating to the
+  canonical DefaultAccount.
+```
+
+There is **no `deploy()` and no `create()` transaction to send.** The account is
+brought into existence as a side effect of its first transaction, which carries
+`account.createChange` alongside whatever calls you actually wanted to make.
+Creation costs no extra round-trip: deploy and first batch are one tx.
+
+That leaves exactly two routes from counterfactual to deployed:
+
+| Route | Needs funding first? | How |
+|---|---|---|
+| **Sponsored** (shortest path) | No | `sendSponsoredCalls` with `accountChanges: [account.createChange]`. The payer pays gas, so this works at a zero balance — no faucet, no cooldown. See [payer-sponsorship.md](payer-sponsorship.md). |
+| **Self-paid** | Yes | Faucet-fund `account.address`, then `sendCalls8130` with `accountChanges: [account.createChange]`. The account pays its own deploy+batch gas. |
+
+Reach for the sponsored route when onboarding a user or writing a first
+example — it removes the faucet from the critical path entirely.
+
+### Checking whether an account is deployed
+
+Read it from the chain; never track it as local/optimistic UI state. It is not
+cosmetic — it decides whether the next transaction attaches `createChange`, so a
+stale `true` produces a malformed tx and a stale `false` re-sends a create.
+
+```ts
+const code = await client.getCode({ address: account.address });
+const deployed = Boolean(code && code !== "0x");
+```
+
+`getCode` lags ~1 block (~2s) behind the receipt, so immediately after a
+successful create it can still return `0x` on a transaction whose every phase
+succeeded. **Poll it** — don't conclude the deploy failed from a single read.
+The same lag hits the payer: sponsoring right after a self-paid deploy fails
+with `actor is not bound` until the config propagates.
+
+Once deployed, **omit `accountChanges` on every subsequent transaction.**
+
 ## Minimal end-to-end: create a smart account and send a batch
 
 ```ts
+// Core helpers come from `viem` itself — the 8130 module does NOT re-export them.
+import { createPublicClient, http, parseEther, toHex } from "viem";
 import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
 import {
-  createPublicClient, http, parseEther, toHex,
   newSmartAccount8130, sendCalls8130, estimateGas8130, encodeWalletCalls,
   waitForTransactionReceipt8130, allPhasesSucceeded,
 } from "viem/experimental/eip8130";
@@ -51,8 +102,9 @@ const chain = {
   rpcUrls: { default: { http: [RPC_URL] } },
 };
 const client = createPublicClient({ chain, transport: http(RPC_URL) });
-// Browser apps: use https://vibes.base.org/api/vibenet/account/rpc instead
-// (same chain, CORS-safe proxy).
+// This RPC is CORS-enabled, so it works from the browser too. The hosted
+// proxy at https://api.vibes.base.org/api/vibenet/account/rpc is an
+// alternative path to the same chain.
 
 // 1) Signer = LocalAccount (NOT key.k1 — that builds an actor identity).
 const signer = privateKeyToAccount(generatePrivateKey());
@@ -71,8 +123,10 @@ const account = newSmartAccount8130({ signer }); // synchronous — no await
 // 3) Fund account.address (faucet), then estimate + send. The drip responds
 //    with { tx_hash, amount_wei, to } and grants 0.1 ETH, usually landing in
 //    ~2s — but treat the shape as unstable: confirm funding by polling
-//    eth_getBalance until non-zero (allow ~60s and handle rate limits).
-await fetch("https://vibes.base.org/api/vibenet/faucet/drip", {
+//    eth_getBalance until non-zero (allow ~60s). Cooldown is ~10s per address
+//    and per IP; GET /api/vibenet/faucet/status returns the live values.
+//    The endpoint is CORS-enabled, so a browser can call it directly.
+await fetch("https://api.vibes.base.org/api/vibenet/faucet/drip", {
   method: "POST",
   headers: { "content-type": "application/json" },
   body: JSON.stringify({ address: account.address }),
@@ -161,15 +215,38 @@ requires `unlockDelay >= 1`.
   lags ~1 block behind the receipt, so an immediate getCode can return `0x`
   on a tx that succeeded. Poll before concluding the deploy failed (same lag
   as config-change read-backs).
+- **A value-bearing call to a brand-new address reverts.** Sending `value` to an
+  address that has never held a balance comes back `status: 0x0` with
+  `phaseStatuses: ["0x0"]` (reproduced 4/4 on vibenet). The same call to an
+  address that already has a balance succeeds and moves the exact amount, and a
+  zero-value call to a fresh address is fine — so it is specific to funding an
+  untouched address, not to `value` in general. Cause unconfirmed; if you are
+  onboarding a fresh recipient, fund it from the faucet first or expect the
+  revert.
 - Attribution goes in `dataSuffix` on `sendCalls8130` (maps to signed `metadata`).
 - **Always pass explicit `gas`** to `sendCalls8130` (estimate with
   `estimateGas8130`, add ~20% headroom, as in the example above). Omitting it
   gets the tx rejected with the misleading error
   `transaction type not supported` — live-confirmed, and easy to misread as
   an RPC capability problem.
-- `rpc.vibes.base.org` **is** fine for `0x79` broadcasts (Node/scripts). The
-  `account/rpc` URL is only required in the browser (CORS proxy to the same
-  chain).
+- `rpc.vibes.base.org` **is** fine for `0x79` broadcasts, from Node and from the
+  browser (it serves `access-control-allow-origin: *`). The
+  `api.vibes.base.org/api/vibenet/account/rpc` proxy is an alternative route to
+  the same chain, not a requirement.
+- **The API host is `api.vibes.base.org`.** A bare `vibes.base.org/api/…` URL
+  302s to an HTML page, and viem surfaces that as
+  `JSON Parse error: Unrecognized token '<'` — easy to misread as a bug in your
+  code.
+- **`no backend is currently healthy to serve traffic` means the devnet is
+  halted, not that your code or RPC URL is wrong.** vibenet is an ephemeral
+  devnet and does stall. Reads (`eth_chainId`, `eth_blockNumber`) keep answering
+  from the last block while `eth_sendRawTransaction` fails, which makes it look
+  like a transaction-shaped problem. Confirm with
+  `GET https://api.vibes.base.org/api/vibenet/chain-health`, which reports
+  `{ healthy, reason, detail, head, headAgeSecs, stuckSecs }` — a halted chain
+  returns `healthy: false, reason: "halted"` with a rising `headAgeSecs`. Wait
+  for it to recover; there is nothing to fix client-side. Worth surfacing in any
+  UI or script that sends transactions.
 - **Nonce-free (expiring) sends have a known bug (planned fix July 22, 2026):**
   the node can intermittently reject a valid `0x79` with a misleading
   `transaction type not supported` (the short `expiry` lapses before

--- a/skills/vibenet/references/eip8130-accounts.md
+++ b/skills/vibenet/references/eip8130-accounts.md
@@ -1,0 +1,182 @@
+# EIP-8130 accounts and transactions (viem)
+
+Creating 8130 smart accounts and sending batched calls on vibenet / Base
+Sepolia with viem's `experimental/eip8130` module. For network endpoints and
+install, see the [skill root](../SKILL.md).
+
+## Core concepts
+
+- **Account** — a viem-style account object with `.address` (deterministic,
+  CREATE2-derived), `.create()` / `.createChange` (first-tx deploy change), and
+  `signTransaction`. Create via `newSmartAccount8130` / `to8130Account` /
+  `toEoa8130Account`.
+- **Signer** — a signing object that can produce `sender_auth`. For K1, use
+  `privateKeyToAccount(pk)` (a viem `LocalAccount`). For P-256 / WebAuthn use
+  `toP256Signer` / `toWebAuthnSigner`.
+- **Actor** — an on-chain identity (`{ actorId, authenticator }`), built with
+  `key.k1(address)` / `key.p256(...)` / `key.webAuthn(...)`. Used for
+  `initialActors`, `authorizeActor`, `revokeActor` — **not** as the `signer`
+  passed to `newSmartAccount8130`.
+- **Scope** (`actorScope`) — `scopeUnrestricted` (0x00) is admin. Bits:
+  `sender` `policy` `nonce` `selfPayer` `sponsorPayer`. A policy-bearing actor
+  must be restricted (non-zero scope), or `authorizeActor` throws.
+- **Nonce mode** — admin (`0x00`) or an actor with the `nonce` bit
+  (`SCOPE_NONCE`) may use **ordered** (sequenced, expiry-free) *or* nonce-free
+  (expiring) nonces; sends default to ordered. Only a restricted actor
+  **without** `SCOPE_NONCE` is confined to nonce-free.
+- **Policy** — on-chain rules (e.g. `SessionPolicy`: per-token spend limits +
+  call scopes). See
+  [session-keys-and-policies.md](session-keys-and-policies.md).
+- **Calls** — a batch of `{ to, value?, data? }` executed atomically, with
+  optional signed top-level `metadata` (set via `dataSuffix` on send).
+- **Payer (ERC-8168)** — a service that co-signs `payer_auth` to pay gas. See
+  [payer-sponsorship.md](payer-sponsorship.md).
+
+## Minimal end-to-end: create a smart account and send a batch
+
+```ts
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import {
+  createPublicClient, http, parseEther, toHex,
+  newSmartAccount8130, sendCalls8130, estimateGas8130, encodeWalletCalls,
+  waitForTransactionReceipt8130, allPhasesSucceeded,
+} from "viem/experimental/eip8130";
+
+const chainId = 84538453; // vibenet (Base Sepolia = 84532)
+const RPC_URL = "https://rpc.vibes.base.org"; // 8130-capable public RPC
+const chain = {
+  id: chainId,
+  name: "vibenet",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: [RPC_URL] } },
+};
+const client = createPublicClient({ chain, transport: http(RPC_URL) });
+// Browser apps: use https://vibes.base.org/api/vibenet/account/rpc instead
+// (same chain, CORS-safe proxy).
+
+// 1) Signer = LocalAccount (NOT key.k1 — that builds an actor identity).
+const signer = privateKeyToAccount(generatePrivateKey());
+//    P-256: toP256Signer({ privateKey }) · WebAuthn: toWebAuthnSigner(...)
+
+// 2) Deterministic account — address exists before any tx. The owner is an
+//    admin actor (scope 0x00), so sends default to ORDERED (sequenced) nonces,
+//    which are expiry-free. (Nonce-free/expiring mode is opt-in via
+//    `nonceKey: nonceKeyMax` — see Gotchas for its current known bug.)
+//    key.k1(signer.address) is what newSmartAccount8130 uses internally for
+//    the primary actor — you only call key.* when authorizing extra actors.
+const account = newSmartAccount8130({ signer }); // synchronous — no await
+// (The fork's TS types may require casting a K1 LocalAccount when passing
+// it as `signer`.)
+
+// 3) Fund account.address (faucet), then estimate + send. The drip responds
+//    with { tx_hash, amount_wei, to } and grants 0.1 ETH, usually landing in
+//    ~2s — but treat the shape as unstable: confirm funding by polling
+//    eth_getBalance until non-zero (allow ~60s and handle rate limits).
+await fetch("https://vibes.base.org/api/vibenet/faucet/drip", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ address: account.address }),
+});
+
+const calls = [{ to: "0x…recipient", value: parseEther("0.001") }];
+const wire = encodeWalletCalls({ account: account.address, calls: [calls] });
+const gas = await estimateGas8130(client, {
+  sender: account.address,
+  accountChanges: [account.createChange],
+  calls: wire,
+});
+
+const hash = await sendCalls8130(client, {
+  account,
+  accountChanges: [account.createChange], // omit on subsequent txs
+  calls,
+  dataSuffix: toHex("invoice #4242"), // maps to signed metadata
+  gas: (gas * 120n) / 100n,
+});
+
+// 4) Wait and check every phase succeeded.
+const receipt = await waitForTransactionReceipt8130(client, { hash });
+if (!allPhasesSucceeded(receipt)) throw new Error("a phase reverted");
+```
+
+An 8130 receipt executes in **phases** (one per call batch). `phaseStatuses`
+on the receipt reports per-phase success for CALL phases only —
+account-change application is not covered (see
+[session-keys-and-policies.md](session-keys-and-policies.md) for why config
+changes need a read-back instead). UIs that display per-phase results should
+render `phaseStatuses` and treat `allPhasesSucceeded(receipt)` as the overall
+verdict; don't rely on `receipt.status` alone. For the exact field shape,
+check `src/experimental/eip8130` on the fork branch — it is experimental and
+may shift.
+
+## Canonical deployment
+
+Canonical contract addresses per chain come from `getEip8130Deployment(chainId)`
+(or `canonicalEip8130Deployment`): `accountConfiguration`, `accounts.*`,
+`authenticators.*`, `policies.{manager,sessionPolicy}`.
+
+The current canonical deployment uses AccountConfiguration
+`0x53648Cf00356fbAA1F2B531715c6B64AaBDE1555`, DefaultAccount
+`0x58da469ef71Dd4B092B010CdA37DE124C926EebD`, PolicyManager
+`0x6e9E627770C1c90371A2E4CB9474A7Af577a4306`, and SessionPolicy
+`0x58ef2d572a1bC528f0B9121d686B2618809604Dc`.
+
+## Account creation modes
+
+- `newSmartAccount8130({ signer })` — new CREATE2 smart account (most common).
+  `signer` must be a signing account (`privateKeyToAccount(pk)`, `toP256Signer`,
+  or `toWebAuthnSigner`) — **not** `key.k1(...)`.
+- `to8130Account({ signer, userSalt, code, initialActors, authenticator, accountConfigAddress })`
+  — full control over salt / initial actors.
+- `to8130Account({ signer, address, authenticator })` — a configured (non-default)
+  actor on an existing/delegated account.
+- `toEoa8130Account(signer)` — an EOA acting as its own default K1 actor
+  (raw 65-byte sig, EIP-7702 delegation via `account.delegate(impl)`).
+
+## Reading account state (viem actions)
+
+All take `(client, params)` and read the on-chain `AccountConfiguration`:
+`getActorConfig8130`, `isActor8130`, `getPolicy8130`, `getSessionSpend8130`,
+`getLockStatus8130` / `isLocked8130`, `getConfigSequence8130`,
+`getTransactionCount8130`, `getTransaction8130`, `getTransactionReceipt8130`,
+`waitForTransactionReceipt8130`.
+
+## Locking
+
+`lockCall` / `initiateUnlockCall` build `applySignedLockChanges` calls; hash the
+change to sign with `hashLockChange8130` (`lockChangeTypehash`). `lockCall`
+requires `unlockDelay >= 1`.
+
+## Gotchas
+
+- **`key.k1` ≠ signer.** `key.k1(address)` builds an actor id for authorize /
+  `initialActors`. Passing it (or a raw private-key hex) as `signer` to
+  `newSmartAccount8130` fails with an opaque `pad()` TypeError — use
+  `privateKeyToAccount(pk)`.
+- Fund `account.address` **before** a self-paid first tx — the deploy+batch pays
+  gas from the account (unless a payer sponsors it).
+- Only the **first** tx includes `account.createChange`; later txs omit it.
+- After a successful create, `eth_getCode` on the account returns an EIP-1167
+  minimal proxy delegating to the canonical DefaultAccount — but the read
+  lags ~1 block behind the receipt, so an immediate getCode can return `0x`
+  on a tx that succeeded. Poll before concluding the deploy failed (same lag
+  as config-change read-backs).
+- Attribution goes in `dataSuffix` on `sendCalls8130` (maps to signed `metadata`).
+- **Always pass explicit `gas`** to `sendCalls8130` (estimate with
+  `estimateGas8130`, add ~20% headroom, as in the example above). Omitting it
+  gets the tx rejected with the misleading error
+  `transaction type not supported` — live-confirmed, and easy to misread as
+  an RPC capability problem.
+- `rpc.vibes.base.org` **is** fine for `0x79` broadcasts (Node/scripts). The
+  `account/rpc` URL is only required in the browser (CORS proxy to the same
+  chain).
+- **Nonce-free (expiring) sends have a known bug (planned fix July 22, 2026):**
+  the node can intermittently reject a valid `0x79` with a misleading
+  `transaction type not supported` (the short `expiry` lapses before
+  validation). Until then, prefer **ordered (expiry-free)** sends — the default
+  for admin and `SCOPE_NONCE` actors — which are unaffected.
+- Contract addresses are bytecode-derived — the deployed system must be compiled
+  with the same solc as `canonicalEip8130Deployment`, or account creation fails
+  with "create address mismatch".
+- Chains must be 8130-aware: use `register8130Chains` / `is8130Enabled` when
+  operating outside the built-in `eip8130ChainIds`.

--- a/skills/vibenet/references/payer-sponsorship.md
+++ b/skills/vibenet/references/payer-sponsorship.md
@@ -7,7 +7,7 @@ account creation and core concepts, read
 
 A **payer** is a service that co-signs `payer_auth` to pay gas (sponsored or
 in ERC-20). The hosted vibenet payer lives at
-`https://vibes.base.org/api/vibenet/account/payer` and supports **both**
+`https://api.vibes.base.org/api/vibenet/account/payer` and supports **both**
 ERC-8168 modes:
 
 - `mode: "send"` (default) — payer co-signs and submits (`payer_sendTransaction`)
@@ -16,22 +16,24 @@ ERC-8168 modes:
 ## Sponsor a first transaction (gasless onboarding)
 
 ```ts
+import type { Hex } from "viem";
 import { createPayerClient, sendSponsoredCalls } from "viem/experimental/eip8168";
 import { waitForTransactionReceipt8130 } from "viem/experimental/eip8130";
 
 const payerClient = createPayerClient({
-  url: "https://vibes.base.org/api/vibenet/account/payer",
+  url: "https://api.vibes.base.org/api/vibenet/account/payer",
 });
 
-// Default mode:"send" — payer co-signs and broadcasts. Returns the tx HASH
-// directly (SendTransactionReturnType) — do NOT destructure { transactionHash }.
-const hash = await sendSponsoredCalls(client, {
+// Default mode:"send" — payer co-signs and broadcasts, resolving with an
+// OBJECT: `{ transactionHash }`. Destructure it. (The declared return type says
+// otherwise — see the note below — so TypeScript needs a cast.)
+const { transactionHash: hash } = (await sendSponsoredCalls(client, {
   account,
   payerClient,
   accountChanges: [account.createChange], // deploy rides in the first sponsored tx
   calls: [{ to: account.address, value: 0n, data: "0x" }],
   context: { flow: "transact" }, // budgets free grants per (sender, flow)
-});
+})) as unknown as { transactionHash: Hex };
 const receipt = await waitForTransactionReceipt8130(client, { hash });
 ```
 
@@ -39,10 +41,16 @@ No faucet call and no user ETH is needed anywhere in this flow — the payer's
 `payer_auth` makes the protocol debit gas from the payer, not the sender.
 
 For self-submit (e.g. custom RPC / retry control), pass `mode: "sign"` — the
-call then resolves with the signed raw transaction
-(`SignTransactionReturnType`), which you broadcast yourself with
-`eth_sendRawTransaction`. Both modes return a plain hex string, not an
-object: the tx hash in `send` mode, the signed tx in `sign` mode.
+call then resolves with the signed raw transaction, which you broadcast yourself
+with `eth_sendRawTransaction`.
+
+**The declared return type is wrong.** `SendSponsoredCallsReturnType` is typed
+as a union of hex strings (`SendTransactionReturnType | SignTransactionReturnType`),
+but `mode: "send"` resolves with `{ transactionHash }` at runtime —
+live-confirmed against the hosted payer. Passing the raw result into
+`waitForTransactionReceipt8130` fails at the RPC layer with
+`invalid type: map, expected 32 bytes`, which points nowhere near the cause. The
+union also isn't assignable to `Hex`, so narrowing needs `as unknown as`.
 
 ## Wire protocol (JSON-RPC over the payer URL)
 
@@ -62,6 +70,15 @@ the fork branch.
 
 - Subsequent sponsored txs omit `account.createChange` — only the first tx
   carries it.
+- **Don't sponsor immediately after a self-paid deploy.** Account config
+  propagates ~1 block behind the receipt (the same lag as `eth_getCode` and
+  config read-backs), and the payer validates against the lagging state — so a
+  sponsored tx sent right after a successful deploy is rejected with
+  `EIP-8130 validation failed: actor is not bound`, surfaced as viem's
+  `InvalidInputRpcError: Missing or invalid parameters`. Neither message points
+  at timing. Retry on `actor is not bound` (a few seconds is enough) or wait for
+  the account's code read-back before sponsoring. Live-confirmed: the same call
+  fails immediately after deploy and succeeds ~6s later.
 - `context.flow` lets the hosted payer budget free grants per
   `(sender, flow)` pair; pick a stable string per product surface
   (e.g. `"onboarding"`, `"transact"`).

--- a/skills/vibenet/references/payer-sponsorship.md
+++ b/skills/vibenet/references/payer-sponsorship.md
@@ -17,8 +17,8 @@ ERC-8168 modes:
 
 ```ts
 import type { Hex } from "viem";
-import { createPayerClient, sendSponsoredCalls } from "viem/experimental/eip8168";
-import { waitForTransactionReceipt8130 } from "viem/experimental/eip8130";
+import { createPayerClient, sendSponsoredCalls } from "viem/eip8168";
+import { waitForTransactionReceipt } from "viem/eip8130";
 
 const payerClient = createPayerClient({
   url: "https://api.vibes.base.org/api/vibenet/account/payer",
@@ -34,7 +34,7 @@ const { transactionHash: hash } = (await sendSponsoredCalls(client, {
   calls: [{ to: account.address, value: 0n, data: "0x" }],
   context: { flow: "transact" }, // budgets free grants per (sender, flow)
 })) as unknown as { transactionHash: Hex };
-const receipt = await waitForTransactionReceipt8130(client, { hash });
+const receipt = await waitForTransactionReceipt(client, { hash });
 ```
 
 No faucet call and no user ETH is needed anywhere in this flow — the payer's
@@ -48,7 +48,7 @@ with `eth_sendRawTransaction`.
 as a union of hex strings (`SendTransactionReturnType | SignTransactionReturnType`),
 but `mode: "send"` resolves with `{ transactionHash }` at runtime —
 live-confirmed against the hosted payer. Passing the raw result into
-`waitForTransactionReceipt8130` fails at the RPC layer with
+`waitForTransactionReceipt` fails at the RPC layer with
 `invalid type: map, expected 32 bytes`, which points nowhere near the cause. The
 union also isn't assignable to `Hex`, so narrowing needs `as unknown as`.
 
@@ -63,7 +63,7 @@ Under the hood `sendSponsoredCalls` runs the ERC-8168 flow: fetch terms with
 Rejections come back as JSON-RPC error `-32000` with a
 `data: { code, reason }` envelope — branch on the string `code` (e.g.
 `BUDGET_EXHAUSTED`, `SENDER_LIMIT_REACHED`, whose context includes a
-`validFor` retry hint). Full types: `src/experimental/eip8168/types.ts` on
+`validFor` retry hint). Full types: `src/eip8168/types.ts` on
 the fork branch.
 
 ## Notes
@@ -83,4 +83,4 @@ the fork branch.
   `(sender, flow)` pair; pick a stable string per product surface
   (e.g. `"onboarding"`, `"transact"`).
 - Payer standard: https://eip.tools/eip/8168 (viem module:
-  `src/experimental/eip8168` on the fork branch).
+  `src/eip8168` on the fork branch).

--- a/skills/vibenet/references/payer-sponsorship.md
+++ b/skills/vibenet/references/payer-sponsorship.md
@@ -1,0 +1,69 @@
+# Payer gas sponsorship (ERC-8168)
+
+Sponsoring gas for 8130 accounts with a payer service — the path to gasless
+onboarding (account creation + first transaction with zero user ETH). For
+account creation and core concepts, read
+[eip8130-accounts.md](eip8130-accounts.md) first.
+
+A **payer** is a service that co-signs `payer_auth` to pay gas (sponsored or
+in ERC-20). The hosted vibenet payer lives at
+`https://vibes.base.org/api/vibenet/account/payer` and supports **both**
+ERC-8168 modes:
+
+- `mode: "send"` (default) — payer co-signs and submits (`payer_sendTransaction`)
+- `mode: "sign"` — payer co-signs only; you broadcast with `eth_sendRawTransaction`
+
+## Sponsor a first transaction (gasless onboarding)
+
+```ts
+import { createPayerClient, sendSponsoredCalls } from "viem/experimental/eip8168";
+import { waitForTransactionReceipt8130 } from "viem/experimental/eip8130";
+
+const payerClient = createPayerClient({
+  url: "https://vibes.base.org/api/vibenet/account/payer",
+});
+
+// Default mode:"send" — payer co-signs and broadcasts. Returns the tx HASH
+// directly (SendTransactionReturnType) — do NOT destructure { transactionHash }.
+const hash = await sendSponsoredCalls(client, {
+  account,
+  payerClient,
+  accountChanges: [account.createChange], // deploy rides in the first sponsored tx
+  calls: [{ to: account.address, value: 0n, data: "0x" }],
+  context: { flow: "transact" }, // budgets free grants per (sender, flow)
+});
+const receipt = await waitForTransactionReceipt8130(client, { hash });
+```
+
+No faucet call and no user ETH is needed anywhere in this flow — the payer's
+`payer_auth` makes the protocol debit gas from the payer, not the sender.
+
+For self-submit (e.g. custom RPC / retry control), pass `mode: "sign"` — the
+call then resolves with the signed raw transaction
+(`SignTransactionReturnType`), which you broadcast yourself with
+`eth_sendRawTransaction`. Both modes return a plain hex string, not an
+object: the tx hash in `send` mode, the signed tx in `sign` mode.
+
+## Wire protocol (JSON-RPC over the payer URL)
+
+Under the hood `sendSponsoredCalls` runs the ERC-8168 flow: fetch terms with
+`payer_getTerms`, build and sign `sender_auth` with `payer` set and
+`payer_auth` empty, then hand off via `payer_sendTransaction` (send mode) or
+`payer_signTransaction` (sign mode). `payer_getTerms` +
+`payer_sendTransaction` are the required pair every payer implements;
+`payer_signTransaction` is optional (advertised in the terms' `methods`).
+Rejections come back as JSON-RPC error `-32000` with a
+`data: { code, reason }` envelope — branch on the string `code` (e.g.
+`BUDGET_EXHAUSTED`, `SENDER_LIMIT_REACHED`, whose context includes a
+`validFor` retry hint). Full types: `src/experimental/eip8168/types.ts` on
+the fork branch.
+
+## Notes
+
+- Subsequent sponsored txs omit `account.createChange` — only the first tx
+  carries it.
+- `context.flow` lets the hosted payer budget free grants per
+  `(sender, flow)` pair; pick a stable string per product surface
+  (e.g. `"onboarding"`, `"transact"`).
+- Payer standard: https://eip.tools/eip/8168 (viem module:
+  `src/experimental/eip8168` on the fork branch).

--- a/skills/vibenet/references/session-keys-and-policies.md
+++ b/skills/vibenet/references/session-keys-and-policies.md
@@ -1,0 +1,95 @@
+# Session keys, actors, and policies (EIP-8130)
+
+Authorizing scoped session-key actors with on-chain policies, and verifying
+config changes correctly. For account creation and core concepts, read
+[eip8130-accounts.md](eip8130-accounts.md) first.
+
+## Authorize a policy-gated session actor
+
+```ts
+import {
+  key, authorizeActor, actorScope,
+  defineSessionPolicy, encodeSessionPolicyConfig, getEip8130Deployment,
+} from "viem/experimental/eip8130";
+
+const dep = getEip8130Deployment(chainId);
+const policyConfig = encodeSessionPolicyConfig({
+  tokenLimits: [{ token: usdv, limit: 100_000_000n, period: 604_800n }], // 100 USDV / week
+  callScopes: [{ target: usdv, selectorRules: [{ selector: "0xa9059cbb" }] }], // transfer only
+});
+const session = defineSessionPolicy({
+  account: account.address, policy: dep.policies.sessionPolicy,
+  policyConfig, manager: dep.policies.manager, validUntil: 1_900_000_000n,
+});
+
+// There is no install step. Every execute carries the full PolicyBinding and
+// the manager recomputes its authorized commitment.
+const call = session.executeCall({ target, value: 0n, data });
+
+// Actor identity for authorize (not a LocalAccount). SCOPE_POLICY is set
+// automatically when `policy` is present.
+const sessionActor = key.p256({ x: "0x…", y: "0x…" });
+const change = authorizeActor(sessionActor, {
+  scope: actorScope.sender,
+  expiry: 1_900_000_000n,
+  policy: session.actorPolicy,
+});
+// Include `change` in accountChanges of a sendCalls8130 signed by an admin actor.
+```
+
+A policy actor must have a non-zero scope; admin (scope 0) + policy is
+rejected by `authorizeActor`.
+
+## Verifying a config change (and why it can look "silent")
+
+Account changes (authorize/revoke) do **not** surface success the way calls do.
+Check them by **reading back on-chain state**, not by the receipt:
+
+- **`receipt.logs` is empty even on a successful authorize.** `ActorAuthorized`
+  is not surfaced as a normal EVM log here — "no events" is NOT a failure. Do
+  not gate success on scanning logs.
+- **`allPhasesSucceeded` / `phaseStatuses` only cover CALL phases**, not the
+  account-change application. A skipped authorize marks no failed phase, throws
+  nothing, and the tx still reports `status: success`.
+- **The only reliable success check is a read-back:** `isActor8130`,
+  `getActorConfig8130`, or a bumped `getConfigSequence8130`.
+- **Reads lag ~1 block (~2s)** behind the receipt — poll the read-back.
+
+## Sequence correctness
+
+The usual cause of a silent no-op: the digest binds
+`(account, chainId, sequence)`. Always read the **live** counter for the channel
+right before signing — never hardcode it. Session-key auth uses the **local**
+channel (`chainId = chain.id`); owner changes use the **multichain** channel
+(`chainId = 0`). The first-authorize sequence depends on the deploy path:
+
+| Deploy path | First local sequence |
+|---|---|
+| Smart wallet (`createAccount`) | `1` (create bumps local 0→1) |
+| Explicit `importAccount` | `1` |
+| Bare 7702 delegation (`account.delegate`) | `0` (delegation does not initialize state) |
+
+```ts
+import { getConfigSequence8130, isActor8130 } from "viem/experimental/eip8130";
+
+const { local } = await getConfigSequence8130(client, {
+  accountConfiguration: dep.accountConfiguration,
+  account: account.address,
+}); // read live — do not assume 0 or 1
+const change = await account.change([authorizeActor(/* … */)], {
+  chainId, // local channel for session keys
+  sequence: Number(local),
+});
+// … send the tx, then verify by read-back (polled for ~1 block of lag):
+const bound = await isActor8130(client, {
+  account: account.address, actorId, accountConfiguration: dep.accountConfiguration,
+});
+if (!bound) throw new Error("authorize was skipped — check sequence/channel");
+```
+
+## Reference
+
+- Session-key end-to-end walkthrough (create → register PolicyManager +
+  session key → drive a call through the session key, with read-back
+  verification at each step):
+  https://gist.github.com/chunter-cb/bf70c53a5ab6d8361ce7f4215b776114

--- a/skills/vibenet/references/session-keys-and-policies.md
+++ b/skills/vibenet/references/session-keys-and-policies.md
@@ -10,7 +10,7 @@ config changes correctly. For account creation and core concepts, read
 import {
   key, authorizeActor, actorScope,
   defineSessionPolicy, encodeSessionPolicyConfig, getEip8130Deployment,
-} from "viem/experimental/eip8130";
+} from "viem/eip8130";
 
 const dep = getEip8130Deployment(chainId);
 const policyConfig = encodeSessionPolicyConfig({
@@ -34,7 +34,11 @@ const change = authorizeActor(sessionActor, {
   expiry: 1_900_000_000n,
   policy: session.actorPolicy,
 });
-// Include `change` in accountChanges of a sendCalls8130 signed by an admin actor.
+// `change` is an unsigned change object. Apply it via account.change([change],
+// { chainId, sequence }) with a LIVE-read sequence — see Sequence correctness
+// below — then include the result in a sendCalls signed by an admin actor.
+// Don't hand-build accountChanges with a hardcoded sequence; that is the #1
+// cause of a silently skipped authorize.
 ```
 
 A policy actor must have a non-zero scope; admin (scope 0) + policy is
@@ -64,8 +68,8 @@ Check them by **reading back on-chain state**, not by the receipt:
   actor was bound and the config sequence had bumped. Account changes are not
   atomic with the calls they ride along with, in either direction. **Never infer
   config state from `receipt.status`.**
-- **The only reliable check is a read-back:** `isActor8130`,
-  `getActorConfig8130`, or a bumped `getConfigSequence8130` — after a failed tx
+- **The only reliable check is a read-back:** `isActor`,
+  `getActorConfig`, or a bumped `getConfigSequence` — after a failed tx
   as much as a successful one.
 - **Reads lag ~1 block (~2s)** behind the receipt — poll the read-back.
 
@@ -79,14 +83,14 @@ channel (`chainId = chain.id`); owner changes use the **multichain** channel
 
 | Deploy path | First local sequence |
 |---|---|
-| Smart wallet (`createAccount`) | `1` (create bumps local 0→1) |
-| Explicit `importAccount` | `1` |
-| Bare 7702 delegation (`account.delegate`) | `0` (delegation does not initialize state) |
+| CREATE2 smart account (`newSmartAccount` + `account.createChange`) | `1` (create bumps local 0→1) |
+| Configured account on an existing address (`toAccount({ address })`) | `1` |
+| Bare 7702 delegation (`toEoaAccount` + `account.delegate`) | `0` (delegation does not initialize state) |
 
 ```ts
-import { getConfigSequence8130, isActor8130 } from "viem/experimental/eip8130";
+import { getConfigSequence, isActor } from "viem/eip8130";
 
-const { local } = await getConfigSequence8130(client, {
+const { local } = await getConfigSequence(client, {
   accountConfiguration: dep.accountConfiguration,
   account: account.address,
 }); // read live — do not assume 0 or 1
@@ -95,7 +99,7 @@ const change = await account.change([authorizeActor(/* … */)], {
   sequence: Number(local),
 });
 // … send the tx, then verify by read-back (polled for ~1 block of lag):
-const bound = await isActor8130(client, {
+const bound = await isActor(client, {
   account: account.address, actorId, accountConfiguration: dep.accountConfiguration,
 });
 if (!bound) throw new Error("authorize was skipped — check sequence/channel");

--- a/skills/vibenet/references/session-keys-and-policies.md
+++ b/skills/vibenet/references/session-keys-and-policies.md
@@ -49,10 +49,24 @@ Check them by **reading back on-chain state**, not by the receipt:
   is not surfaced as a normal EVM log here — "no events" is NOT a failure. Do
   not gate success on scanning logs.
 - **`allPhasesSucceeded` / `phaseStatuses` only cover CALL phases**, not the
-  account-change application. A skipped authorize marks no failed phase, throws
-  nothing, and the tx still reports `status: success`.
-- **The only reliable success check is a read-back:** `isActor8130`,
-  `getActorConfig8130`, or a bumped `getConfigSequence8130`.
+  account-change application. On a change-only transaction (no calls)
+  `phaseStatuses` is absent entirely and `allPhasesSucceeded` returns `true`
+  vacuously — it is reporting on nothing.
+- **A wrong sequence is rejected at broadcast, not silently applied.** Signing a
+  change over a stale *or* future sequence makes `eth_sendRawTransaction` fail
+  with `EIP-8130 validation failed: config change sequence mismatch` (surfaced
+  by viem as `InvalidInputRpcError: Missing or invalid parameters`). The tx
+  never lands, so there is no receipt to inspect — the failure is loud, but the
+  error text names neither the sequence you used nor the one expected.
+- **The real trap is the inverse: a config change can apply on a transaction
+  that reports failure.** Live-confirmed — a tx carrying an authorize plus a
+  reverting call came back `status: 0x0` with `phaseStatuses: ["0x0"]`, yet the
+  actor was bound and the config sequence had bumped. Account changes are not
+  atomic with the calls they ride along with, in either direction. **Never infer
+  config state from `receipt.status`.**
+- **The only reliable check is a read-back:** `isActor8130`,
+  `getActorConfig8130`, or a bumped `getConfigSequence8130` — after a failed tx
+  as much as a successful one.
 - **Reads lag ~1 block (~2s)** behind the receipt — poll the read-back.
 
 ## Sequence correctness

--- a/skills/vibenet/scripts/setup-viem-8130.sh
+++ b/skills/vibenet/scripts/setup-viem-8130.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# setup-viem-8130.sh — one-shot installer for viem's EIP-8130 / ERC-8168 modules.
+#
+# The 8130 tooling is not on npm yet (upstream PR wevm/viem#5004 is still an
+# open draft). Until it ships, this builds it from the fork branch the PR is
+# opened from — chunter-cb/viem feat/eip-8130-production — and links the built
+# package into your project. Every step here is fiddly enough that doing it by
+# hand invites mistakes, so this script captures the whole dance:
+#
+#   clone the fork branch -> pnpm build -> npm install --install-links
+#
+# When PR #5004 merges and a viem release ships the modules, this whole script
+# collapses to `npm install viem@latest` — the imports (viem/eip8130,
+# viem/eip8168) and APIs are unchanged, so nothing else in your code moves.
+#
+# Usage:
+#   scripts/setup-viem-8130.sh [APP_DIR] [BUILD_DIR]
+#
+#   APP_DIR    project to install viem into (default: current directory)
+#   BUILD_DIR  where to clone+build the fork (default: <APP_DIR>/.viem-8130-src)
+#
+# Env overrides:
+#   VIEM_FORK_REPO    (default: https://github.com/chunter-cb/viem)
+#   VIEM_FORK_BRANCH  (default: feat/eip-8130-production)
+#
+# Idempotent: re-running pulls the latest branch commit and rebuilds.
+
+set -euo pipefail
+
+APP_DIR="${1:-$PWD}"
+APP_DIR="$(cd "$APP_DIR" && pwd)"                     # absolute
+BUILD_DIR="${2:-$APP_DIR/.viem-8130-src}"
+REPO="${VIEM_FORK_REPO:-https://github.com/chunter-cb/viem}"
+BRANCH="${VIEM_FORK_BRANCH:-feat/eip-8130-production}"
+
+echo "==> viem 8130 setup"
+echo "    app:    $APP_DIR"
+echo "    build:  $BUILD_DIR"
+echo "    source: $REPO @ $BRANCH"
+
+command -v git >/dev/null || { echo "error: git not found" >&2; exit 1; }
+command -v npx >/dev/null || { echo "error: npx (Node.js) not found" >&2; exit 1; }
+
+# 1) Clone or update the fork branch.
+if [ -d "$BUILD_DIR/.git" ]; then
+  echo "==> updating existing checkout"
+  git -C "$BUILD_DIR" fetch origin "$BRANCH" --depth 1
+  git -C "$BUILD_DIR" checkout "$BRANCH"
+  git -C "$BUILD_DIR" reset --hard "origin/$BRANCH"
+else
+  echo "==> cloning $BRANCH"
+  git clone -b "$BRANCH" --depth 1 "$REPO" "$BUILD_DIR"
+fi
+
+# 2) Build. --ignore-scripts skips the monorepo's postinstall hooks (which
+#    aren't needed to produce the package and can fail in a bare checkout).
+#    The build populates the package that lives in the repo's src/.
+echo "==> installing build deps (pnpm, via npx — no global install)"
+( cd "$BUILD_DIR" && npx --yes pnpm install --ignore-scripts )
+echo "==> building viem"
+( cd "$BUILD_DIR" && npx --yes pnpm run build )
+
+# 3) Link into the app. --install-links is REQUIRED: without it npm symlinks
+#    node_modules/viem to a path outside the project root, and bundlers
+#    (Turbopack/Next.js) then fail with "Can't resolve 'viem'" even though tsc
+#    resolves it fine — a confusing, wrong-looking bundler error.
+echo "==> installing viem into the app (--install-links)"
+( cd "$APP_DIR" && npm install --install-links "viem@file:$BUILD_DIR/src" )
+
+cat <<EOF
+
+==> done.
+    Import 8130 helpers from 'viem/eip8130' and payer helpers from 'viem/eip8168'.
+    Core helpers (createPublicClient, parseEther, ...) come from plain 'viem'.
+
+    If your TS build rejects the module's BigInt literals, set
+    "target": "ES2020" (or later) in tsconfig.json. Next.js 16's generated
+    config already works, since its lib includes "esnext".
+EOF


### PR DESCRIPTION
## Description

Adds the `vibenet` skill for Base's EIP-8130 devnet, and corrects it against live behaviour.

Everything here was verified by building a Next.js app end to end against the devnet — creating 8130 accounts, drawing from the faucet, and sending both self-paid and sponsored transactions. Several of the original claims turned out to be wrong in ways that break working code, so this PR fixes them and adds the gotchas that cost real debugging time.

### Endpoints (blocking — every hosted URL was dead)

`vibes.base.org` now 302-redirects to the `chain.base.org/vibenet` HTML page. viem's HTTP transport parses that as JSON and throws `JSON Parse error: Unrecognized token '<'`, which reads like a code bug rather than a moved URL.

The API host is `api.vibes.base.org`; paths are unchanged. Also added `faucet/status`, `chain-health`, and the explorer. `rpc.vibes.base.org` serves `access-control-allow-origin: *`, so the browser proxy is now documented as optional rather than required (measured from a real browser origin, not curl).

### New: account lifecycle

The most common point of confusion, and previously absent: an 8130 account has no deploy step. `newSmartAccount8130` derives a CREATE2 address locally with zero RPC; the account is created as a side effect of its first transaction. Adds a lifecycle section covering both routes (sponsored needs no funding and is the shortest path), how to check deployment via `eth_getCode`, and why deployment state must be read from chain rather than tracked optimistically — it decides whether the next tx carries `createChange`.

### Corrections, each reproduced live

- **`sendSponsoredCalls` resolves with `{ transactionHash }`.** The previous text said emphatically *not* to destructure it. Following it feeds an object into `waitForTransactionReceipt8130` and fails with `invalid type: map, expected 32 bytes`. The declared return type is also wrong, so the call needs a cast either way.
- **A bad config sequence is rejected at broadcast, not silently applied.** The previous text claimed a skipped authorize "still reports `status: success`". Measured: a stale *or* future sequence fails `eth_sendRawTransaction` with `EIP-8130 validation failed: config change sequence mismatch` and never lands. The real trap is the inverse — a config change can apply on a transaction reporting `status: 0x0`. Account changes are not atomic with the calls they ride along with, in either direction.
- **The end-to-end example could not compile.** It imported `createPublicClient`, `http`, `parseEther`, and `toHex` from `viem/experimental/eip8130`, which exports none of them.
- **`npm install` of the fork needs `--install-links`.** Without it npm symlinks outside the project root and Turbopack fails with `Module not found: Can't resolve 'viem'` for a package that is plainly present (`tsc` resolves it fine). The install section now leads with the path that works, instead of a `bun add` that yields an unbuilt monorepo.

### New gotchas

- Payer validation lags ~1 block behind a deploy, so sponsoring immediately after one fails with `actor is not bound`. Retry across the lag.
- `no backend is currently healthy to serve traffic` means the devnet is halted, not that your code is wrong. Reads keep answering from the last block while sends fail, which disguises it. `chain-health` is the diagnostic.
- A value-bearing call to a never-funded address reverts (reproduced 4/4). The same call to a funded address succeeds and moves the exact amount, and zero-value to a fresh address is fine. **Cause unconfirmed** — documented as observed behaviour, and worth a look from whoever owns the devnet.

## Type of change

- [ ] Base MCP plugin submission
- [x] Update to an existing skill/plugin
- [ ] New skill
- [ ] Documentation
- [ ] Other (please describe):

## Affected skill(s)

`vibenet`

## Plugin checklist

- [ ] Plugin spec/manifest is accurate and tested
- [x] (If Applicable) API endpoints and/or external MCP/CLI tested and functional
- [ ] Follows [Contribution Scope](../skills/base-mcp/references/plugin-spec.md#contribution-scope)

<sub>Not a Base MCP plugin, so the spec/manifest and contribution-scope items don't apply. Endpoints were tested live against the devnet.</sub>

## Verification

- Next.js 16 app built against the skill: create → faucet → self-paid deploy+batch → sponsored send, driven in a real browser with no console errors.
- Gasless onboarding confirmed at a zero balance from start to finish.
- Both skill code examples extracted verbatim and compiled — the accounts example previously did not build.
- Account-change semantics isolated across five cases (call-only, change-only, change+call at live/stale/future sequence).

## Related issues

<!-- none -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHVyDbPh8A6ySYL7Q7HtnG
