### PR TITLE
fix(vibenet): require proxy: "erc1167" in account examples, correct tsconfig guidance

### DIFF
--- a/skills/vibenet/SKILL.md
+++ b/skills/vibenet/SKILL.md
@@ -88,8 +88,7 @@ module does not re-export them.
 
 Set `"target": "ES2020"` or later in `tsconfig.json`. BigInt literals (`0n`)
 trigger TS2737 on any lower `target` — the check depends on `target`, not
-`lib` — and create-next-app still generates `"target": "ES2017"`, so Next.js
-apps need the bump too.
+`lib`, and many generated configs still default to an older target.
 
 ## Accounts Have No Deploy Step
 

--- a/skills/vibenet/SKILL.md
+++ b/skills/vibenet/SKILL.md
@@ -86,9 +86,10 @@ Then import from `viem/eip8130` (and `viem/eip8168` for payers). Core helpers
 like `createPublicClient` / `parseEther` come from plain `viem` — the 8130
 module does not re-export them.
 
-If your TypeScript build rejects the module's BigInt literals, set
-`"target": "ES2020"` or later in `tsconfig.json`. Next.js 16's generated config
-already works as-is, since its `lib` includes `esnext`.
+Set `"target": "ES2020"` or later in `tsconfig.json`. BigInt literals (`0n`)
+trigger TS2737 on any lower `target` — the check depends on `target`, not
+`lib` — and create-next-app still generates `"target": "ES2017"`, so Next.js
+apps need the bump too.
 
 ## Accounts Have No Deploy Step
 

--- a/skills/vibenet/references/eip8130-accounts.md
+++ b/skills/vibenet/references/eip8130-accounts.md
@@ -39,7 +39,7 @@ the [skill root](../SKILL.md).
 and nothing you call moves it between them directly.
 
 ```
-newSmartAccount({ signer })     →  COUNTERFACTUAL
+newSmartAccount({ signer, proxy: "erc1167" })     →  COUNTERFACTUAL
   address derived locally (CREATE2), synchronous, zero RPC calls.
   eth_getCode returns 0x. The account does not exist on-chain.
 
@@ -116,7 +116,11 @@ const signer = privateKeyToAccount(generatePrivateKey());
 //    `nonceKey: nonceKeyMax` — see Gotchas for a historical timing caveat.)
 //    key.k1(signer.address) is what newSmartAccount uses internally for
 //    the primary actor — you only call key.* when authorizing extra actors.
-const account = newSmartAccount({ signer }); // synchronous — no await
+//    `proxy: "erc1167"` is required in practice: the default ("upgradeable")
+//    throws `No canonical UpgradeableAccount is enshrined yet` unless you pass
+//    an explicit implementation. "erc1167" gives an immutable
+//    DefaultAccount-backed account.
+const account = newSmartAccount({ signer, proxy: "erc1167" }); // synchronous — no await
 // (The fork's TS types may require casting a K1 LocalAccount when passing
 // it as `signer`.)
 
@@ -177,9 +181,12 @@ The current canonical deployment uses AccountConfiguration
 
 ## Account creation modes
 
-- `newSmartAccount({ signer })` — new CREATE2 smart account (most common).
-  `signer` must be a signing account (`privateKeyToAccount(pk)`, `toP256Signer`,
-  or `toWebAuthnSigner`) — **not** `key.k1(...)`.
+- `newSmartAccount({ signer, proxy: "erc1167" })` — new CREATE2 smart account
+  (most common). `signer` must be a signing account (`privateKeyToAccount(pk)`,
+  `toP256Signer`, or `toWebAuthnSigner`) — **not** `key.k1(...)`. The `proxy`
+  option defaults to `"upgradeable"`, which throws until a canonical
+  UpgradeableAccount is enshrined unless you pass an explicit implementation —
+  pass `proxy: "erc1167"` for an immutable DefaultAccount-backed account.
 - `toAccount({ signer, userSalt, code, initialActors, authenticator, accountConfigAddress })`
   — full control over salt / initial actors.
 - `toAccount({ signer, address, authenticator })` — a configured (non-default)
@@ -204,6 +211,12 @@ change), no separate hash step. `lockChange` requires `unlockDelay >= 1`
 
 ## Gotchas
 
+- **Pass `proxy: "erc1167"` to `newSmartAccount` / `toAccount`.** The `proxy`
+  option defaults to `"upgradeable"`, which throws
+  `BaseError: No canonical UpgradeableAccount is enshrined yet (pending final
+  implementation)` unless you supply an explicit implementation. `"erc1167"`
+  creates an immutable DefaultAccount-backed account and is the mode every
+  example in this skill uses.
 - **`key.k1` ≠ signer.** `key.k1(address)` builds an actor id for authorize /
   `initialActors`. Passing it (or a raw private-key hex) as `signer` to
   `newSmartAccount` fails with an opaque `pad()` TypeError — use
@@ -211,8 +224,9 @@ change), no separate hash step. `lockChange` requires `unlockDelay >= 1`
 - Fund `account.address` **before** a self-paid first tx — the deploy+batch pays
   gas from the account (unless a payer sponsors it).
 - Only the **first** tx includes `account.createChange`; later txs omit it.
-- After a successful create, `eth_getCode` on the account returns an EIP-1167
-  minimal proxy delegating to the canonical DefaultAccount — but the read
+- After a successful create (with `proxy: "erc1167"`), `eth_getCode` on the
+  account returns an EIP-1167 minimal proxy delegating to the canonical
+  DefaultAccount — but the read
   lags ~1 block behind the receipt, so an immediate getCode can return `0x`
   on a tx that succeeded. Poll before concluding the deploy failed (same lag
   as config-change read-backs).

--- a/skills/vibenet/scripts/setup-viem-8130.sh
+++ b/skills/vibenet/scripts/setup-viem-8130.sh
@@ -75,6 +75,5 @@ cat <<EOF
     Core helpers (createPublicClient, parseEther, ...) come from plain 'viem'.
 
     Set "target": "ES2020" (or later) in tsconfig.json — BigInt literals
-    (0n) fail with TS2737 on any lower target, and create-next-app still
-    generates "target": "ES2017".
+    (0n) fail with TS2737 on any lower target.
 EOF

--- a/skills/vibenet/scripts/setup-viem-8130.sh
+++ b/skills/vibenet/scripts/setup-viem-8130.sh
@@ -74,7 +74,7 @@ cat <<EOF
     Import 8130 helpers from 'viem/eip8130' and payer helpers from 'viem/eip8168'.
     Core helpers (createPublicClient, parseEther, ...) come from plain 'viem'.
 
-    If your TS build rejects the module's BigInt literals, set
-    "target": "ES2020" (or later) in tsconfig.json. Next.js 16's generated
-    config already works, since its lib includes "esnext".
+    Set "target": "ES2020" (or later) in tsconfig.json — BigInt literals
+    (0n) fail with TS2737 on any lower target, and create-next-app still
+    generates "target": "ES2017".
 EOF


### PR DESCRIPTION
Field-testing the vibenet skill against `chunter-cb/viem@feat/eip-8130-production` (viem 2.55.15, built 2026-08-24) surfaced two inaccuracies.

## 1. `newSmartAccount({ signer })` throws on the current fork

The fork added a `proxy` option defaulting to `"upgradeable"`, which throws:

> BaseError: No canonical UpgradeableAccount is enshrined yet (pending final implementation), so proxy: "upgradeable" requires an explicit implementation … Alternatively pass proxy: "erc1167" for an immutable DefaultAccount-backed account.

Every account-creation example (lifecycle diagram, minimal end-to-end, creation-modes list) now passes `proxy: "erc1167"`, a new gotcha documents the error, and the "EIP-1167 minimal proxy" deployment claim is qualified as the `erc1167`-mode behavior.

## 2. Next.js tsconfig claim was wrong

SKILL.md claimed Next.js 16's generated config "works as-is, since its lib includes esnext" — but TS2737 (BigInt literals) depends on `target`, not `lib`, and create-next-app generates `"target": "ES2017"`. The skill now unconditionally instructs `"target": "ES2020"` or later.

Everything else was verified accurate against the live devnet (installer script, faucet/CORS, `sendSponsoredCalls` return-shape cast, counterfactual→deployed lifecycle) and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)